### PR TITLE
ci: simplify CI to use Node.js latest only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,28 +9,24 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
-    strategy:
-      matrix:
-        node-version: [18.x, 20.x]
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Setup Node.js ${{ matrix.node-version }}
+    - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 'latest'
         cache: 'npm'
 
     - name: Cache node_modules
       uses: actions/cache@v4
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+        key: ${{ runner.os }}-node-latest-${{ hashFiles('package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-${{ matrix.node-version }}-
+          ${{ runner.os }}-node-latest-
           ${{ runner.os }}-node-
 
     - name: Install dependencies
@@ -49,16 +45,16 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: 'latest'
         cache: 'npm'
 
     - name: Cache node_modules
       uses: actions/cache@v4
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-20.x-${{ hashFiles('package-lock.json') }}
+        key: ${{ runner.os }}-node-latest-${{ hashFiles('package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-20.x-
+          ${{ runner.os }}-node-latest-
           ${{ runner.os }}-node-
 
     - name: Install dependencies
@@ -81,16 +77,16 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: 'latest'
         cache: 'npm'
 
     - name: Cache node_modules
       uses: actions/cache@v4
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-20.x-${{ hashFiles('package-lock.json') }}
+        key: ${{ runner.os }}-node-latest-${{ hashFiles('package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-20.x-
+          ${{ runner.os }}-node-latest-
           ${{ runner.os }}-node-
 
     - name: Install dependencies


### PR DESCRIPTION
## 概要

CI の Node.js バージョンマトリクス（18.x, 20.x）を廃止し、`latest` のみに統一。

## 変更内容

- test ジョブの `strategy.matrix` を削除
- 全ジョブ（test, lint, build）の `node-version` を `'latest'` に変更
- キャッシュキーも `node-latest` に統一