### PR TITLE
fix: having _count/_avg/_sum use numeric filter conditions

### DIFF
--- a/src/__test__/types/coreTypes.test.ts
+++ b/src/__test__/types/coreTypes.test.ts
@@ -1,0 +1,52 @@
+import type { HavingCore } from "../../types/coreTypes";
+import type { GroupByData } from "../../types/groupByType";
+
+describe("HavingCore aggregate filter types", () => {
+  test("should accept number FilterConditions for _count/_avg/_sum", () => {
+    const havingCore: HavingCore = {
+      _count: { gt: 2, gte: 3, lt: 10, lte: 9, not: 0 },
+      _avg: { equals: null, gte: 1.5 },
+      _sum: { in: [1, 2], notIn: [3], equals: 100 },
+    };
+
+    expect(havingCore).toBeDefined();
+  });
+
+  test("should accept _count having on string field via GroupByData", () => {
+    const groupByData: GroupByData = {
+      by: "住所",
+      having: { 郵便番号: { _count: { gt: 2 } } },
+      _count: { 郵便番号: true },
+    };
+
+    expect(groupByData).toBeDefined();
+  });
+
+  test("should keep field-value FilterConditions for _min/_max", () => {
+    const havingCore: HavingCore = {
+      _min: { contains: "a", mode: "insensitive" },
+      _max: { startsWith: "b", endsWith: "c", gte: "x" },
+    };
+
+    expect(havingCore).toBeDefined();
+  });
+
+  test("should reject string operators and string values for _count/_avg/_sum", () => {
+    // @ts-expect-error _count は件数（数値）なので contains は指定できない
+    const countContains: HavingCore = { _count: { contains: "a" } };
+
+    // @ts-expect-error _count は件数（数値）なので文字列値は指定できない
+    const countStringGt: HavingCore = { _count: { gt: "a" } };
+
+    // @ts-expect-error _avg は数値なので startsWith は指定できない
+    const avgStartsWith: HavingCore = { _avg: { startsWith: "a" } };
+
+    // @ts-expect-error _sum は数値なので文字列の in は指定できない
+    const sumStringIn: HavingCore = { _sum: { in: ["a"] } };
+
+    expect(countContains).toBeDefined();
+    expect(countStringGt).toBeDefined();
+    expect(avgStartsWith).toBeDefined();
+    expect(sumStringIn).toBeDefined();
+  });
+});

--- a/src/__test__/util/groupby/groupbyUtil/having.test.ts
+++ b/src/__test__/util/groupby/groupbyUtil/having.test.ts
@@ -37,6 +37,23 @@ describe("groupByFunc with having clause", () => {
     ]);
   });
 
+  test("should filter groups with having count gt on string field", () => {
+    const result = groupByFunc(getExtendedMockControllerUtil(), {
+      by: "住所",
+      having: {
+        名前: {
+          _count: { gt: 2 },
+        },
+      },
+      _count: { 名前: true },
+    });
+
+    // Only Tokyo should pass (count = 4 > 2), Osaka and Kyoto (count = 2) should be filtered out
+    expectArrayToEqualIgnoringOrder(result, [
+      { 住所: "Tokyo", _count: { 名前: 4 } },
+    ]);
+  });
+
   test("should filter groups with having condition - max age", () => {
     const result = groupByFunc(getExtendedMockControllerUtil(), {
       by: "住所",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -367,12 +367,23 @@ declare namespace Gassma {
     cursor?: Record<string, unknown>;
   };
 
+  type NumberFilterConditions = {
+    equals?: number | null;
+    not?: number | null;
+    in?: number[];
+    notIn?: number[];
+    lt?: number;
+    lte?: number;
+    gt?: number;
+    gte?: number;
+  };
+
   type HavingCore = {
-    _avg?: FilterConditions;
-    _count?: FilterConditions;
+    _avg?: NumberFilterConditions;
+    _count?: NumberFilterConditions;
     _max?: FilterConditions;
     _min?: FilterConditions;
-    _sum?: FilterConditions;
+    _sum?: NumberFilterConditions;
   } & FilterConditions;
 
   type HavingUse = {

--- a/src/types/coreTypes.ts
+++ b/src/types/coreTypes.ts
@@ -48,12 +48,23 @@ type WhereUse = {
   NOT?: WhereUse[] | WhereUse;
 };
 
+type NumberFilterConditions = {
+  equals?: number | null;
+  not?: number | null;
+  in?: number[];
+  notIn?: number[];
+  lt?: number;
+  lte?: number;
+  gt?: number;
+  gte?: number;
+};
+
 type HavingCore = {
-  _avg?: FilterConditions;
-  _count?: FilterConditions;
+  _avg?: NumberFilterConditions;
+  _count?: NumberFilterConditions;
   _max?: FilterConditions;
   _min?: FilterConditions;
-  _sum?: FilterConditions;
+  _sum?: NumberFilterConditions;
 } & FilterConditions;
 
 type HavingUse = {
@@ -152,6 +163,7 @@ export type {
   AnyUse,
   UpdateAnyUse,
   FilterConditions,
+  NumberFilterConditions,
   WhereUse,
   HavingCore,
   HavingUse,


### PR DESCRIPTION
## 概要

groupBy `having` の **`_count`/`_avg`/`_sum` フィルタ型がフィールド自身の型に束縛されていた**バグを、数値フィルタに修正しました（残タスク2の本体側）。

例: `having: { name: { _count: { gt: 2 } } }`（文字列フィールドの件数フィルタ）は実行時（`normalHavingFilter` → `getAggregate`）には数値比較で正当なのに、型が文字列 Filter を要求して弾いていました。

## Prisma 実測（prisma-test で裏取り）

- 文字列フィールドへの `_count: { gt: 2 }` は型・実行時とも正当（`_count` は `NestedIntFilter` = 数値フィルタ。`gt: 'a'` / `contains` は型エラー）。
- `_avg`/`_sum` は数値フィルタ（`NestedFloat(Nullable)Filter` 等）。
- `_min`/`_max` はフィールド型フィルタ（現状の gassma と同じ、変更なし）。

## 修正（型のみ・実行時挙動の変更ゼロ）

`NumberFilterConditions`（`equals`/`not`: `number | null`、`in`/`notIn`: `number[]`、`lt`/`lte`/`gt`/`gte`: `number`）を新設し、`HavingCore` の `_avg`/`_count`/`_sum` に適用（`src/types/coreTypes.ts` + 公開宣言 `src/index.d.ts` をミラー）。`_min`/`_max` は従来どおりフィールド型 Filter。

- 数値フィルタに `FieldRef` は含めていません（having 経路は `resolveFieldRefs` を通らず実行時未対応のため）。
- `HavingCore` 参照箇所（`normalHavingFilter` / `notPatternFilter`）は読み取りのみで非影響、既存 having テストも全通過。

## テスト（TDD: Red → Green）

- 型テスト新規: 数値フィルタ受け入れ（`_avg: { equals: null }` 含む）、文字列フィールドへの `_count` having、`_min`/`_max` の維持、`@ts-expect-error` 4件（`_count.contains` 等。修正前は TS2578 で Red を実証）。
- ランタイムテスト追加: 文字列フィールドへの `_count: { gt: 2 }` having（Prisma 実測と対）。
- **97 suites / 1138 tests 全 green**、`tsc --noEmit` clean、biome clean。

## スコープ外所見（別判断）

- Prisma は having の `_avg`/`_sum` を**数値フィールド限定**にしている。gassma 本体の `HavingUse` はフィールド型を知らないため無制限（実行時は非数値で `GassmaAggregateAvgTypeError` 等を throw）。フィールド単位の制限は CLI 生成型でのみ表現可能 — 要否は別途判断。
- gassma-cli 側の同種バグ（per-field HavingCore）は後続 PR で対応（本 PR マージ後にマージ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja