### PR TITLE
fix: aggregate _count returns 0 on zero hits (Prisma parity)

### DIFF
--- a/src/__test__/util/aggregate/aggregate.test.ts
+++ b/src/__test__/util/aggregate/aggregate.test.ts
@@ -272,7 +272,7 @@ describe("aggregate functionality tests", () => {
       });
     });
 
-    test("should return null values when cursor not found", () => {
+    test("should return null avg and zero count when cursor not found", () => {
       const result = aggregateFunc(getExtendedMockControllerUtil(), {
         cursor: { 名前: "NonExistent" },
         _avg: { 年齢: true },
@@ -281,7 +281,7 @@ describe("aggregate functionality tests", () => {
 
       expect(result).toEqual({
         _avg: { 年齢: null },
-        _count: { 名前: null },
+        _count: { 名前: 0 },
       });
     });
   });
@@ -296,7 +296,7 @@ describe("aggregate functionality tests", () => {
 
       expect(result).toEqual({
         _avg: { 年齢: null },
-        _count: { 名前: null },
+        _count: { 名前: 0 },
       });
     });
 
@@ -309,7 +309,7 @@ describe("aggregate functionality tests", () => {
 
       expect(result).toEqual({
         _avg: { 年齢: null },
-        _count: { 名前: null },
+        _count: { 名前: 0 },
       });
     });
 
@@ -322,7 +322,7 @@ describe("aggregate functionality tests", () => {
 
       expect(result).toEqual({
         _sum: { 年齢: null },
-        _count: { 名前: null },
+        _count: { 名前: 0 },
       });
     });
 

--- a/src/__test__/util/aggregate/aggregateUtil/count.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/count.test.ts
@@ -1,0 +1,66 @@
+import { getCount } from "../../../../util/aggregate/aggregateUtil/count";
+
+describe("getCount", () => {
+  test("should count non-null values for each field", () => {
+    const rows = [
+      { age: 10, score: 80 },
+      { age: 20, score: 90 },
+      { age: 30, score: 70 },
+    ];
+    const result = getCount(rows, { age: true, score: true });
+
+    expect(result).toEqual({
+      age: 3,
+      score: 3,
+    });
+  });
+
+  test("should exclude null and undefined values from count", () => {
+    const rows = [
+      { age: 10, score: null },
+      { age: null, score: 80 },
+      { age: 30, score: undefined },
+    ];
+    const result = getCount(rows, { age: true, score: true });
+
+    expect(result).toEqual({
+      age: 2,
+      score: 1,
+    });
+  });
+
+  test("should return 0 for empty rows array", () => {
+    const rows: any[] = [];
+    const result = getCount(rows, { age: true });
+
+    expect(result).toEqual({
+      age: 0,
+    });
+  });
+
+  test("should return 0 for fields where all values are null", () => {
+    const rows = [
+      { age: null, score: 80 },
+      { age: null, score: 90 },
+    ];
+    const result = getCount(rows, { age: true, score: true });
+
+    expect(result).toEqual({
+      age: 0,
+      score: 2,
+    });
+  });
+
+  test("should count zero and false as valid values", () => {
+    const rows = [
+      { num: 0, flag: false },
+      { num: 0, flag: false },
+    ];
+    const result = getCount(rows, { num: true, flag: true });
+
+    expect(result).toEqual({
+      num: 2,
+      flag: 2,
+    });
+  });
+});

--- a/src/util/aggregate/aggregateUtil/count.ts
+++ b/src/util/aggregate/aggregateUtil/count.ts
@@ -10,7 +10,7 @@ const getCount = (rows: Record<string, any>[], avgData: Select) => {
       return row[key] !== null && row[key] !== undefined;
     }).length;
 
-    countResult[key] = hitCount !== 0 ? hitCount : null;
+    countResult[key] = hitCount;
   });
 
   return countResult;


### PR DESCRIPTION
## 概要

aggregate の `_count` が **0件ヒット時に `null` を返す**バグを、Prisma に合わせて **`0` 返却**に修正しました（残タスク1）。

## Prisma 実測（prisma-test で裏取り）

- 0件ヒット aggregate の `_count: { id: true }` → `{ id: 0 }`（**0**）
- `_avg` / `_sum` / `_min` / `_max` → `null`（gassma の現挙動と同じ、変更なし）
- ヒットはあるが対象カラムが全行 null → `_count: 0`（null 値はカウント対象外。gassma の除外ロジック自体は Prisma と一致）
- 0件ヒットの groupBy → `[]`

## 修正

`src/util/aggregate/aggregateUtil/count.ts` の1行のみ:

```diff
- countResult[key] = hitCount !== 0 ? hitCount : null;
+ countResult[key] = hitCount;
```

## 影響範囲（getCount 呼び出し元3箇所を調査）

- **aggregate**: 今回の修正対象。
- **groupBy**: グループは常に1行以上なので通常挙動は不変。「グループ内で対象カラムが全行 null」の場合のみ null → 0 になり、Prisma 実測と一致する方向。
- **having**（getAggregate 経由）: 同上。null との比較（常に false）→ 0 との数値比較になり、Prisma の COUNT 意味論に近づく。
- `count()` メソッドは getCount と無関係（未変更）。

## テスト

- getCount 単体テスト新規5件（0件で 0 / null・undefined 除外 / 全行 null で 0 / 0・false は有効値）。
- 既存 aggregate テスト4件の `_count: null` assert を `0` に更新（`_avg`/`_sum` の null assert は維持）。
- **96 suites / 1133 tests 全 green**、`tsc --noEmit` clean、biome clean。
- reference に「`_count` が null」という記述は無いことを確認済み（docs 修正不要）。

## 関連

- gassma-cli 側の生成型（`_count: number | null` → `number`）は後続 PR で対応（本 PR マージ後にマージ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)