### PR TITLE
fix: upsert/delete throw on select + omit conflict

### DIFF
--- a/src/__test__/util/omit/selectOmitConflict.test.ts
+++ b/src/__test__/util/omit/selectOmitConflict.test.ts
@@ -1,0 +1,202 @@
+import { GassmaClient } from "../../../gassma";
+import { GassmaController } from "../../../gassmaController";
+
+type MockRange = {
+  getValues: () => unknown[][];
+  setValues: (values: unknown[][]) => void;
+};
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => MockRange;
+  getDataRange: () => { getValues: () => unknown[][] };
+  deleteRow: (rowIndex: number) => void;
+};
+
+const makeSheet = (name: string, initial: unknown[][]): MockSheet => {
+  const data = initial.map((row) => [...row]);
+  return {
+    getName: () => name,
+    getLastRow: () => data.length,
+    getLastColumn: () => data[0].length,
+    getRange: (row, col, numRows, numCols) => ({
+      getValues: () =>
+        data
+          .slice(row - 1, row - 1 + numRows)
+          .map((r) => r.slice(col - 1, col - 1 + numCols)),
+      setValues: (values) => {
+        values.forEach((rowValues, i) => {
+          while (data.length < row + i) {
+            data.push(Array(data[0].length).fill(""));
+          }
+          rowValues.forEach((value, j) => {
+            data[row - 1 + i][col - 1 + j] = value;
+          });
+        });
+      },
+    }),
+    getDataRange: () => ({ getValues: () => data }),
+    deleteRow: (rowIndex) => {
+      data.splice(rowIndex - 1, 1);
+    },
+  };
+};
+
+const buildClient = (): GassmaClient => {
+  const sheets = [
+    makeSheet("Users", [
+      ["id", "name", "email"],
+      [1, "Alice", "a@example.com"],
+      [2, "Bob", "b@example.com"],
+    ]),
+  ];
+  const mockSpreadsheet = {
+    getId: () => "test-spreadsheet",
+    getSheets: () => sheets,
+    getSheetByName: (name: string) =>
+      sheets.find((sheet) => sheet.getName() === name) ?? null,
+  };
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+  });
+  return new GassmaClient();
+};
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!(controller instanceof GassmaController)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+describe("upsert / delete の select + omit 同時指定", () => {
+  let client: GassmaClient;
+
+  beforeEach(() => {
+    client = buildClient();
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, { SpreadsheetApp: undefined });
+  });
+
+  describe("upsert", () => {
+    it("update経路: select と omit の同時指定でエラーを投げる", () => {
+      expect(() =>
+        sheetOf(client, "Users").upsert({
+          where: { id: 1 },
+          create: { id: 1, name: "never", email: "x@example.com" },
+          update: { name: "Alice2" },
+          select: { name: true },
+          omit: { email: true },
+        }),
+      ).toThrow("Cannot use both select and omit in the same query");
+    });
+
+    it("create経路: select と omit の同時指定でエラーを投げる", () => {
+      expect(() =>
+        sheetOf(client, "Users").upsert({
+          where: { id: 99 },
+          create: { id: 99, name: "Carol", email: "c@example.com" },
+          update: { name: "never" },
+          select: { name: true },
+          omit: { email: true },
+        }),
+      ).toThrow("Cannot use both select and omit in the same query");
+    });
+
+    it("エラー時はシートに書き込まれない", () => {
+      expect(() =>
+        sheetOf(client, "Users").upsert({
+          where: { id: 99 },
+          create: { id: 99, name: "Carol", email: "c@example.com" },
+          update: { name: "never" },
+          select: { name: true },
+          omit: { email: true },
+        }),
+      ).toThrow("Cannot use both select and omit in the same query");
+
+      expect(sheetOf(client, "Users").findMany({})).toHaveLength(2);
+    });
+  });
+
+  describe("delete", () => {
+    it("select と omit の同時指定でエラーを投げる", () => {
+      expect(() =>
+        sheetOf(client, "Users").delete({
+          where: { id: 1 },
+          select: { name: true },
+          omit: { email: true },
+        }),
+      ).toThrow("Cannot use both select and omit in the same query");
+    });
+
+    it("エラー時はレコードが削除されない", () => {
+      expect(() =>
+        sheetOf(client, "Users").delete({
+          where: { id: 1 },
+          select: { name: true },
+          omit: { email: true },
+        }),
+      ).toThrow("Cannot use both select and omit in the same query");
+
+      expect(sheetOf(client, "Users").findMany({})).toHaveLength(2);
+    });
+  });
+
+  describe("非回帰", () => {
+    it("upsert: select のみは従来通り動く", () => {
+      const result = sheetOf(client, "Users").upsert({
+        where: { id: 1 },
+        create: { id: 1, name: "never", email: "x@example.com" },
+        update: { name: "Alice2" },
+        select: { id: true, name: true },
+      });
+
+      expect(result).toEqual({ id: 1, name: "Alice2" });
+    });
+
+    it("upsert: omit のみは従来通り動く", () => {
+      const result = sheetOf(client, "Users").upsert({
+        where: { id: 1 },
+        create: { id: 1, name: "never", email: "x@example.com" },
+        update: { name: "Alice2" },
+        omit: { email: true },
+      });
+
+      expect(result).toEqual({ id: 1, name: "Alice2" });
+    });
+
+    it("delete: select のみは従来通り動く", () => {
+      const result = sheetOf(client, "Users").delete({
+        where: { id: 2 },
+        select: { name: true },
+      });
+
+      expect(result).toEqual({ name: "Bob" });
+      expect(sheetOf(client, "Users").findMany({})).toHaveLength(1);
+    });
+
+    it("delete: omit のみは従来通り動く", () => {
+      const result = sheetOf(client, "Users").delete({
+        where: { id: 2 },
+        omit: { email: true },
+      });
+
+      expect(result).toEqual({ id: 2, name: "Bob" });
+      expect(sheetOf(client, "Users").findMany({})).toHaveLength(1);
+    });
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -879,6 +879,9 @@ class GassmaController {
     if (upsertData.include && !this.relationContext) {
       throw new IncludeWithoutRelationsError();
     }
+    if (upsertData.select && upsertData.omit) {
+      throw new GassmaFindSelectOmitConflictError();
+    }
 
     const resolvedWhere =
       this.resolveWhere(upsertData.where) ?? upsertData.where;
@@ -914,6 +917,9 @@ class GassmaController {
     }
     if (deleteData.include && !this.relationContext) {
       throw new IncludeWithoutRelationsError();
+    }
+    if (deleteData.select && deleteData.omit) {
+      throw new GassmaFindSelectOmitConflictError();
     }
 
     const resolvedWhere =


### PR DESCRIPTION
## 概要

**upsert / delete が select + omit 同時指定でも `GassmaFindSelectOmitConflictError` を投げなかった**バグを修正しました（新規タスク1）。

find 系 / create / update は controller 入口で「include+select」「include かつ relation なし」「select+omit」の3点を検証しますが、upsert / delete は **select+omit チェックだけが欠落**していました。reference（upsert.md / delete.md）は「select と同時に使用できません」を既に明記しており、今回でランタイムがドキュメントと一致します。cli 生成型は XOR で型レベル排他済みですが、CLI なし（手動設定）ユーザー向けのランタイム検証です。

## 修正（6行のみ）

controller の `upsert` / `delete` 入口に既存と同一の検証を追加:

```ts
if (upsertData.select && upsertData.omit) {
  throw new GassmaFindSelectOmitConflictError();
}
```

- upsert は create/update 分岐**前**の入口1回で両経路をカバー（テストで両経路検証済み）。
- **util 層には置かない**: controller は「select のみ + `@ignore` 設定」の正当ケースで `mergeIgnoreIntoOmit` が合成 omit を select と同時に util へ渡すため、util 側検証は誤爆する。ユーザー生引数を検証する controller 入口が正解（create/update と同じ）。

## テスト（TDD: Red → Green）

- 新規9件: upsert conflict throw（update 経路・create 経路・エラー時シート未書込）、delete conflict throw（+ エラー時未削除）、非回帰（select のみ / omit のみ）。
- **99 suites / 1164 tests 全 green**（+9）、`tsc --noEmit` clean、biome clean。
- reference は変更不要（エラー一覧・upsert/delete ページとも既存記載と一致）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja