### PR TITLE
fix: Date equality matches by instant (equals/not/in/notIn/direct/cursor)

### DIFF
--- a/src/__test__/util/filterConditions/filterConditionsEquals.test.ts
+++ b/src/__test__/util/filterConditions/filterConditionsEquals.test.ts
@@ -54,4 +54,28 @@ describe("filterConditionsEquals", () => {
     const filterOptions = { equals: 42, mode: "insensitive" as const };
     expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(true);
   });
+
+  test("should match Dates with the same time but different instances", () => {
+    const cellData = new Date("2026-07-18T09:30:00.000Z");
+    const filterOptions = { equals: new Date("2026-07-18T09:30:00.000Z") };
+    expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(true);
+  });
+
+  test("should not match Dates with different times", () => {
+    const cellData = new Date("2026-07-18T09:30:00.000Z");
+    const filterOptions = { equals: new Date("2026-07-18T10:00:00.000Z") };
+    expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(false);
+  });
+
+  test("should not match Date cell against ISO string filter", () => {
+    const cellData = new Date("2026-07-18T09:30:00.000Z");
+    const filterOptions = { equals: "2026-07-18T09:30:00.000Z" };
+    expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(false);
+  });
+
+  test("should not match string cell against Date filter", () => {
+    const cellData = "2026-07-18T09:30:00.000Z";
+    const filterOptions = { equals: new Date("2026-07-18T09:30:00.000Z") };
+    expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(false);
+  });
 });

--- a/src/__test__/util/filterConditions/filterConditionsIn.test.ts
+++ b/src/__test__/util/filterConditions/filterConditionsIn.test.ts
@@ -30,4 +30,27 @@ describe("filterConditionsIn", () => {
     const filterOptions = { in: [true, false] };
     expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(true);
   });
+
+  test("should match a Date with the same time but different instance", () => {
+    const cellData = new Date("2026-07-18T09:30:00.000Z");
+    const filterOptions = {
+      in: [
+        new Date("2026-07-18T09:30:00.000Z"),
+        new Date("2026-07-19T00:00:00.000Z"),
+      ],
+    };
+    expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(true);
+  });
+
+  test("should not match a Date when no time matches", () => {
+    const cellData = new Date("2026-07-18T09:30:00.000Z");
+    const filterOptions = { in: [new Date("2026-07-19T00:00:00.000Z")] };
+    expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(false);
+  });
+
+  test("should not match a Date cell against ISO strings", () => {
+    const cellData = new Date("2026-07-18T09:30:00.000Z");
+    const filterOptions = { in: ["2026-07-18T09:30:00.000Z"] };
+    expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(false);
+  });
 });

--- a/src/__test__/util/filterConditions/filterConditionsNot.test.ts
+++ b/src/__test__/util/filterConditions/filterConditionsNot.test.ts
@@ -42,4 +42,16 @@ describe("filterConditionsNot", () => {
     const filterOptions = { not: "hello", mode: "insensitive" as const };
     expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(false);
   });
+
+  test("should return false for Dates with the same time but different instances", () => {
+    const cellData = new Date("2026-07-18T09:30:00.000Z");
+    const filterOptions = { not: new Date("2026-07-18T09:30:00.000Z") };
+    expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(false);
+  });
+
+  test("should return true for Dates with different times", () => {
+    const cellData = new Date("2026-07-18T09:30:00.000Z");
+    const filterOptions = { not: new Date("2026-07-18T10:00:00.000Z") };
+    expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(true);
+  });
 });

--- a/src/__test__/util/filterConditions/filterConditionsNotIn.test.ts
+++ b/src/__test__/util/filterConditions/filterConditionsNotIn.test.ts
@@ -30,4 +30,16 @@ describe("filterConditionsNotIn", () => {
     const filterOptions = { notIn: [true] };
     expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(true);
   });
+
+  test("should return false when a Date with the same time is listed", () => {
+    const cellData = new Date("2026-07-18T09:30:00.000Z");
+    const filterOptions = { notIn: [new Date("2026-07-18T09:30:00.000Z")] };
+    expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(false);
+  });
+
+  test("should return true when no listed Date has the same time", () => {
+    const cellData = new Date("2026-07-18T09:30:00.000Z");
+    const filterOptions = { notIn: [new Date("2026-07-19T00:00:00.000Z")] };
+    expect(isFilterConditionsMatch(cellData, filterOptions)).toBe(true);
+  });
 });

--- a/src/__test__/util/filterConditions/matchFilterCondition.test.ts
+++ b/src/__test__/util/filterConditions/matchFilterCondition.test.ts
@@ -148,6 +148,40 @@ describe("matchFilterCondition", () => {
     });
   });
 
+  describe("equals with FieldRef on Date columns", () => {
+    const dateTitles = ["createdAt", "updatedAt"];
+
+    test("should match when both columns hold the same time", () => {
+      const row = [
+        new Date("2026-07-18T09:30:00.000Z"),
+        new Date("2026-07-18T09:30:00.000Z"),
+      ];
+      expect(
+        matchFilterCondition(
+          row[0],
+          fc({ equals: new FieldRef("User", "updatedAt") }),
+          row,
+          dateTitles,
+        ),
+      ).toBe(true);
+    });
+
+    test("should not match when the times differ", () => {
+      const row = [
+        new Date("2026-07-18T09:30:00.000Z"),
+        new Date("2026-07-18T10:00:00.000Z"),
+      ];
+      expect(
+        matchFilterCondition(
+          row[0],
+          fc({ equals: new FieldRef("User", "updatedAt") }),
+          row,
+          dateTitles,
+        ),
+      ).toBe(false);
+    });
+  });
+
   describe("backward compatibility (no FieldRef)", () => {
     test("should delegate to isFilterConditionsMatch for plain values", () => {
       expect(matchFilterCondition("test", { equals: "test" }, [], [])).toBe(

--- a/src/__test__/util/find/findUtil/applyCursor.test.ts
+++ b/src/__test__/util/find/findUtil/applyCursor.test.ts
@@ -65,4 +65,30 @@ describe("applyCursor", () => {
     const result = applyCursor(data, { id: 3, name: "Alice" }, 2);
     expect(result).toEqual([]);
   });
+
+  test("should match a Date cursor with the same time but different instance", () => {
+    const dateData = [
+      { id: 1, createdAt: new Date("2026-07-18T09:30:00.000Z") },
+      { id: 2, createdAt: new Date("2026-07-19T12:00:00.000Z") },
+      { id: 3, createdAt: new Date("2026-07-20T15:45:00.000Z") },
+    ];
+    const result = applyCursor(
+      dateData,
+      { createdAt: new Date("2026-07-19T12:00:00.000Z") },
+      null,
+    );
+    expect(result).toEqual([dateData[1], dateData[2]]);
+  });
+
+  test("should return empty array when no Date time matches", () => {
+    const dateData = [
+      { id: 1, createdAt: new Date("2026-07-18T09:30:00.000Z") },
+    ];
+    const result = applyCursor(
+      dateData,
+      { createdAt: new Date("2026-07-18T09:30:00.001Z") },
+      null,
+    );
+    expect(result).toEqual([]);
+  });
 });

--- a/src/__test__/util/find/whereDate.test.ts
+++ b/src/__test__/util/find/whereDate.test.ts
@@ -1,0 +1,142 @@
+import type { GassmaControllerUtil } from "../../../types/gassmaControllerUtilType";
+import { findManyFunc } from "../../../util/find/findMany";
+
+const aliceDate = "2026-07-18T09:30:00.000Z";
+const bobDate = "2026-07-19T12:00:00.000Z";
+const charlieDate = "2026-07-20T15:45:00.000Z";
+
+const getDateMockControllerUtil = (): GassmaControllerUtil => ({
+  sheet: {
+    getDataRange: () =>
+      ({
+        getValues: () => [
+          ["名前", "作成日"],
+          ["Alice", new Date(aliceDate)],
+          ["Bob", new Date(bobDate)],
+          ["Charlie", new Date(charlieDate)],
+        ],
+      }) as any,
+    getLastRow: () => 4,
+    getLastColumn: () => 2,
+    getRange: (
+      row: number,
+      _col: number,
+      numRows: number,
+      _numCols: number,
+    ) => {
+      if (row === 1 && numRows === 1) {
+        return {
+          getValues: () => [["名前", "作成日"]],
+        } as any;
+      }
+      return {
+        getValues: () => [
+          ["Alice", new Date(aliceDate)],
+          ["Bob", new Date(bobDate)],
+          ["Charlie", new Date(charlieDate)],
+        ],
+      } as any;
+    },
+  } as any,
+  startRowNumber: 1,
+  startColumnNumber: 1,
+  endColumnNumber: 2,
+});
+
+describe("findManyFunc with Date where", () => {
+  test("should match direct value with same time but different instance", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { 作成日: new Date(aliceDate) },
+    });
+
+    expect(result).toEqual([{ 名前: "Alice", 作成日: new Date(aliceDate) }]);
+  });
+
+  test("should not match direct value with different time", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { 作成日: new Date("2026-07-18T09:30:00.001Z") },
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("should not match ISO string direct value against Date cells", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { 作成日: aliceDate },
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("should match equals with same time but different instance", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { 作成日: { equals: new Date(aliceDate) } },
+    });
+
+    expect(result).toEqual([{ 名前: "Alice", 作成日: new Date(aliceDate) }]);
+  });
+
+  test("should exclude same time with not", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { 作成日: { not: new Date(aliceDate) } },
+    });
+
+    expect(result).toEqual([
+      { 名前: "Bob", 作成日: new Date(bobDate) },
+      { 名前: "Charlie", 作成日: new Date(charlieDate) },
+    ]);
+  });
+
+  test("should match in with same times but different instances", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { 作成日: { in: [new Date(aliceDate), new Date(bobDate)] } },
+    });
+
+    expect(result).toEqual([
+      { 名前: "Alice", 作成日: new Date(aliceDate) },
+      { 名前: "Bob", 作成日: new Date(bobDate) },
+    ]);
+  });
+
+  test("should exclude same times with notIn", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { 作成日: { notIn: [new Date(aliceDate), new Date(bobDate)] } },
+    });
+
+    expect(result).toEqual([
+      { 名前: "Charlie", 作成日: new Date(charlieDate) },
+    ]);
+  });
+
+  test("should match direct value inside AND", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { AND: [{ 作成日: new Date(aliceDate) }] },
+    });
+
+    expect(result).toEqual([{ 名前: "Alice", 作成日: new Date(aliceDate) }]);
+  });
+
+  test("should match direct values inside OR", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: {
+        OR: [{ 作成日: new Date(aliceDate) }, { 作成日: new Date(bobDate) }],
+      },
+    });
+
+    expect(result).toEqual([
+      { 名前: "Alice", 作成日: new Date(aliceDate) },
+      { 名前: "Bob", 作成日: new Date(bobDate) },
+    ]);
+  });
+
+  test("should exclude direct value inside NOT", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { NOT: [{ 作成日: new Date(aliceDate) }] },
+    });
+
+    expect(result).toEqual([
+      { 名前: "Bob", 作成日: new Date(bobDate) },
+      { 名前: "Charlie", 作成日: new Date(charlieDate) },
+    ]);
+  });
+});

--- a/src/__test__/util/other/isValueEqual.test.ts
+++ b/src/__test__/util/other/isValueEqual.test.ts
@@ -1,0 +1,76 @@
+import { containsValue, isValueEqual } from "../../../util/other/isValueEqual";
+
+describe("isValueEqual", () => {
+  test("should return true for Dates with the same time but different instances", () => {
+    expect(
+      isValueEqual(
+        new Date("2026-07-18T09:30:00.000Z"),
+        new Date("2026-07-18T09:30:00.000Z"),
+      ),
+    ).toBe(true);
+  });
+
+  test("should return false for Dates with different times", () => {
+    expect(
+      isValueEqual(
+        new Date("2026-07-18T09:30:00.000Z"),
+        new Date("2026-07-18T09:30:00.001Z"),
+      ),
+    ).toBe(false);
+  });
+
+  test("should return false for Date vs ISO string in both directions", () => {
+    const date = new Date("2026-07-18T09:30:00.000Z");
+    expect(isValueEqual(date, "2026-07-18T09:30:00.000Z")).toBe(false);
+    expect(isValueEqual("2026-07-18T09:30:00.000Z", date)).toBe(false);
+  });
+
+  test("should return false for Date vs null", () => {
+    expect(isValueEqual(new Date("2026-07-18T09:30:00.000Z"), null)).toBe(
+      false,
+    );
+    expect(isValueEqual(null, new Date("2026-07-18T09:30:00.000Z"))).toBe(
+      false,
+    );
+  });
+
+  test("should keep strict equality for non-Date values", () => {
+    expect(isValueEqual("test", "test")).toBe(true);
+    expect(isValueEqual(42, 42)).toBe(true);
+    expect(isValueEqual(true, true)).toBe(true);
+    expect(isValueEqual(null, null)).toBe(true);
+    expect(isValueEqual(42, "42")).toBe(false);
+    expect(isValueEqual(Number.NaN, Number.NaN)).toBe(false);
+  });
+});
+
+describe("containsValue", () => {
+  test("should find a Date with the same time but different instance", () => {
+    const list = [new Date("2026-07-18T09:30:00.000Z")];
+    expect(containsValue(list, new Date("2026-07-18T09:30:00.000Z"))).toBe(
+      true,
+    );
+  });
+
+  test("should not find a Date when no time matches", () => {
+    const list = [new Date("2026-07-18T09:30:00.000Z")];
+    expect(containsValue(list, new Date("2026-07-18T10:00:00.000Z"))).toBe(
+      false,
+    );
+  });
+
+  test("should not match a Date against ISO strings", () => {
+    expect(
+      containsValue(
+        ["2026-07-18T09:30:00.000Z"],
+        new Date("2026-07-18T09:30:00.000Z"),
+      ),
+    ).toBe(false);
+  });
+
+  test("should keep SameValueZero for non-Date values", () => {
+    expect(containsValue(["a", "b"], "a")).toBe(true);
+    expect(containsValue([1, 2], 3)).toBe(false);
+    expect(containsValue([Number.NaN], Number.NaN)).toBe(true);
+  });
+});

--- a/src/util/andOrNot/and.ts
+++ b/src/util/andOrNot/and.ts
@@ -8,6 +8,7 @@ import type { HitRowData } from "../../types/hitRowDataType";
 import { getWantFindIndex } from "../core/getWantFindIndex";
 import { matchFilterCondition } from "../filterConditions/matchFilterCondition";
 import { isDict } from "../other/isDict";
+import { isValueEqual } from "../other/isValueEqual";
 import { isLogicMatch } from "./entry";
 
 const isAndMatch = (
@@ -34,7 +35,7 @@ const isAndMatch = (
             titles,
           );
 
-        return row.row[i] === whereOptionContent;
+        return isValueEqual(row.row[i], whereOptionContent);
       });
 
       if (matchRow.length === wantFindIndex.length) return row;

--- a/src/util/andOrNot/not.ts
+++ b/src/util/andOrNot/not.ts
@@ -8,6 +8,7 @@ import type { HitRowData } from "../../types/hitRowDataType";
 import { getWantFindIndex } from "../core/getWantFindIndex";
 import { matchFilterCondition } from "../filterConditions/matchFilterCondition";
 import { isDict } from "../other/isDict";
+import { isValueEqual } from "../other/isValueEqual";
 import { isLogicMatch } from "./entry";
 
 const isNotMatch = (
@@ -34,7 +35,7 @@ const isNotMatch = (
             titles,
           );
 
-        return row.row[i] === whereOptionContent;
+        return isValueEqual(row.row[i], whereOptionContent);
       });
 
       if (matchRow.length === wantFindIndex.length) return row;

--- a/src/util/andOrNot/or.ts
+++ b/src/util/andOrNot/or.ts
@@ -8,6 +8,7 @@ import type { HitRowData } from "../../types/hitRowDataType";
 import { getWantFindIndex } from "../core/getWantFindIndex";
 import { matchFilterCondition } from "../filterConditions/matchFilterCondition";
 import { isDict } from "../other/isDict";
+import { isValueEqual } from "../other/isValueEqual";
 import { isLogicMatch } from "./entry";
 
 const isOrMatch = (
@@ -34,7 +35,7 @@ const isOrMatch = (
             titles,
           );
 
-        return row.row[i] === whereOptionContent;
+        return isValueEqual(row.row[i], whereOptionContent);
       });
 
       if (matchRow.length === wantFindIndex.length) return row;

--- a/src/util/core/whereFilter.ts
+++ b/src/util/core/whereFilter.ts
@@ -5,6 +5,7 @@ import type { HitRowData } from "../../types/hitRowDataType";
 import { isLogicMatch } from "../andOrNot/entry";
 import { matchFilterCondition } from "../filterConditions/matchFilterCondition";
 import { isDict } from "../other/isDict";
+import { isValueEqual } from "../other/isValueEqual";
 import { getAllData } from "./getAllData";
 import { getTitle } from "./getTitle";
 import { getWantFindIndex } from "./getWantFindIndex";
@@ -44,7 +45,7 @@ const whereFilter = (
 
       const replacedNullWhereOptionContent =
         whereOptionContent === "" ? null : whereOptionContent;
-      return row[i] === replacedNullWhereOptionContent;
+      return isValueEqual(row[i], replacedNullWhereOptionContent);
     });
 
     if (matchRow.length === wantFindIndex.length) {

--- a/src/util/filterConditions/filterConditions.ts
+++ b/src/util/filterConditions/filterConditions.ts
@@ -1,4 +1,5 @@
 import type { FilterConditions, GassmaAny } from "../../types/coreTypes";
+import { containsValue, isValueEqual } from "../other/isValueEqual";
 
 const isFilterConditionsMatch = (
   cellData: GassmaAny,
@@ -16,7 +17,7 @@ const isFilterConditionsMatch = (
         ) {
           return filterEquals.toLowerCase() === cellData.toLowerCase();
         }
-        return filterEquals === cellData;
+        return isValueEqual(filterEquals, cellData);
       }
       case "not": {
         const filterNot = filterOptions.not === "" ? null : filterOptions.not;
@@ -27,14 +28,14 @@ const isFilterConditionsMatch = (
         ) {
           return filterNot.toLowerCase() !== cellData.toLowerCase();
         }
-        return filterNot !== cellData;
+        return !isValueEqual(filterNot, cellData);
       }
       case "in":
         if (cellData === null) return false;
-        return filterOptions.in.includes(cellData);
+        return containsValue(filterOptions.in, cellData);
       case "notIn":
         if (cellData === null) return false;
-        return !filterOptions.notIn.includes(cellData);
+        return !containsValue(filterOptions.notIn, cellData);
       case "lt":
         if (cellData === null) return false;
         return cellData < filterOptions.lt;

--- a/src/util/find/findUtil/applyCursor.ts
+++ b/src/util/find/findUtil/applyCursor.ts
@@ -1,3 +1,5 @@
+import { isValueEqual } from "../../other/isValueEqual";
+
 const applyCursor = (
   records: Record<string, unknown>[],
   cursor: Record<string, unknown>,
@@ -5,7 +7,7 @@ const applyCursor = (
 ): Record<string, unknown>[] => {
   const cursorEntries = Object.entries(cursor);
   const index = records.findIndex((record) =>
-    cursorEntries.every(([key, value]) => record[key] === value),
+    cursorEntries.every(([key, value]) => isValueEqual(record[key], value)),
   );
   if (index === -1) return [];
 

--- a/src/util/other/isValueEqual.ts
+++ b/src/util/other/isValueEqual.ts
@@ -1,0 +1,11 @@
+const isValueEqual = (a: unknown, b: unknown): boolean => {
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  return a === b;
+};
+
+const containsValue = (list: readonly unknown[], value: unknown): boolean =>
+  list.includes(value) || list.some((item) => isValueEqual(item, value));
+
+export { containsValue, isValueEqual };


### PR DESCRIPTION
## 概要

Date の等価系フィルタが**参照比較**(`===` / `Array.includes`)だったため、`equals`・直値 where・`in`/`notIn`・cursor が**同時刻のセルが実在してもマッチ不能**だったバグを、**時刻一致(getTime)比較**に修正しました(gassma-test D-1 実装時に実測確認された本体課題)。`gt`/`gte`/`lt`/`lte` は valueOf 数値化で元々正常のため不変です。

## Prisma 実測(prisma-test で裏取り)

同 instant の**別 Date インスタンス**で: `equals`/直値/`not`/`in`/`notIn` すべて時刻一致でマッチ、+1ms は不一致。→ getTime 比較が Prisma パリティ。

## 修正

`isValueEqual`(両者が Date なら getTime、それ以外は `===`)と `containsValue`(従来の SameValueZero を完全維持 + Date 時刻一致を追加)を新設し、**等価判定の全経路**に適用:

| 経路 | 場所 |
|---|---|
| equals / not / in / notIn | `filterConditions.ts` |
| where 直値 | `whereFilter.ts` |
| AND / OR / NOT の直値 | `andOrNot/*.ts` |
| cursor の行マッチ | `applyCursor.ts` |

- FieldRef(fields)・リレーション where 解決(some/every/none/is/isNot)・having・全 whereFilter 系メソッドは**共有層経由で自動的に修正が波及**。
- 片方だけ Date(ISO 文字列 vs Date)は**従来通り不一致**(暗黙変換なし。Prisma は文字列も変換受理するが別議論)。

## テスト(TDD: Red → Green)

- 新規: `isValueEqual` 単体9件、findMany 統合10件(直値/equals/not/in/notIn/AND/OR/NOT/異時刻/ISO 文字列不一致)。既存6ファイルに Date ケース15件追記。
- **102 suites / 1215 tests 全 green**(+32)、`tsc --noEmit` clean、biome clean。

## デプロイ後の影響(想定通りの検知)

gassma-test の `testDateFilter` は現挙動(equals→0件)を**意図的に固定した検知テスト**のため、本修正のデプロイ後に落ちます(equals/直値 0→1件、in 0→1件、notIn 300→299件)。マージ・デプロイ後に gassma-test 側を新挙動へ更新します。他の統合テストへの影響はなし(Date を where に使うのは testDateFilter のみ)。

## スコープ外所見(残存する Date の非時刻比較・別課題)

- groupBy `byClassification` のグルーピング(`by` に Date 列で同時刻が別グループ)
- `resolveOnUpdate` の変更検知(同時刻別インスタンスを変更ありと誤検知)
- リレーション resolver の Map キー突合(Date FK の lookup)
- distinct は JSON.stringify キー化のため既に正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja