### PR TITLE
fix: write methods merge globalOmit with query omit on include paths

### DIFF
--- a/src/__test__/util/omit/writeIncludeGlobalOmit.test.ts
+++ b/src/__test__/util/omit/writeIncludeGlobalOmit.test.ts
@@ -1,0 +1,404 @@
+import { GassmaClient } from "../../../gassma";
+import { GassmaController } from "../../../gassmaController";
+
+type MockRange = {
+  getValues: () => unknown[][];
+  setValues: (values: unknown[][]) => void;
+};
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => MockRange;
+  getDataRange: () => { getValues: () => unknown[][] };
+  deleteRow: (rowIndex: number) => void;
+};
+
+const makeSheet = (name: string, initial: unknown[][]): MockSheet => {
+  const data = initial.map((row) => [...row]);
+  return {
+    getName: () => name,
+    getLastRow: () => data.length,
+    getLastColumn: () => data[0].length,
+    getRange: (row, col, numRows, numCols) => ({
+      getValues: () =>
+        data
+          .slice(row - 1, row - 1 + numRows)
+          .map((r) => r.slice(col - 1, col - 1 + numCols)),
+      setValues: (values) => {
+        values.forEach((rowValues, i) => {
+          while (data.length < row + i) {
+            data.push(Array(data[0].length).fill(""));
+          }
+          rowValues.forEach((value, j) => {
+            data[row - 1 + i][col - 1 + j] = value;
+          });
+        });
+      },
+    }),
+    getDataRange: () => ({ getValues: () => data }),
+    deleteRow: (rowIndex) => {
+      data.splice(rowIndex - 1, 1);
+    },
+  };
+};
+
+const buildClient = (): GassmaClient => {
+  const sheets = [
+    makeSheet("Users", [
+      ["id", "name", "password", "email"],
+      [1, "Alice", "pw-a", "a@example.com"],
+      [2, "Bob", "pw-b", "b@example.com"],
+    ]),
+    makeSheet("Posts", [
+      ["id", "authorId", "title"],
+      [101, 1, "Post A"],
+      [102, 2, "Post B"],
+    ]),
+  ];
+  const mockSpreadsheet = {
+    getId: () => "test-spreadsheet",
+    getSheets: () => sheets,
+    getSheetByName: (name: string) =>
+      sheets.find((sheet) => sheet.getName() === name) ?? null,
+  };
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+  });
+  return new GassmaClient({
+    relations: {
+      Users: {
+        posts: {
+          type: "oneToMany",
+          to: "Posts",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+    },
+    omit: { Users: { password: true } },
+  });
+};
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!(controller instanceof GassmaController)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+describe("write系 include + omit 併用時の globalOmit マージ", () => {
+  let client: GassmaClient;
+
+  beforeEach(() => {
+    client = buildClient();
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, { SpreadsheetApp: undefined });
+  });
+
+  describe("create", () => {
+    it("include + クエリomit(email) で globalOmit(password) もマージされ除外される", () => {
+      const result = sheetOf(client, "Users").create({
+        data: {
+          id: 3,
+          name: "Carol",
+          password: "pw-c",
+          email: "c@example.com",
+        },
+        include: { posts: true },
+        omit: { email: true },
+      });
+
+      expect(result).toEqual({ id: 3, name: "Carol", posts: [] });
+    });
+
+    it("include + omit: { password: false } で password が返る（解除）", () => {
+      const result = sheetOf(client, "Users").create({
+        data: {
+          id: 3,
+          name: "Carol",
+          password: "pw-c",
+          email: "c@example.com",
+        },
+        include: { posts: true },
+        omit: { password: false },
+      });
+
+      expect(result).toEqual({
+        id: 3,
+        name: "Carol",
+        password: "pw-c",
+        email: "c@example.com",
+        posts: [],
+      });
+    });
+  });
+
+  describe("createManyAndReturn", () => {
+    it("include + クエリomit(email) で globalOmit(password) もマージされ除外される", () => {
+      const result = sheetOf(client, "Users").createManyAndReturn({
+        data: [
+          { id: 3, name: "Carol", password: "pw-c", email: "c@example.com" },
+        ],
+        include: { posts: true },
+        omit: { email: true },
+      });
+
+      expect(result).toEqual([{ id: 3, name: "Carol", posts: [] }]);
+    });
+
+    it("include + omit: { password: false } で password が返る（解除）", () => {
+      const result = sheetOf(client, "Users").createManyAndReturn({
+        data: [
+          { id: 3, name: "Carol", password: "pw-c", email: "c@example.com" },
+        ],
+        include: { posts: true },
+        omit: { password: false },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 3,
+          name: "Carol",
+          password: "pw-c",
+          email: "c@example.com",
+          posts: [],
+        },
+      ]);
+    });
+  });
+
+  describe("update", () => {
+    it("include + クエリomit(email) で globalOmit(password) もマージされ除外される", () => {
+      const result = sheetOf(client, "Users").update({
+        where: { id: 1 },
+        data: { name: "Alice2" },
+        include: { posts: true },
+        omit: { email: true },
+      });
+
+      expect(result).toEqual({
+        id: 1,
+        name: "Alice2",
+        posts: [{ id: 101, authorId: 1, title: "Post A" }],
+      });
+    });
+
+    it("include + omit: { password: false } で password が返る（解除）", () => {
+      const result = sheetOf(client, "Users").update({
+        where: { id: 1 },
+        data: { name: "Alice2" },
+        include: { posts: true },
+        omit: { password: false },
+      });
+
+      expect(result).toEqual({
+        id: 1,
+        name: "Alice2",
+        password: "pw-a",
+        email: "a@example.com",
+        posts: [{ id: 101, authorId: 1, title: "Post A" }],
+      });
+    });
+  });
+
+  describe("upsert", () => {
+    it("update経路: include のみで globalOmit(password) が適用される", () => {
+      const result = sheetOf(client, "Users").upsert({
+        where: { id: 1 },
+        create: { id: 1, name: "never", password: "x", email: "x" },
+        update: { name: "Alice2" },
+        include: { posts: true },
+      });
+
+      expect(result).toEqual({
+        id: 1,
+        name: "Alice2",
+        email: "a@example.com",
+        posts: [{ id: 101, authorId: 1, title: "Post A" }],
+      });
+    });
+
+    it("update経路: include + クエリomit(email) で globalOmit もマージされる", () => {
+      const result = sheetOf(client, "Users").upsert({
+        where: { id: 1 },
+        create: { id: 1, name: "never", password: "x", email: "x" },
+        update: { name: "Alice2" },
+        include: { posts: true },
+        omit: { email: true },
+      });
+
+      expect(result).toEqual({
+        id: 1,
+        name: "Alice2",
+        posts: [{ id: 101, authorId: 1, title: "Post A" }],
+      });
+    });
+
+    it("update経路: include + omit: { password: false } で password が返る（解除）", () => {
+      const result = sheetOf(client, "Users").upsert({
+        where: { id: 1 },
+        create: { id: 1, name: "never", password: "x", email: "x" },
+        update: { name: "Alice2" },
+        include: { posts: true },
+        omit: { password: false },
+      });
+
+      expect(result).toEqual({
+        id: 1,
+        name: "Alice2",
+        password: "pw-a",
+        email: "a@example.com",
+        posts: [{ id: 101, authorId: 1, title: "Post A" }],
+      });
+    });
+
+    it("create経路: include + クエリomit(email) で globalOmit もマージされる", () => {
+      const result = sheetOf(client, "Users").upsert({
+        where: { id: 4 },
+        create: {
+          id: 4,
+          name: "Dave",
+          password: "pw-d",
+          email: "d@example.com",
+        },
+        update: { name: "never" },
+        include: { posts: true },
+        omit: { email: true },
+      });
+
+      expect(result).toEqual({ id: 4, name: "Dave", posts: [] });
+    });
+  });
+
+  describe("delete", () => {
+    it("include のみで globalOmit(password) が適用される", () => {
+      const result = sheetOf(client, "Users").delete({
+        where: { id: 2 },
+        include: { posts: true },
+      });
+
+      expect(result).toEqual({
+        id: 2,
+        name: "Bob",
+        email: "b@example.com",
+        posts: [{ id: 102, authorId: 2, title: "Post B" }],
+      });
+    });
+
+    it("include + クエリomit(email) で globalOmit もマージされる", () => {
+      const result = sheetOf(client, "Users").delete({
+        where: { id: 2 },
+        include: { posts: true },
+        omit: { email: true },
+      });
+
+      expect(result).toEqual({
+        id: 2,
+        name: "Bob",
+        posts: [{ id: 102, authorId: 2, title: "Post B" }],
+      });
+    });
+
+    it("include + omit: { password: false } で password が返る（解除）", () => {
+      const result = sheetOf(client, "Users").delete({
+        where: { id: 2 },
+        include: { posts: true },
+        omit: { password: false },
+      });
+
+      expect(result).toEqual({
+        id: 2,
+        name: "Bob",
+        password: "pw-b",
+        email: "b@example.com",
+        posts: [{ id: 102, authorId: 2, title: "Post B" }],
+      });
+    });
+  });
+
+  describe("非回帰", () => {
+    it("create: include のみで globalOmit(password) が適用される", () => {
+      const result = sheetOf(client, "Users").create({
+        data: {
+          id: 3,
+          name: "Carol",
+          password: "pw-c",
+          email: "c@example.com",
+        },
+        include: { posts: true },
+      });
+
+      expect(result).toEqual({
+        id: 3,
+        name: "Carol",
+        email: "c@example.com",
+        posts: [],
+      });
+    });
+
+    it("create: select 指定時は globalOmit を無視して password を返す", () => {
+      const result = sheetOf(client, "Users").create({
+        data: {
+          id: 3,
+          name: "Carol",
+          password: "pw-c",
+          email: "c@example.com",
+        },
+        select: { name: true, password: true },
+      });
+
+      expect(result).toEqual({ name: "Carol", password: "pw-c" });
+    });
+
+    it("create: include なし + omit: { password: false } で password が返る", () => {
+      const result = sheetOf(client, "Users").create({
+        data: {
+          id: 3,
+          name: "Carol",
+          password: "pw-c",
+          email: "c@example.com",
+        },
+        omit: { password: false },
+      });
+
+      expect(result).toEqual({
+        id: 3,
+        name: "Carol",
+        password: "pw-c",
+        email: "c@example.com",
+      });
+    });
+
+    it("findMany: include + omit: { password: false } で password が返る", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: true },
+        omit: { password: false },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          password: "pw-a",
+          email: "a@example.com",
+          posts: [{ id: 101, authorId: 1, title: "Post A" }],
+        },
+      ]);
+    });
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -17,7 +17,13 @@ import { resolveGlobalOmit } from "./util/omit/resolveGlobalOmit";
 import { GassmaIncludeSelectConflictError } from "./errors/relation/relationError";
 import { IncludeWithoutRelationsError } from "./errors/relation/relationValidationError";
 import type { AggregateData } from "./types/aggregateType";
-import type { AnyUse, Select, Omit, WhereUse } from "./types/coreTypes";
+import type {
+  AnyUse,
+  Select,
+  Omit,
+  QueryOmit,
+  WhereUse,
+} from "./types/coreTypes";
 import type { CountData } from "./types/countType";
 import type {
   CreateData,
@@ -220,7 +226,7 @@ class GassmaController {
 
   private resolveEffectiveOmit(
     select: Record<string, unknown> | null | undefined,
-    queryOmit: Omit | null | undefined,
+    queryOmit: QueryOmit | null | undefined,
   ): Omit | null {
     return resolveGlobalOmit(this.globalOmit, select, queryOmit);
   }
@@ -325,10 +331,8 @@ class GassmaController {
         createdData.include,
         this.relationContext,
       );
-      if (createdData.omit) {
-        return resolved.map((r) => omitFunc(createdData.omit!, r));
-      }
-      return resolved.map((r) => this.applyOmitToResult(r, this.globalOmit));
+      const includeOmit = this.resolveEffectiveOmit(null, createdData.omit);
+      return resolved.map((r) => this.applyOmitToResult(r, includeOmit));
     }
 
     if (createdData.select) {
@@ -375,8 +379,10 @@ class GassmaController {
         this.relationContext,
       );
       const included = resolved[0] ?? mapped;
-      if (createdData.omit) return omitFunc(createdData.omit, included);
-      return this.applyOmitToResult(included, this.globalOmit);
+      return this.applyOmitToResult(
+        included,
+        this.resolveEffectiveOmit(null, createdData.omit),
+      );
     }
 
     if (createdData.select) return findedDataSelect(createdData.select, mapped);
@@ -788,8 +794,10 @@ class GassmaController {
         this.relationContext,
       );
       const included = resolved[0] ?? stripped;
-      if (updateData.omit) return omitFunc(updateData.omit, included);
-      return this.applyOmitToResult(included, this.globalOmit);
+      return this.applyOmitToResult(
+        included,
+        this.resolveEffectiveOmit(null, updateData.omit),
+      );
     }
 
     if (updateData.select) return findedDataSelect(updateData.select, stripped);

--- a/src/types/coreTypes.ts
+++ b/src/types/coreTypes.ts
@@ -21,6 +21,10 @@ type Omit = {
   [key: string]: true;
 };
 
+type QueryOmit = {
+  [key: string]: boolean;
+};
+
 type NumberOperation = {
   increment?: number;
   decrement?: number;
@@ -159,6 +163,7 @@ export type {
   OrderBy,
   Select,
   Omit,
+  QueryOmit,
   NumberOperation,
   AnyUse,
   UpdateAnyUse,

--- a/src/types/createTypes.ts
+++ b/src/types/createTypes.ts
@@ -1,10 +1,10 @@
-import type { AnyUse, ManyReturn, Omit, Select } from "./coreTypes";
+import type { AnyUse, ManyReturn, QueryOmit, Select } from "./coreTypes";
 import type { IncludeData } from "./relationTypes";
 
 type CreateData = {
   data: AnyUse;
   select?: Select;
-  omit?: Omit;
+  omit?: QueryOmit;
   include?: IncludeData;
 };
 
@@ -15,7 +15,7 @@ type CreateManyData = {
 type CreateManyAndReturnData = {
   data: AnyUse[];
   select?: Select;
-  omit?: Omit;
+  omit?: QueryOmit;
   include?: IncludeData;
 };
 

--- a/src/types/findTypes.ts
+++ b/src/types/findTypes.ts
@@ -1,8 +1,8 @@
 import type {
   AnyUse,
   ManyReturn,
-  Omit,
   OrderBy,
+  QueryOmit,
   Select,
   UpdateAnyUse,
   WhereUse,
@@ -20,7 +20,7 @@ type FindSelect = {
 type FindFirstData = {
   where?: WhereUse;
   select?: FindSelect;
-  omit?: Omit;
+  omit?: QueryOmit;
   orderBy?: OrderBy | OrderBy[];
   include?: IncludeData;
   cursor?: Record<string, unknown>;
@@ -29,7 +29,7 @@ type FindFirstData = {
 type FindData = {
   where?: WhereUse;
   select?: FindSelect;
-  omit?: Omit;
+  omit?: QueryOmit;
   orderBy?: OrderBy | OrderBy[];
   take?: number;
   skip?: number;
@@ -42,7 +42,7 @@ type UpdateSingleData = {
   where: WhereUse;
   data: Record<string, unknown>;
   select?: Select;
-  omit?: Omit;
+  omit?: QueryOmit;
   include?: IncludeData;
 };
 
@@ -58,14 +58,14 @@ type UpsertSingleData = {
   update: AnyUse;
   select?: Select;
   include?: IncludeData;
-  omit?: Omit;
+  omit?: QueryOmit;
 };
 
 type DeleteSingleData = {
   where: WhereUse;
   select?: Select;
   include?: IncludeData;
-  omit?: Omit;
+  omit?: QueryOmit;
 };
 
 type DeleteData = {

--- a/src/util/delete/delete.ts
+++ b/src/util/delete/delete.ts
@@ -33,7 +33,11 @@ const deleteFunc = (
 
   deleteManyFunc(gassmaControllerUtil, { where: deleteData.where, limit: 1 });
 
-  if (includeResult) return includeResult[0] ?? null;
+  if (includeResult) {
+    const included = includeResult[0] ?? null;
+    if (included && deleteData.omit) return omitFunc(deleteData.omit, included);
+    return included;
+  }
   if (deleteData.select) return findedDataSelect(deleteData.select, record);
   if (deleteData.omit) return omitFunc(deleteData.omit, record);
 

--- a/src/util/find/findUtil/applySelectOmit.ts
+++ b/src/util/find/findUtil/applySelectOmit.ts
@@ -1,4 +1,4 @@
-import type { Omit } from "../../../types/coreTypes";
+import type { QueryOmit } from "../../../types/coreTypes";
 import { GassmaFindSelectOmitConflictError } from "../../../errors/find/findError";
 import { findedDataSelect } from "./findDataSelect";
 import { omitFunc } from "./omit";
@@ -6,7 +6,7 @@ import { omitFunc } from "./omit";
 const applySelectOmit = (
   records: Record<string, unknown>[],
   select: Record<string, unknown> | null | undefined,
-  omit: Omit | null | undefined,
+  omit: QueryOmit | null | undefined,
 ): Record<string, unknown>[] => {
   if (select && omit) {
     throw new GassmaFindSelectOmitConflictError();

--- a/src/util/find/findUtil/omit.ts
+++ b/src/util/find/findUtil/omit.ts
@@ -1,8 +1,8 @@
-import type { Omit } from "../../../types/coreTypes";
+import type { QueryOmit } from "../../../types/coreTypes";
 
-const omitFunc = (omit: Omit, row: Record<string, unknown>) => {
+const omitFunc = (omit: QueryOmit, row: Record<string, unknown>) => {
   const result = { ...row };
-  const omitKeys = Object.keys(omit);
+  const omitKeys = Object.keys(omit).filter((key) => omit[key]);
 
   omitKeys.forEach((key) => {
     delete result[key];

--- a/src/util/omit/resolveGlobalOmit.ts
+++ b/src/util/omit/resolveGlobalOmit.ts
@@ -1,9 +1,9 @@
-import type { Omit } from "../../types/coreTypes";
+import type { Omit, QueryOmit } from "../../types/coreTypes";
 
 const resolveGlobalOmit = (
   globalOmit: Omit | null,
   select: Record<string, unknown> | null | undefined,
-  queryOmit: Record<string, boolean> | null | undefined,
+  queryOmit: QueryOmit | null | undefined,
 ): Omit | null => {
   if (select) return null;
 

--- a/src/util/upsert/upsert.ts
+++ b/src/util/upsert/upsert.ts
@@ -24,7 +24,9 @@ const applyOptions = (
       upsertData.include,
       relationContext,
     );
-    return resolved[0] ?? result;
+    const included = resolved[0] ?? result;
+    if (upsertData.omit) return omitFunc(upsertData.omit, included);
+    return included;
   }
   if (upsertData.select) return findedDataSelect(upsertData.select, result);
   if (upsertData.omit) return omitFunc(upsertData.omit, result);


### PR DESCRIPTION
## 概要

write 系メソッドの **include + クエリ omit 併用パス**で omit の意味論が壊れていたランタイムバグを修正しました（残タスク3）。

## バグ（全 write 系 × 分岐を再調査した結果）

| メソッド | include 経路の問題 |
|---|---|
| create / createManyAndReturn / update | `omitFunc(クエリomit)` を直適用 → (a) **globalOmit がマージされない**（find 系は `applyOmitToResult` でマージ） (b) `omitFunc` が値 `false` のキーも削除 → **`omit: { field: false }`（解除の意味）が「除外」になる** |
| **upsert / delete（新規発見）** | include 解決後に **omit を一切適用せず返却** — globalOmit もクエリ omit も全落ち |

reference の omit 優先順位（select 最優先 → クエリ omit はマージ・`false` で解除 → globalOmit）と矛盾していました。

## 修正

- `omitFunc` を「値が truthy のキーのみ削除」に変更（`false` = 解除をプリミティブで保証）。
- create / createManyAndReturn / update の include 分岐を find 系と同一の `applyOmitToResult(resolveEffectiveOmit(...))` に統一（`omit!` の non-null assertion も消滅）。
- upsert / delete は include 解決後に実効 omit を適用。
- 内部型 `QueryOmit`（boolean 許容）を追加しクエリ omit 7箇所に適用。**公開 `src/index.d.ts` は既に `Record<string, boolean>` で宣言済みのため公開 API 変更なし**（内部型の整合化）。

## 検証

- **Prisma 実測**（prisma-test、実行後に原状復元済み）: create / update / upsert 両経路 / delete の include + omit で「globalOmit マージ」「`false` 解除」を確認。挙動一致。
- reference `globalOmit.md` の優先順位表（write 系 8 メソッド対応）と一致。
- TDD: 新規テスト 17 件（バグ検証 13 + 非回帰 4、Red→Green 実証）。
- **98 suites / 1155 tests 全 green**（+17）、`tsc --noEmit` clean、biome clean（lint 警告は 52→51 で新規なし）。

## スコープ外所見（別判断・MEMORY 記録済み）

- upsert / delete は select + omit 同時指定で `GassmaFindSelectOmitConflictError` を投げない（find / create / update は投げる。reference は「同時使用不可」記載）。
- nested include 内の relation レベル omit は `false` 解除未対応（型も true のみ。解除には別実装が必要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)