### PR TITLE
fix: resolve true-form relations in nested select (match top-level)

### DIFF
--- a/src/__test__/util/relation/nestedSelectTrueForm.test.ts
+++ b/src/__test__/util/relation/nestedSelectTrueForm.test.ts
@@ -1,0 +1,385 @@
+import { GassmaClient } from "../../../gassma";
+import { GassmaController } from "../../../gassmaController";
+import type { RelationsConfig } from "../../../types/relationTypes";
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => { getValues: () => unknown[][] };
+  getDataRange: () => { getValues: () => unknown[][] };
+};
+
+const makeSheet = (name: string, data: unknown[][]): MockSheet => ({
+  getName: () => name,
+  getLastRow: () => data.length,
+  getLastColumn: () => data[0].length,
+  getRange: (row, col, numRows, numCols) => ({
+    getValues: () =>
+      data
+        .slice(row - 1, row - 1 + numRows)
+        .map((r) => r.slice(col - 1, col - 1 + numCols)),
+  }),
+  getDataRange: () => ({ getValues: () => data }),
+});
+
+const sheets = [
+  makeSheet("Users", [
+    ["id", "name"],
+    [1, "Alice"],
+    [2, "Bob"],
+  ]),
+  makeSheet("Posts", [
+    ["id", "authorId", "title"],
+    [101, 1, "Post A"],
+    [102, 1, "Post B"],
+    [103, 2, "Post C"],
+  ]),
+  makeSheet("Comments", [
+    ["id", "postId", "body"],
+    [201, 101, "Nice"],
+    [202, 101, "Great"],
+    [203, 103, "Hmm"],
+  ]),
+  makeSheet("Profiles", [
+    ["id", "userId", "bio"],
+    [301, 1, "Alice bio"],
+    [302, 2, "Bob bio"],
+  ]),
+  makeSheet("Categories", [
+    ["id", "name"],
+    [401, "Tech"],
+    [402, "Life"],
+  ]),
+  makeSheet("PostCategories", [
+    ["postId", "categoryId"],
+    [101, 401],
+    [101, 402],
+    [103, 401],
+  ]),
+];
+
+const mockSpreadsheet = {
+  getId: () => "test-spreadsheet",
+  getSheets: () => sheets,
+  getSheetByName: (name: string) =>
+    sheets.find((sheet) => sheet.getName() === name) ?? null,
+};
+
+const relations: RelationsConfig = {
+  Users: {
+    posts: {
+      type: "oneToMany",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+    },
+    profile: {
+      type: "oneToOne",
+      to: "Profiles",
+      field: "id",
+      reference: "userId",
+    },
+  },
+  Posts: {
+    author: {
+      type: "manyToOne",
+      to: "Users",
+      field: "authorId",
+      reference: "id",
+    },
+    comments: {
+      type: "oneToMany",
+      to: "Comments",
+      field: "id",
+      reference: "postId",
+    },
+    categories: {
+      type: "manyToMany",
+      to: "Categories",
+      field: "id",
+      reference: "id",
+      through: {
+        sheet: "PostCategories",
+        field: "postId",
+        reference: "categoryId",
+      },
+    },
+  },
+  Profiles: {
+    user: {
+      type: "manyToOne",
+      to: "Users",
+      field: "userId",
+      reference: "id",
+    },
+  },
+  Categories: {
+    posts: {
+      type: "manyToMany",
+      to: "Posts",
+      field: "id",
+      reference: "id",
+      through: {
+        sheet: "PostCategories",
+        field: "categoryId",
+        reference: "postId",
+      },
+    },
+  },
+};
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!(controller instanceof GassmaController)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+describe("nested select の true 形式 relation 解決（統合）", () => {
+  let client: GassmaClient;
+
+  beforeAll(() => {
+    Object.assign(globalThis, {
+      SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+    });
+    client = new GassmaClient({ relations });
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, { SpreadsheetApp: undefined });
+  });
+
+  describe("manyToOne 内の true 形式", () => {
+    it("select: { author: { select: { posts: true } } } が posts を解決する", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { id: 101 },
+        select: {
+          title: true,
+          author: { select: { name: true, posts: true } },
+        },
+      });
+
+      expect(result).toEqual([
+        {
+          title: "Post A",
+          author: {
+            name: "Alice",
+            posts: [
+              { id: 101, authorId: 1, title: "Post A" },
+              { id: 102, authorId: 1, title: "Post B" },
+            ],
+          },
+        },
+      ]);
+    });
+
+    it("findFirst でも対称に解決される", () => {
+      const result = sheetOf(client, "Posts").findFirst({
+        where: { id: 101 },
+        select: { author: { select: { posts: true } } },
+      });
+
+      expect(result).toEqual({
+        author: {
+          posts: [
+            { id: 101, authorId: 1, title: "Post A" },
+            { id: 102, authorId: 1, title: "Post B" },
+          ],
+        },
+      });
+    });
+  });
+
+  describe("oneToMany 内の true 形式", () => {
+    it("select: { posts: { select: { comments: true } } } が comments を解決する", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        select: { posts: { select: { title: true, comments: true } } },
+      });
+
+      expect(result).toEqual([
+        {
+          posts: [
+            {
+              title: "Post A",
+              comments: [
+                { id: 201, postId: 101, body: "Nice" },
+                { id: 202, postId: 101, body: "Great" },
+              ],
+            },
+            { title: "Post B", comments: [] },
+          ],
+        },
+      ]);
+    });
+
+    it("where/orderBy/skip/take と nested true を併用できる", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        select: {
+          posts: {
+            where: { id: { lt: 103 } },
+            orderBy: { id: "desc" },
+            skip: 1,
+            take: 1,
+            select: { id: true, comments: true },
+          },
+        },
+      });
+
+      expect(result).toEqual([
+        {
+          posts: [
+            {
+              id: 101,
+              comments: [
+                { id: 201, postId: 101, body: "Nice" },
+                { id: 202, postId: 101, body: "Great" },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe("oneToOne 内の true 形式", () => {
+    it("select: { profile: { select: { user: true } } } が user を解決する", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        select: { profile: { select: { bio: true, user: true } } },
+      });
+
+      expect(result).toEqual([
+        {
+          profile: {
+            bio: "Alice bio",
+            user: { id: 1, name: "Alice" },
+          },
+        },
+      ]);
+    });
+  });
+
+  describe("manyToMany 内の true 形式", () => {
+    it("select: { categories: { select: { posts: true } } } が posts を解決する", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { id: 101 },
+        select: { categories: { select: { name: true, posts: true } } },
+      });
+
+      expect(result).toEqual([
+        {
+          categories: [
+            {
+              name: "Tech",
+              posts: [
+                { id: 101, authorId: 1, title: "Post A" },
+                { id: 103, authorId: 2, title: "Post C" },
+              ],
+            },
+            {
+              name: "Life",
+              posts: [{ id: 101, authorId: 1, title: "Post A" }],
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe("object 形式の非回帰", () => {
+    it("object 形式の深いネスト select は引き続き解決される", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { id: 101 },
+        select: {
+          author: { select: { posts: { select: { title: true } } } },
+        } as any,
+      });
+
+      expect(result).toEqual([
+        {
+          author: {
+            posts: [{ title: "Post A" }, { title: "Post B" }],
+          },
+        },
+      ]);
+    });
+
+    it("object 形式の内側の true 形式（3階層）も解決される", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { id: 103 },
+        select: {
+          author: { select: { posts: { select: { comments: true } } } },
+        } as any,
+      });
+
+      expect(result).toEqual([
+        {
+          author: {
+            posts: [{ comments: [{ id: 203, postId: 103, body: "Hmm" }] }],
+          },
+        },
+      ]);
+    });
+
+    it("非 relation キーの true は scalar として扱われる", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        select: { posts: { select: { title: true } } },
+      });
+
+      expect(result).toEqual([
+        { posts: [{ title: "Post A" }, { title: "Post B" }] },
+      ]);
+    });
+  });
+
+  describe("既存仕様の維持", () => {
+    it("nested select + include の併用はエラーになる", () => {
+      expect(() =>
+        sheetOf(client, "Users").findMany({
+          select: {
+            posts: { select: { title: true }, include: { comments: true } },
+          },
+        }),
+      ).toThrow(
+        'Include "posts": cannot use both select and include at the same time',
+      );
+    });
+
+    it("nested omit は引き続き適用される", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 2 },
+        select: { posts: { omit: { authorId: true } } },
+      });
+
+      expect(result).toEqual([{ posts: [{ id: 103, title: "Post C" }] }]);
+    });
+
+    it("トップレベル select の true 形式 relation は従来どおり解決される", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 2 },
+        select: { name: true, posts: true },
+      });
+
+      expect(result).toEqual([
+        {
+          name: "Bob",
+          posts: [{ id: 103, authorId: 2, title: "Post C" }],
+        },
+      ]);
+    });
+  });
+});

