### PR TITLE
fix: relation-level omit false un-omits target globalOmit fields

### DIFF
--- a/src/__test__/util/omit/includeRelationOmit.test.ts
+++ b/src/__test__/util/omit/includeRelationOmit.test.ts
@@ -1,0 +1,350 @@
+import { GassmaClient } from "../../../gassma";
+import { GassmaController } from "../../../gassmaController";
+
+type MockRange = {
+  getValues: () => unknown[][];
+  setValues: (values: unknown[][]) => void;
+};
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => MockRange;
+  getDataRange: () => { getValues: () => unknown[][] };
+  deleteRow: (rowIndex: number) => void;
+};
+
+const makeSheet = (name: string, initial: unknown[][]): MockSheet => {
+  const data = initial.map((row) => [...row]);
+  return {
+    getName: () => name,
+    getLastRow: () => data.length,
+    getLastColumn: () => data[0].length,
+    getRange: (row, col, numRows, numCols) => ({
+      getValues: () =>
+        data
+          .slice(row - 1, row - 1 + numRows)
+          .map((r) => r.slice(col - 1, col - 1 + numCols)),
+      setValues: (values) => {
+        values.forEach((rowValues, i) => {
+          while (data.length < row + i) {
+            data.push(Array(data[0].length).fill(""));
+          }
+          rowValues.forEach((value, j) => {
+            data[row - 1 + i][col - 1 + j] = value;
+          });
+        });
+      },
+    }),
+    getDataRange: () => ({ getValues: () => data }),
+    deleteRow: (rowIndex) => {
+      data.splice(rowIndex - 1, 1);
+    },
+  };
+};
+
+const buildClient = (): GassmaClient => {
+  const sheets = [
+    makeSheet("Users", [
+      ["id", "name", "password", "email"],
+      [1, "Alice", "pw-a", "a@example.com"],
+      [2, "Bob", "pw-b", "b@example.com"],
+    ]),
+    makeSheet("Posts", [
+      ["id", "authorId", "title", "secret"],
+      [101, 1, "Post A", "s-a"],
+      [102, 2, "Post B", "s-b"],
+    ]),
+    makeSheet("Comments", [
+      ["id", "postId", "body", "hidden"],
+      [1001, 101, "Comment 1", "h-1"],
+      [1002, 102, "Comment 2", "h-2"],
+    ]),
+  ];
+  const mockSpreadsheet = {
+    getId: () => "test-spreadsheet",
+    getSheets: () => sheets,
+    getSheetByName: (name: string) =>
+      sheets.find((sheet) => sheet.getName() === name) ?? null,
+  };
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+  });
+  return new GassmaClient({
+    relations: {
+      Users: {
+        posts: {
+          type: "oneToMany",
+          to: "Posts",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+      Posts: {
+        author: {
+          type: "manyToOne",
+          to: "Users",
+          field: "authorId",
+          reference: "id",
+        },
+        comments: {
+          type: "oneToMany",
+          to: "Comments",
+          field: "id",
+          reference: "postId",
+        },
+      },
+    },
+    omit: {
+      Users: { password: true },
+      Posts: { secret: true },
+      Comments: { hidden: true },
+    },
+  });
+};
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!(controller instanceof GassmaController)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+describe("nested include/select の relation レベル omit と globalOmit", () => {
+  let client: GassmaClient;
+
+  beforeEach(() => {
+    client = buildClient();
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, { SpreadsheetApp: undefined });
+  });
+
+  describe("false 解除", () => {
+    it("include: { posts: { omit: { secret: false } } } で globalOmit(secret) が解除される", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: { omit: { secret: false } } },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          email: "a@example.com",
+          posts: [{ id: 101, authorId: 1, title: "Post A", secret: "s-a" }],
+        },
+      ]);
+    });
+
+    it("manyToOne: include: { author: { omit: { password: false } } } で password が返る", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { id: 101 },
+        include: { author: { omit: { password: false } } },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 101,
+          authorId: 1,
+          title: "Post A",
+          author: {
+            id: 1,
+            name: "Alice",
+            password: "pw-a",
+            email: "a@example.com",
+          },
+        },
+      ]);
+    });
+
+    it("select 内 relation の omit: { secret: false } でも解除される", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        select: { name: true, posts: { omit: { secret: false } } },
+      });
+
+      expect(result).toEqual([
+        {
+          name: "Alice",
+          posts: [{ id: 101, authorId: 1, title: "Post A", secret: "s-a" }],
+        },
+      ]);
+    });
+
+    it("深いネスト: comments の omit: { hidden: false } でも解除される", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: {
+          posts: { include: { comments: { omit: { hidden: false } } } },
+        },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          email: "a@example.com",
+          posts: [
+            {
+              id: 101,
+              authorId: 1,
+              title: "Post A",
+              comments: [
+                { id: 1001, postId: 101, body: "Comment 1", hidden: "h-1" },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("findFirst でも include: { posts: { omit: { secret: false } } } が解除される", () => {
+      const result = sheetOf(client, "Users").findFirst({
+        where: { id: 1 },
+        include: { posts: { omit: { secret: false } } },
+      });
+
+      expect(result).toEqual({
+        id: 1,
+        name: "Alice",
+        email: "a@example.com",
+        posts: [{ id: 101, authorId: 1, title: "Post A", secret: "s-a" }],
+      });
+    });
+  });
+
+  describe("globalOmit とのマージ", () => {
+    it("omit: { title: true } は globalOmit(secret) とマージされ両方除外される", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: { omit: { title: true } } },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          email: "a@example.com",
+          posts: [{ id: 101, authorId: 1 }],
+        },
+      ]);
+    });
+
+    it("omit: { secret: false, title: true } 混在で secret 再表示 + title 除外", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: { omit: { secret: false, title: true } } },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          email: "a@example.com",
+          posts: [{ id: 101, authorId: 1, secret: "s-a" }],
+        },
+      ]);
+    });
+
+    it("globalOmit に無いフィールドの omit: { title: false } は no-op", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: { omit: { title: false } } },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          email: "a@example.com",
+          posts: [{ id: 101, authorId: 1, title: "Post A" }],
+        },
+      ]);
+    });
+  });
+
+  describe("非回帰", () => {
+    it("include: { posts: true } では globalOmit(secret) が適用される", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: true },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          email: "a@example.com",
+          posts: [{ id: 101, authorId: 1, title: "Post A" }],
+        },
+      ]);
+    });
+
+    it("omit: { authorId: true }（グルーピング列の除外）でも紐付けが保たれる", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: { omit: { authorId: true } } },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          email: "a@example.com",
+          posts: [{ id: 101, title: "Post A" }],
+        },
+      ]);
+    });
+
+    it("omit: { id: true } + 深いネスト include でも子孫の紐付けが保たれる", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: { omit: { id: true }, include: { comments: true } } },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          email: "a@example.com",
+          posts: [
+            {
+              authorId: 1,
+              title: "Post A",
+              comments: [{ id: 1001, postId: 101, body: "Comment 1" }],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("include: { posts: { select: { title: true } } } は従来通り select が適用される", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: { select: { title: true } } },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          email: "a@example.com",
+          posts: [{ title: "Post A" }],
+        },
+      ]);
+    });
+  });
+});

--- a/src/__test__/util/relation/resolvers/manyToMany.test.ts
+++ b/src/__test__/util/relation/resolvers/manyToMany.test.ts
@@ -301,6 +301,25 @@ describe("resolveManyToMany", () => {
     expect(result[0].categories).toEqual([{ id: 10, name: "Tech" }]);
   });
 
+  it("omit の false エントリのみをターゲット取得に渡し、中間テーブルには渡さない", () => {
+    const parents = [{ id: 1, title: "Post A" }];
+
+    mockFindMany.mockReturnValueOnce([{ postId: 1, categoryId: 10 }]);
+    mockFindMany.mockReturnValueOnce([
+      { id: 10, name: "Tech", description: "Tech stuff" },
+    ]);
+
+    resolveManyToMany(parents, relation, "categories", mockFindMany, {
+      omit: { description: true, secret: false },
+    });
+
+    expect(mockFindMany.mock.calls[0][1].omit).toBeUndefined();
+    expect(mockFindMany).toHaveBeenNthCalledWith(2, "Categories", {
+      where: { id: { in: [10] } },
+      omit: { secret: false },
+    });
+  });
+
   it("ターゲット取得にincludeが渡され、中間テーブルには渡されない", () => {
     const parents = [{ id: 1, title: "Post A" }];
 

--- a/src/__test__/util/relation/resolvers/manyToOne.test.ts
+++ b/src/__test__/util/relation/resolvers/manyToOne.test.ts
@@ -134,6 +134,23 @@ describe("resolveManyToOne", () => {
     expect(result[0].author).toEqual({ id: 1, name: "Alice" });
   });
 
+  it("omit の false エントリのみを findManyOnSheet に渡す", () => {
+    const parents = [{ id: 101, authorId: 1, title: "Post A" }];
+
+    mockFindMany.mockReturnValue([
+      { id: 1, name: "Alice", email: "alice@test.com" },
+    ]);
+
+    resolveManyToOne(parents, relation, "author", mockFindMany, {
+      omit: { email: true, password: false },
+    });
+
+    expect(mockFindMany).toHaveBeenCalledWith("Users", {
+      where: { id: { in: [1] } },
+      omit: { password: false },
+    });
+  });
+
   it("FK値がnullの場合selectオプションがあってもnullを返す", () => {
     const parents = [{ id: 101, authorId: null, title: "Draft" }];
 

--- a/src/__test__/util/relation/resolvers/oneToMany.test.ts
+++ b/src/__test__/util/relation/resolvers/oneToMany.test.ts
@@ -262,6 +262,37 @@ describe("resolveOneToMany", () => {
     ]);
   });
 
+  it("omit の false エントリのみを findManyOnSheet に渡す", () => {
+    const parents = [{ id: 1, name: "Alice" }];
+
+    mockFindMany.mockReturnValue([
+      { id: 101, authorId: 1, title: "Post A", content: "Body A" },
+    ]);
+
+    resolveOneToMany(parents, relation, "posts", mockFindMany, {
+      omit: { content: true, secret: false },
+    });
+
+    expect(mockFindMany).toHaveBeenCalledWith("Posts", {
+      where: { authorId: { in: [1] } },
+      omit: { secret: false },
+    });
+  });
+
+  it("omit に false エントリが無ければ omit を渡さない", () => {
+    const parents = [{ id: 1, name: "Alice" }];
+
+    mockFindMany.mockReturnValue([
+      { id: 101, authorId: 1, title: "Post A", content: "Body A" },
+    ]);
+
+    resolveOneToMany(parents, relation, "posts", mockFindMany, {
+      omit: { content: true },
+    });
+
+    expect(mockFindMany.mock.calls[0][1].omit).toBeUndefined();
+  });
+
   it("targetRelationNames にある select 内の true 形式 relation を include として解決する", () => {
     const parents = [{ id: 1, name: "Alice" }];
 

--- a/src/__test__/util/relation/resolvers/oneToOne.test.ts
+++ b/src/__test__/util/relation/resolvers/oneToOne.test.ts
@@ -111,6 +111,23 @@ describe("resolveOneToOne", () => {
     expect(result[0].profile).toEqual({ id: 10, userId: 1, bio: "Hello" });
   });
 
+  it("omit の false エントリのみを findManyOnSheet に渡す", () => {
+    const parents = [{ id: 1, name: "Alice" }];
+
+    mockFindMany.mockReturnValue([
+      { id: 10, userId: 1, bio: "Hello", avatar: "pic.png" },
+    ]);
+
+    resolveOneToOne(parents, relation, "profile", mockFindMany, {
+      omit: { avatar: true, secret: false },
+    });
+
+    expect(mockFindMany).toHaveBeenCalledWith("Profiles", {
+      where: { userId: { in: [1] } },
+      omit: { secret: false },
+    });
+  });
+
   it("子レコードがnullの場合selectオプションがあってもnullを返す", () => {
     const parents = [{ id: 1, name: "Alice" }];
 

--- a/src/gassma.ts
+++ b/src/gassma.ts
@@ -1,5 +1,5 @@
 import { GassmaController } from "./gassmaController";
-import type { AnyUse, WhereUse } from "./types/coreTypes";
+import type { AnyUse, QueryOmit, WhereUse } from "./types/coreTypes";
 import type { GassmaSheet } from "./types/gassmaTypes";
 import type {
   GassmaClientOptions,
@@ -117,7 +117,7 @@ class GassmaClient {
 
     const findManyOnSheet = (
       sheetName: string,
-      findData: { where?: WhereUse; include?: IncludeData },
+      findData: { where?: WhereUse; include?: IncludeData; omit?: QueryOmit },
     ): Record<string, unknown>[] => {
       const controller = controllers[sheetName];
       if (!controller) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -170,7 +170,7 @@ declare namespace Gassma {
     skip?: number;
     take?: number;
     select?: Select;
-    omit?: Omit;
+    omit?: Record<string, boolean>;
     include?: IncludeData;
   };
 

--- a/src/types/relationTypes.ts
+++ b/src/types/relationTypes.ts
@@ -3,6 +3,7 @@ import type {
   GassmaAny,
   Omit,
   OrderBy,
+  QueryOmit,
   Select,
   WhereUse,
 } from "./coreTypes";
@@ -41,7 +42,7 @@ type IncludeItemOptions = {
   skip?: number;
   take?: number;
   select?: Select;
-  omit?: Omit;
+  omit?: QueryOmit;
   include?: IncludeData;
 };
 
@@ -105,7 +106,7 @@ type RelationContext = {
   relationNamesOnSheet?: (sheetName: string) => string[];
   findManyOnSheet: (
     sheetName: string,
-    findData: { where?: WhereUse; include?: IncludeData },
+    findData: { where?: WhereUse; include?: IncludeData; omit?: QueryOmit },
   ) => Record<string, unknown>[];
   deleteManyOnSheet?: (
     sheetName: string,

--- a/src/util/relation/pickOmitFalse.ts
+++ b/src/util/relation/pickOmitFalse.ts
@@ -1,0 +1,15 @@
+import type { QueryOmit } from "../../types/coreTypes";
+
+const pickOmitFalse = (omit?: QueryOmit): QueryOmit | undefined => {
+  if (!omit) return undefined;
+  const falseKeys = Object.keys(omit).filter((key) => omit[key] === false);
+  if (falseKeys.length === 0) return undefined;
+
+  const result: QueryOmit = {};
+  falseKeys.forEach((key) => {
+    result[key] = false;
+  });
+  return result;
+};
+
+export { pickOmitFalse };

--- a/src/util/relation/resolvers/manyToMany.ts
+++ b/src/util/relation/resolvers/manyToMany.ts
@@ -3,18 +3,19 @@ import type {
   IncludeItemOptions,
   RelationDefinition,
 } from "../../../types/relationTypes";
-import type { WhereUse } from "../../../types/coreTypes";
+import type { QueryOmit, WhereUse } from "../../../types/coreTypes";
 import { GassmaSkipNegativeError } from "../../../errors/find/findError";
 import { GassmaThroughRequiredError } from "../../../errors/relation/relationError";
 import { orderByFunc } from "../../find/findUtil/orderBy";
 import { applySelectOmit } from "../../find/findUtil/applySelectOmit";
 import { applySelectRelations } from "../../find/findUtil/applySelectRelations";
 import { collectKeys } from "../collectKeys";
+import { pickOmitFalse } from "../pickOmitFalse";
 import { processSelectForInclude } from "../processSelectForInclude";
 
 type FindManyOnSheet = (
   sheetName: string,
-  findData: { where?: WhereUse; include?: IncludeData },
+  findData: { where?: WhereUse; include?: IncludeData; omit?: QueryOmit },
 ) => Record<string, unknown>[];
 
 const resolveManyToMany = (
@@ -62,6 +63,7 @@ const resolveManyToMany = (
   const targets = findManyOnSheet(relation.to, {
     where: targetWhere,
     include: mergedInclude,
+    omit: pickOmitFalse(options?.omit),
   });
 
   // Step 3: ターゲットをルックアップマップに

--- a/src/util/relation/resolvers/manyToOne.ts
+++ b/src/util/relation/resolvers/manyToOne.ts
@@ -3,16 +3,17 @@ import type {
   IncludeItemOptions,
   RelationDefinition,
 } from "../../../types/relationTypes";
-import type { WhereUse } from "../../../types/coreTypes";
+import type { QueryOmit, WhereUse } from "../../../types/coreTypes";
 import { GassmaRelationDuplicateError } from "../../../errors/relation/relationError";
 import { applySelectOmit } from "../../find/findUtil/applySelectOmit";
 import { applySelectRelations } from "../../find/findUtil/applySelectRelations";
 import { collectKeys } from "../collectKeys";
+import { pickOmitFalse } from "../pickOmitFalse";
 import { processSelectForInclude } from "../processSelectForInclude";
 
 type FindManyOnSheet = (
   sheetName: string,
-  findData: { where?: WhereUse; include?: IncludeData },
+  findData: { where?: WhereUse; include?: IncludeData; omit?: QueryOmit },
 ) => Record<string, unknown>[];
 
 const resolveManyToOne = (
@@ -42,6 +43,7 @@ const resolveManyToOne = (
   const targets = findManyOnSheet(relation.to, {
     where,
     include: mergedInclude,
+    omit: pickOmitFalse(options?.omit),
   });
 
   const lookup = new Map<unknown, Record<string, unknown>>();

--- a/src/util/relation/resolvers/oneToMany.ts
+++ b/src/util/relation/resolvers/oneToMany.ts
@@ -3,17 +3,18 @@ import type {
   IncludeItemOptions,
   RelationDefinition,
 } from "../../../types/relationTypes";
-import type { WhereUse } from "../../../types/coreTypes";
+import type { QueryOmit, WhereUse } from "../../../types/coreTypes";
 import { GassmaSkipNegativeError } from "../../../errors/find/findError";
 import { orderByFunc } from "../../find/findUtil/orderBy";
 import { applySelectOmit } from "../../find/findUtil/applySelectOmit";
 import { applySelectRelations } from "../../find/findUtil/applySelectRelations";
 import { collectKeys } from "../collectKeys";
+import { pickOmitFalse } from "../pickOmitFalse";
 import { processSelectForInclude } from "../processSelectForInclude";
 
 type FindManyOnSheet = (
   sheetName: string,
-  findData: { where?: WhereUse; include?: IncludeData },
+  findData: { where?: WhereUse; include?: IncludeData; omit?: QueryOmit },
 ) => Record<string, unknown>[];
 
 const resolveOneToMany = (
@@ -43,6 +44,7 @@ const resolveOneToMany = (
   const children = findManyOnSheet(relation.to, {
     where,
     include: mergedInclude,
+    omit: pickOmitFalse(options?.omit),
   });
 
   const grouped = new Map<unknown, Record<string, unknown>[]>();

--- a/src/util/relation/resolvers/oneToOne.ts
+++ b/src/util/relation/resolvers/oneToOne.ts
@@ -3,16 +3,17 @@ import type {
   IncludeItemOptions,
   RelationDefinition,
 } from "../../../types/relationTypes";
-import type { WhereUse } from "../../../types/coreTypes";
+import type { QueryOmit, WhereUse } from "../../../types/coreTypes";
 import { GassmaRelationDuplicateError } from "../../../errors/relation/relationError";
 import { applySelectOmit } from "../../find/findUtil/applySelectOmit";
 import { applySelectRelations } from "../../find/findUtil/applySelectRelations";
 import { collectKeys } from "../collectKeys";
+import { pickOmitFalse } from "../pickOmitFalse";
 import { processSelectForInclude } from "../processSelectForInclude";
 
 type FindManyOnSheet = (
   sheetName: string,
-  findData: { where?: WhereUse; include?: IncludeData },
+  findData: { where?: WhereUse; include?: IncludeData; omit?: QueryOmit },
 ) => Record<string, unknown>[];
 
 const resolveOneToOne = (
@@ -42,6 +43,7 @@ const resolveOneToOne = (
   const children = findManyOnSheet(relation.to, {
     where,
     include: mergedInclude,
+    omit: pickOmitFalse(options?.omit),
   });
 
   const lookup = new Map<unknown, Record<string, unknown>>();


### PR DESCRIPTION
## 概要

nested include/select 内の **relation レベル `omit` で `omit: { field: false }`（ターゲット globalOmit の解除）が型・実装とも未対応**だった問題を修正しました（新規タスク2、最後の1件）。

## 原因

- 型: `IncludeItemOptions.omit` が true のみで `false` が書けない。
- 実装: nested 取得はターゲットの findMany（`findManyOnSheet`）経由で **globalOmit が fetch 時点で適用**されるため、resolver に届く前に列が消えており、ローカルでは解除が構造的に不可能。

## 設計: 「false エントリのみ pass-down」

relation omit を分割し、**false エントリだけ**ターゲット findMany にクエリ omit として渡す（既存の `resolveEffectiveOmit` マージが解除を実施）。truthy エントリは従来どおりグルーピング後にローカル適用。

- **全量 pass-down にしない理由**: truthy omit が fetch 時に効くと FK/参照列が落ちて**グルーピングが壊れる**（nested select がローカル適用なのと同じ理由）。false は「列を残す」方向にしか作用しないため pass-down してもグルーピング安全。
- 最終除外集合は `(globalOmit − false群) ∪ true群` = **top-level クエリ omit と同一の意味論**。深いネストにも再帰的に自然に成立。
- **Prisma 実測6ケース**（nested omit false の再表示・true マージ・select 内 relation の omit・FK 除外時の紐付け維持など）と一致。

## 変更

- 新規 `pickOmitFalse` ヘルパー、resolver 4種の fetch に `omit: pickOmitFalse(...)` 付与（manyToMany の中間テーブル fetch には渡さない）。
- `IncludeItemOptions.omit` → `QueryOmit`（boolean）、`RelationContext.findManyOnSheet` に `omit?`、公開 `src/index.d.ts` をミラー。
- **cli 追随は不要**（生成 `Omit` 型は既に boolean で relation optionsType から参照済み）。

## テスト（TDD: Red → Green 実証）

- 統合テスト12件（false 解除 × oneToMany/manyToOne/select 内 relation/深いネスト/findFirst、true マージ、globalOmit 外 false の no-op、非回帰）+ resolver 単体5件（「false のみ pass-down」契約）。
- **100 suites / 1181 tests 全 green**（+17）、`tsc --noEmit` clean、biome 新規指摘ゼロ。

## reference 所見（別途）

`include.md` の omit 節に「globalOmit とマージ・`false` で解除」の記述が無いため、マージ後に追記推奨（今回は変更していません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)