--- a/src/__test__/util/relation/processSelectForInclude.test.ts
+++ b/src/__test__/util/relation/processSelectForInclude.test.ts
@@ -57,4 +57,48 @@ describe("processSelectForInclude", () => {
       profile: { select: { bio: true } },
     });
   });
+
+  describe("relationNames が渡された場合", () => {
+    it("relationNames にあるキーの true は nestedInclude に入る", () => {
+      const result = processSelectForInclude({ id: true, posts: true }, [
+        "posts",
+      ]);
+
+      expect(result.scalarSelect).toEqual({ id: true });
+      expect(result.nestedInclude).toEqual({ posts: true });
+    });
+
+    it("relationNames にないキーの true は scalarSelect のまま", () => {
+      const result = processSelectForInclude({ id: true, posts: true }, [
+        "comments",
+      ]);
+
+      expect(result.scalarSelect).toEqual({ id: true, posts: true });
+      expect(result.nestedInclude).toBeNull();
+    });
+
+    it("true 形式とオブジェクト形式の relation を同時に扱える", () => {
+      const result = processSelectForInclude(
+        {
+          id: true,
+          posts: true,
+          profile: { select: { bio: true } },
+        },
+        ["posts", "profile"],
+      );
+
+      expect(result.scalarSelect).toEqual({ id: true });
+      expect(result.nestedInclude).toEqual({
+        posts: true,
+        profile: { select: { bio: true } },
+      });
+    });
+
+    it("relationNames 未指定なら true は scalarSelect に入る（後方互換）", () => {
+      const result = processSelectForInclude({ id: true, posts: true });
+
+      expect(result.scalarSelect).toEqual({ id: true, posts: true });
+      expect(result.nestedInclude).toBeNull();
+    });
+  });
 });

--- a/src/__test__/util/relation/resolveInclude.test.ts
+++ b/src/__test__/util/relation/resolveInclude.test.ts
@@ -359,6 +359,80 @@ describe("resolveInclude", () => {
     });
   });
 
+  describe("nested select の true 形式 relation", () => {
+    const selectRelations: { [name: string]: RelationDefinition } = {
+      posts: {
+        type: "oneToMany",
+        to: "Posts",
+        field: "id",
+        reference: "authorId",
+      },
+    };
+
+    it("relationNamesOnSheet がある場合、select 内の true 形式 relation を include として渡す", () => {
+      const mockFindManySelect = jest.fn();
+
+      const selectContext: RelationContext = {
+        relations: selectRelations,
+        findManyOnSheet: mockFindManySelect,
+        relationNamesOnSheet: (sheetName) =>
+          sheetName === "Posts" ? ["comments"] : [],
+      };
+
+      const parents = [{ id: 1, name: "Alice" }];
+      const include: IncludeData = {
+        posts: { select: { title: true, comments: true } },
+      };
+
+      mockFindManySelect.mockReturnValueOnce([
+        {
+          id: 101,
+          authorId: 1,
+          title: "Post A",
+          comments: [{ id: 201, postId: 101, body: "Nice" }],
+        },
+      ]);
+
+      const result = resolveInclude(parents, include, selectContext);
+
+      expect(mockFindManySelect).toHaveBeenCalledWith("Posts", {
+        where: { authorId: { in: [1] } },
+        include: { comments: true },
+      });
+      expect(result[0].posts).toEqual([
+        {
+          title: "Post A",
+          comments: [{ id: 201, postId: 101, body: "Nice" }],
+        },
+      ]);
+    });
+
+    it("relationNamesOnSheet が無い場合は従来どおり scalar として扱う", () => {
+      const mockFindManySelect = jest.fn();
+
+      const selectContext: RelationContext = {
+        relations: selectRelations,
+        findManyOnSheet: mockFindManySelect,
+      };
+
+      const parents = [{ id: 1, name: "Alice" }];
+      const include: IncludeData = {
+        posts: { select: { title: true, comments: true } },
+      };
+
+      mockFindManySelect.mockReturnValueOnce([
+        { id: 101, authorId: 1, title: "Post A" },
+      ]);
+
+      const result = resolveInclude(parents, include, selectContext);
+
+      expect(mockFindManySelect).toHaveBeenCalledWith("Posts", {
+        where: { authorId: { in: [1] } },
+      });
+      expect(result[0].posts).toEqual([{ title: "Post A" }]);
+    });
+  });
+
   describe("_count", () => {
     it("include: { _count: { select: { posts: true } } } で _count が付与される", () => {
       const parents = [

--- a/src/__test__/util/relation/resolvers/manyToMany.test.ts
+++ b/src/__test__/util/relation/resolvers/manyToMany.test.ts
@@ -329,4 +329,30 @@ describe("resolveManyToMany", () => {
     expect(result).toEqual([]);
     expect(mockFindMany).not.toHaveBeenCalled();
   });
+
+  it("targetRelationNames にある select 内の true 形式 relation を include として解決する", () => {
+    const parents = [{ id: 1, title: "Post A" }];
+
+    mockFindMany.mockReturnValueOnce([{ postId: 1, categoryId: 10 }]);
+    mockFindMany.mockReturnValueOnce([
+      { id: 10, name: "Tech", posts: [{ id: 1, title: "Post A" }] },
+    ]);
+
+    const result = resolveManyToMany(
+      parents,
+      relation,
+      "categories",
+      mockFindMany,
+      { select: { name: true, posts: true } },
+      ["posts"],
+    );
+
+    expect(mockFindMany).toHaveBeenNthCalledWith(2, "Categories", {
+      where: { id: { in: [10] } },
+      include: { posts: true },
+    });
+    expect(result[0].categories).toEqual([
+      { name: "Tech", posts: [{ id: 1, title: "Post A" }] },
+    ]);
+  });
 });

--- a/src/__test__/util/relation/resolvers/manyToOne.test.ts
+++ b/src/__test__/util/relation/resolvers/manyToOne.test.ts
@@ -173,4 +173,34 @@ describe("resolveManyToOne", () => {
       resolveManyToOne(parents, relation, "author", mockFindMany),
     ).toThrow('Duplicate value "1" found in "Users.id" for a unique relation');
   });
+
+  it("targetRelationNames にある select 内の true 形式 relation を include として解決する", () => {
+    const parents = [{ id: 101, authorId: 1, title: "Post A" }];
+
+    mockFindMany.mockReturnValue([
+      {
+        id: 1,
+        name: "Alice",
+        posts: [{ id: 101, authorId: 1, title: "Post A" }],
+      },
+    ]);
+
+    const result = resolveManyToOne(
+      parents,
+      relation,
+      "author",
+      mockFindMany,
+      { select: { name: true, posts: true } },
+      ["posts"],
+    );
+
+    expect(mockFindMany).toHaveBeenCalledWith("Users", {
+      where: { id: { in: [1] } },
+      include: { posts: true },
+    });
+    expect(result[0].author).toEqual({
+      name: "Alice",
+      posts: [{ id: 101, authorId: 1, title: "Post A" }],
+    });
+  });
 });

--- a/src/__test__/util/relation/resolvers/oneToMany.test.ts
+++ b/src/__test__/util/relation/resolvers/oneToMany.test.ts
@@ -262,6 +262,54 @@ describe("resolveOneToMany", () => {
     ]);
   });
 
+  it("targetRelationNames にある select 内の true 形式 relation を include として解決する", () => {
+    const parents = [{ id: 1, name: "Alice" }];
+
+    mockFindMany.mockReturnValue([
+      {
+        id: 101,
+        authorId: 1,
+        title: "Post A",
+        comments: [{ id: 201, postId: 101, body: "Nice" }],
+      },
+    ]);
+
+    const result = resolveOneToMany(
+      parents,
+      relation,
+      "posts",
+      mockFindMany,
+      { select: { title: true, comments: true } },
+      ["comments"],
+    );
+
+    expect(mockFindMany).toHaveBeenCalledWith("Posts", {
+      where: { authorId: { in: [1] } },
+      include: { comments: true },
+    });
+    expect(result[0].posts).toEqual([
+      {
+        title: "Post A",
+        comments: [{ id: 201, postId: 101, body: "Nice" }],
+      },
+    ]);
+  });
+
+  it("targetRelationNames が無い場合は select 内の true を scalar として扱う（後方互換）", () => {
+    const parents = [{ id: 1, name: "Alice" }];
+
+    mockFindMany.mockReturnValue([{ id: 101, authorId: 1, title: "Post A" }]);
+
+    const result = resolveOneToMany(parents, relation, "posts", mockFindMany, {
+      select: { title: true, comments: true },
+    });
+
+    expect(mockFindMany).toHaveBeenCalledWith("Posts", {
+      where: { authorId: { in: [1] } },
+    });
+    expect(result[0].posts).toEqual([{ title: "Post A" }]);
+  });
+
   it("includeオプション付きでfindManyOnSheetにincludeが渡される", () => {
     const parents = [{ id: 1, name: "Alice" }];
 

--- a/src/__test__/util/relation/resolvers/oneToOne.test.ts
+++ b/src/__test__/util/relation/resolvers/oneToOne.test.ts
@@ -152,4 +152,30 @@ describe("resolveOneToOne", () => {
       'Duplicate value "1" found in "Profiles.userId" for a unique relation',
     );
   });
+
+  it("targetRelationNames にある select 内の true 形式 relation を include として解決する", () => {
+    const parents = [{ id: 1, name: "Alice" }];
+
+    mockFindMany.mockReturnValue([
+      { id: 10, userId: 1, bio: "Hello", user: { id: 1, name: "Alice" } },
+    ]);
+
+    const result = resolveOneToOne(
+      parents,
+      relation,
+      "profile",
+      mockFindMany,
+      { select: { bio: true, user: true } },
+      ["user"],
+    );
+
+    expect(mockFindMany).toHaveBeenCalledWith("Profiles", {
+      where: { userId: { in: [1] } },
+      include: { user: true },
+    });
+    expect(result[0].profile).toEqual({
+      bio: "Hello",
+      user: { id: 1, name: "Alice" },
+    });
+  });
 });

--- a/src/gassma.ts
+++ b/src/gassma.ts
@@ -170,12 +170,16 @@ class GassmaClient {
       return controller.createMany(createManyData);
     };
 
+    const relationNamesOnSheet = (sheetName: string): string[] =>
+      Object.keys(relations[sheetName] ?? {});
+
     Object.keys(relations).forEach((sheetName) => {
       const controller = controllers[sheetName];
       if (!controller) return;
 
       controller._setRelationContext({
         relations: relations[sheetName],
+        relationNamesOnSheet,
         findManyOnSheet,
         deleteManyOnSheet,
         updateManyOnSheet,

--- a/src/types/relationTypes.ts
+++ b/src/types/relationTypes.ts
@@ -102,6 +102,7 @@ type GassmaClientOptions = {
 
 type RelationContext = {
   relations: { [relationName: string]: RelationDefinition };
+  relationNamesOnSheet?: (sheetName: string) => string[];
   findManyOnSheet: (
     sheetName: string,
     findData: { where?: WhereUse; include?: IncludeData },

--- a/src/util/relation/processSelectForInclude.ts
+++ b/src/util/relation/processSelectForInclude.ts
@@ -7,6 +7,7 @@ type ProcessedSelect = {
 
 const processSelectForInclude = (
   select: Record<string, unknown>,
+  relationNames?: string[],
 ): ProcessedSelect => {
   const scalar: Record<string, unknown> = {};
   const nested: IncludeData = {};
@@ -14,7 +15,9 @@ const processSelectForInclude = (
   Object.keys(select).forEach((key) => {
     if (key === "_count") return;
     const value = select[key];
-    if (value === true) {
+    if (value === true && relationNames?.includes(key)) {
+      nested[key] = true;
+    } else if (value === true) {
       scalar[key] = true;
     } else if (typeof value === "object" && value !== null) {
       nested[key] = value as IncludeData[string];

--- a/src/util/relation/resolveInclude.ts
+++ b/src/util/relation/resolveInclude.ts
@@ -35,6 +35,7 @@ const resolveInclude = (
         includeValue === true ? undefined : includeValue;
 
       const findMany = context.findManyOnSheet;
+      const targetRelationNames = context.relationNamesOnSheet?.(relation.to);
 
       switch (relation.type) {
         case "oneToMany":
@@ -44,6 +45,7 @@ const resolveInclude = (
             relationName,
             findMany,
             options,
+            targetRelationNames,
           );
         case "oneToOne":
           return resolveOneToOne(
@@ -52,6 +54,7 @@ const resolveInclude = (
             relationName,
             findMany,
             options,
+            targetRelationNames,
           );
         case "manyToOne":
           return resolveManyToOne(
@@ -60,6 +63,7 @@ const resolveInclude = (
             relationName,
             findMany,
             options,
+            targetRelationNames,
           );
         case "manyToMany":
           return resolveManyToMany(
@@ -68,6 +72,7 @@ const resolveInclude = (
             relationName,
             findMany,
             options,
+            targetRelationNames,
           );
         default:
           return acc;

--- a/src/util/relation/resolvers/manyToMany.ts
+++ b/src/util/relation/resolvers/manyToMany.ts
@@ -23,6 +23,7 @@ const resolveManyToMany = (
   relationName: string,
   findManyOnSheet: FindManyOnSheet,
   options?: IncludeItemOptions,
+  targetRelationNames?: string[],
 ): Record<string, unknown>[] => {
   if (parents.length === 0) return [];
 
@@ -52,7 +53,7 @@ const resolveManyToMany = (
     : baseWhere;
 
   const processed = options?.select
-    ? processSelectForInclude(options.select)
+    ? processSelectForInclude(options.select, targetRelationNames)
     : null;
   const mergedInclude = processed?.nestedInclude
     ? { ...(options?.include ?? {}), ...processed.nestedInclude }

--- a/src/util/relation/resolvers/manyToOne.ts
+++ b/src/util/relation/resolvers/manyToOne.ts
@@ -21,6 +21,7 @@ const resolveManyToOne = (
   relationName: string,
   findManyOnSheet: FindManyOnSheet,
   options?: IncludeItemOptions,
+  targetRelationNames?: string[],
 ): Record<string, unknown>[] => {
   if (parents.length === 0) return [];
 
@@ -32,7 +33,7 @@ const resolveManyToOne = (
     : baseWhere;
 
   const processed = options?.select
-    ? processSelectForInclude(options.select)
+    ? processSelectForInclude(options.select, targetRelationNames)
     : null;
   const mergedInclude = processed?.nestedInclude
     ? { ...(options?.include ?? {}), ...processed.nestedInclude }

--- a/src/util/relation/resolvers/oneToMany.ts
+++ b/src/util/relation/resolvers/oneToMany.ts
@@ -22,6 +22,7 @@ const resolveOneToMany = (
   relationName: string,
   findManyOnSheet: FindManyOnSheet,
   options?: IncludeItemOptions,
+  targetRelationNames?: string[],
 ): Record<string, unknown>[] => {
   if (parents.length === 0) return [];
 
@@ -33,7 +34,7 @@ const resolveOneToMany = (
     : baseWhere;
 
   const processed = options?.select
-    ? processSelectForInclude(options.select)
+    ? processSelectForInclude(options.select, targetRelationNames)
     : null;
   const mergedInclude = processed?.nestedInclude
     ? { ...(options?.include ?? {}), ...processed.nestedInclude }

--- a/src/util/relation/resolvers/oneToOne.ts
+++ b/src/util/relation/resolvers/oneToOne.ts
@@ -21,6 +21,7 @@ const resolveOneToOne = (
   relationName: string,
   findManyOnSheet: FindManyOnSheet,
   options?: IncludeItemOptions,
+  targetRelationNames?: string[],
 ): Record<string, unknown>[] => {
   if (parents.length === 0) return [];
 
@@ -32,7 +33,7 @@ const resolveOneToOne = (
     : baseWhere;
 
   const processed = options?.select
-    ? processSelectForInclude(options.select)
+    ? processSelectForInclude(options.select, targetRelationNames)
     : null;
   const mergedInclude = processed?.nestedInclude
     ? { ...(options?.include ?? {}), ...processed.nestedInclude }


### PR DESCRIPTION
## 概要

nested select（リレーションオプション内の `select`）で **`rel: true` 形式のリレーションが解決されず `undefined` になる**非対称を修正しました。トップレベルの `select: { posts: true }` は解決されるのに、`select: { author: { select: { posts: true } } }` の内側 `posts: true` は `undefined` になっていました。

gassma-cli の型修正（③ nested select の深いネスト）で `FindSelect` を全面採用する前提となる本体側の対応です。Prisma パリティ（nested `rel: true` を解決）でもあります。

## 原因

- トップレベル select は `extractSelectRelations`（**リレーション名ベース**）で分割 → `posts: true` を relationInclude として解決。
- nested select は resolver 内の `processSelectForInclude`（**値の型ベース**）で分割 → `true` は scalar バケット行き → リレーション未解決で `undefined`。
- resolver（対象シート = `relation.to`）は対象シートのリレーション名を知る手段がなかった。

## 修正

- `RelationContext` に optional な `relationNamesOnSheet?: (sheetName) => string[]` を追加。
- `gassma.ts` の `injectRelations` が relations 設定を closure して全コンテキストへ注入。
- 各 resolver が対象シート（`relation.to`）のリレーション名を `processSelectForInclude` に渡し、**`true` 形式のリレーションキーを nestedInclude へ**ルーティング → 対象コントローラの findMany で解決（トップレベルと同一経路）。
- **optional + 値の型フォールバック**のため、手組み RelationContext（既存テスト・nested write 系）は挙動不変。

## 検証

- 全リレーション種別（oneToMany / manyToOne / oneToOne / manyToMany）× true/object 形式 × 多階層で解決を統合テスト（モック SpreadsheetApp + 実 GassmaClient 経由）で確認。
- object 形式の深いネスト（既に動作）は非回帰。nested select+include 排他、omit・where・orderBy・skip・take 併用、トップレベル true 形式を維持。
- **95 suites / 1128 tests 全 green**（ベースライン +23、既存テストの変更・削除ゼロ）。`tsc --noEmit` OK、biome clean。

## スコープ外（別課題）

- nested select 内 `_count` の黙殺（従来どおり）。
- write 系（create/update/upsert/delete）top-level select のリレーション未解決（include は解決済み）。
- 本体内部型 `IncludeItemOptions.select`（`{ [key: string]: true }`）は object 形式の深いネスト select リテラルが型で通らない既存の型ラグ（利用者は gassma-cli 生成型を使うため影響なし。公開型変更のため別途）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja