### PR TITLE
fix: realm-safe Date detection (GAS library boundary breaks instanceof)

### DIFF
--- a/src/__test__/consts/crossRealm.ts
+++ b/src/__test__/consts/crossRealm.ts
@@ -1,0 +1,9 @@
+import { runInNewContext } from "node:vm";
+
+const createCrossRealmDate = (iso: string): Date =>
+  runInNewContext(`new Date(${JSON.stringify(iso)})`);
+
+const createCrossRealmValue = <T>(source: string): T =>
+  runInNewContext(`(${source})`);
+
+export { createCrossRealmDate, createCrossRealmValue };

--- a/src/__test__/util/aggregate/aggregateUtil/getType/getHitsDataType.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/getType/getHitsDataType.test.ts
@@ -1,3 +1,4 @@
+import { createCrossRealmDate } from "../../../../consts/crossRealm";
 import { getHitsDataType } from "../../../../../util/aggregate/aggregateUtil/getType/getHitsDataType";
 
 describe("getHitsDataType function tests", () => {
@@ -137,6 +138,22 @@ describe("getHitsDataType function tests", () => {
         new Date(1672531200000), // Timestamp
       ];
       const result = getHitsDataType(dates);
+      expect(result).toBe("Date");
+    });
+
+    test("should return 'Date' when a cross-realm Date comes first", () => {
+      const result = getHitsDataType([
+        createCrossRealmDate("2023-01-01T00:00:00Z"),
+        new Date("2023-06-01T00:00:00Z"),
+      ]);
+      expect(result).toBe("Date");
+    });
+
+    test("should return 'Date' when a cross-realm Date comes later", () => {
+      const result = getHitsDataType([
+        new Date("2023-06-01T00:00:00Z"),
+        createCrossRealmDate("2023-01-01T00:00:00Z"),
+      ]);
       expect(result).toBe("Date");
     });
   });

--- a/src/__test__/util/find/whereDate.test.ts
+++ b/src/__test__/util/find/whereDate.test.ts
@@ -1,4 +1,9 @@
 import type { GassmaControllerUtil } from "../../../types/gassmaControllerUtilType";
+import type { FilterConditions } from "../../../types/coreTypes";
+import {
+  createCrossRealmDate,
+  createCrossRealmValue,
+} from "../../consts/crossRealm";
 import { findManyFunc } from "../../../util/find/findMany";
 
 const aliceDate = "2026-07-18T09:30:00.000Z";
@@ -137,6 +142,85 @@ describe("findManyFunc with Date where", () => {
     expect(result).toEqual([
       { 名前: "Bob", 作成日: new Date(bobDate) },
       { 名前: "Charlie", 作成日: new Date(charlieDate) },
+    ]);
+  });
+});
+
+describe("findManyFunc with cross-realm Date where (GAS library boundary)", () => {
+  test("should match direct value created in another realm", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { 作成日: createCrossRealmDate(aliceDate) },
+    });
+
+    expect(result).toEqual([{ 名前: "Alice", 作成日: new Date(aliceDate) }]);
+  });
+
+  test("should match equals whose filter object and Date are cross-realm", () => {
+    const crossFilter = createCrossRealmValue<FilterConditions>(
+      `{ equals: new Date(${JSON.stringify(aliceDate)}) }`,
+    );
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { 作成日: crossFilter },
+    });
+
+    expect(result).toEqual([{ 名前: "Alice", 作成日: new Date(aliceDate) }]);
+  });
+
+  test("should exclude same time with cross-realm not", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { 作成日: { not: createCrossRealmDate(aliceDate) } },
+    });
+
+    expect(result).toEqual([
+      { 名前: "Bob", 作成日: new Date(bobDate) },
+      { 名前: "Charlie", 作成日: new Date(charlieDate) },
+    ]);
+  });
+
+  test("should match in with a fully cross-realm filter", () => {
+    const crossFilter = createCrossRealmValue<FilterConditions>(
+      `{ in: [new Date(${JSON.stringify(aliceDate)}), new Date(${JSON.stringify(bobDate)})] }`,
+    );
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: { 作成日: crossFilter },
+    });
+
+    expect(result).toEqual([
+      { 名前: "Alice", 作成日: new Date(aliceDate) },
+      { 名前: "Bob", 作成日: new Date(bobDate) },
+    ]);
+  });
+
+  test("should exclude same times with cross-realm notIn", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: {
+        作成日: {
+          notIn: [
+            createCrossRealmDate(aliceDate),
+            createCrossRealmDate(bobDate),
+          ],
+        },
+      },
+    });
+
+    expect(result).toEqual([
+      { 名前: "Charlie", 作成日: new Date(charlieDate) },
+    ]);
+  });
+
+  test("should match cross-realm direct value inside OR", () => {
+    const result = findManyFunc(getDateMockControllerUtil(), {
+      where: {
+        OR: [
+          { 作成日: createCrossRealmDate(aliceDate) },
+          { 作成日: createCrossRealmDate(bobDate) },
+        ],
+      },
+    });
+
+    expect(result).toEqual([
+      { 名前: "Alice", 作成日: new Date(aliceDate) },
+      { 名前: "Bob", 作成日: new Date(bobDate) },
     ]);
   });
 });

--- a/src/__test__/util/other/isDateValue.test.ts
+++ b/src/__test__/util/other/isDateValue.test.ts
@@ -1,0 +1,42 @@
+import {
+  createCrossRealmDate,
+  createCrossRealmValue,
+} from "../../consts/crossRealm";
+import { isDateValue } from "../../../util/other/isDateValue";
+
+describe("isDateValue", () => {
+  test("should return true for a same-realm Date", () => {
+    expect(isDateValue(new Date("2026-07-18T09:30:00.000Z"))).toBe(true);
+  });
+
+  test("should return true for a cross-realm Date", () => {
+    const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
+    expect(crossDate instanceof Date).toBe(false);
+    expect(isDateValue(crossDate)).toBe(true);
+  });
+
+  test("should return false for null and undefined", () => {
+    expect(isDateValue(null)).toBe(false);
+    expect(isDateValue(undefined)).toBe(false);
+  });
+
+  test("should return false for an ISO string", () => {
+    expect(isDateValue("2026-07-18T09:30:00.000Z")).toBe(false);
+  });
+
+  test("should return false for a number", () => {
+    expect(isDateValue(1784367000000)).toBe(false);
+  });
+
+  test("should return false for a plain object and an array", () => {
+    expect(isDateValue({ equals: new Date() })).toBe(false);
+    expect(isDateValue([new Date()])).toBe(false);
+  });
+
+  test("should return false for a cross-realm plain object", () => {
+    const crossObject = createCrossRealmValue<Record<string, unknown>>(
+      '{ equals: new Date("2026-07-18T09:30:00.000Z") }',
+    );
+    expect(isDateValue(crossObject)).toBe(false);
+  });
+});

--- a/src/__test__/util/other/isDict.test.ts
+++ b/src/__test__/util/other/isDict.test.ts
@@ -1,3 +1,7 @@
+import {
+  createCrossRealmDate,
+  createCrossRealmValue,
+} from "../../consts/crossRealm";
 import { isDict } from "../../../util/other/isDict";
 
 describe("isDict", () => {
@@ -161,5 +165,23 @@ describe("isDict", () => {
 
   test("should return false for -Infinity", () => {
     expect(isDict(-Infinity)).toBe(false);
+  });
+
+  test("should return false for a cross-realm Date", () => {
+    const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
+    expect(crossDate instanceof Date).toBe(false);
+    expect(isDict(crossDate)).toBe(false);
+  });
+
+  test("should return true for a cross-realm plain object", () => {
+    const crossObject = createCrossRealmValue<Record<string, unknown>>(
+      '{ gt: new Date("2026-07-18T09:30:00.000Z") }',
+    );
+    expect(isDict(crossObject)).toBe(true);
+  });
+
+  test("should return false for a cross-realm array", () => {
+    const crossArray = createCrossRealmValue<unknown[]>("[1, 2, 3]");
+    expect(isDict(crossArray)).toBe(false);
   });
 });

--- a/src/__test__/util/other/isValueEqual.test.ts
+++ b/src/__test__/util/other/isValueEqual.test.ts
@@ -1,3 +1,7 @@
+import {
+  createCrossRealmDate,
+  createCrossRealmValue,
+} from "../../consts/crossRealm";
 import { containsValue, isValueEqual } from "../../../util/other/isValueEqual";
 
 describe("isValueEqual", () => {
@@ -44,6 +48,40 @@ describe("isValueEqual", () => {
   });
 });
 
+describe("isValueEqual with cross-realm Dates", () => {
+  test("should return true for same time across realms in both directions", () => {
+    const localDate = new Date("2026-07-18T09:30:00.000Z");
+    const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
+    expect(crossDate instanceof Date).toBe(false);
+    expect(isValueEqual(localDate, crossDate)).toBe(true);
+    expect(isValueEqual(crossDate, localDate)).toBe(true);
+  });
+
+  test("should return true for two cross-realm Dates with the same time", () => {
+    expect(
+      isValueEqual(
+        createCrossRealmDate("2026-07-18T09:30:00.000Z"),
+        createCrossRealmDate("2026-07-18T09:30:00.000Z"),
+      ),
+    ).toBe(true);
+  });
+
+  test("should return false for different times across realms", () => {
+    expect(
+      isValueEqual(
+        new Date("2026-07-18T09:30:00.000Z"),
+        createCrossRealmDate("2026-07-18T09:30:00.001Z"),
+      ),
+    ).toBe(false);
+  });
+
+  test("should return false for a cross-realm Date vs an ISO string", () => {
+    const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
+    expect(isValueEqual(crossDate, "2026-07-18T09:30:00.000Z")).toBe(false);
+    expect(isValueEqual("2026-07-18T09:30:00.000Z", crossDate)).toBe(false);
+  });
+});
+
 describe("containsValue", () => {
   test("should find a Date with the same time but different instance", () => {
     const list = [new Date("2026-07-18T09:30:00.000Z")];
@@ -72,5 +110,30 @@ describe("containsValue", () => {
     expect(containsValue(["a", "b"], "a")).toBe(true);
     expect(containsValue([1, 2], 3)).toBe(false);
     expect(containsValue([Number.NaN], Number.NaN)).toBe(true);
+  });
+});
+
+describe("containsValue with cross-realm Dates", () => {
+  test("should find a cross-realm Date in a same-realm list", () => {
+    const list = [new Date("2026-07-18T09:30:00.000Z")];
+    expect(
+      containsValue(list, createCrossRealmDate("2026-07-18T09:30:00.000Z")),
+    ).toBe(true);
+  });
+
+  test("should find a same-realm Date in a cross-realm list", () => {
+    const crossList = createCrossRealmValue<readonly unknown[]>(
+      '[new Date("2026-07-18T09:30:00.000Z")]',
+    );
+    expect(containsValue(crossList, new Date("2026-07-18T09:30:00.000Z"))).toBe(
+      true,
+    );
+  });
+
+  test("should not find a cross-realm Date when no time matches", () => {
+    const list = [new Date("2026-07-18T09:30:00.000Z")];
+    expect(
+      containsValue(list, createCrossRealmDate("2026-07-18T10:00:00.000Z")),
+    ).toBe(false);
   });
 });

--- a/src/__test__/util/relation/collectKeys.test.ts
+++ b/src/__test__/util/relation/collectKeys.test.ts
@@ -1,3 +1,7 @@
+import {
+  createCrossRealmDate,
+  createCrossRealmValue,
+} from "../../consts/crossRealm";
 import { collectKeys, isGassmaAny } from "../../../util/relation/collectKeys";
 
 describe("collectKeys", () => {
@@ -59,5 +63,25 @@ describe("isGassmaAny", () => {
 
   it("配列を false と判定する", () => {
     expect(isGassmaAny([1, 2, 3])).toBe(false);
+  });
+});
+
+describe("クロス realm の値", () => {
+  it("別 realm の Date を true と判定する", () => {
+    const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
+    expect(crossDate instanceof Date).toBe(false);
+    expect(isGassmaAny(crossDate)).toBe(true);
+  });
+
+  it("別 realm のオブジェクトを false と判定する", () => {
+    const crossObject =
+      createCrossRealmValue<Record<string, unknown>>('{ key: "value" }');
+    expect(isGassmaAny(crossObject)).toBe(false);
+  });
+
+  it("別 realm の Date も収集できる", () => {
+    const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
+    const records = [{ key: 1 }, { key: crossDate }, { key: null }];
+    expect(collectKeys(records, "key")).toEqual([1, crossDate]);
   });
 });

--- a/src/util/aggregate/aggregateUtil/getType/getHitsDataType.ts
+++ b/src/util/aggregate/aggregateUtil/getType/getHitsDataType.ts
@@ -1,4 +1,5 @@
 import type { GassmaAny } from "../../../../types/coreTypes";
+import { isDateValue } from "../../../other/isDateValue";
 
 type HitDateType =
   | "string"
@@ -14,11 +15,11 @@ type HitDateType =
 
 const getHitsDataType = (hitsData: GassmaAny[]): HitDateType | false => {
   let hitDataType: HitDateType = typeof hitsData[0];
-  if (hitsData[0] instanceof Date) hitDataType = "Date";
+  if (isDateValue(hitsData[0])) hitDataType = "Date";
 
   const isAllDataTypeSame = hitsData.every((data) => {
     if (hitDataType === "Date") {
-      return data instanceof Date;
+      return isDateValue(data);
     }
     return typeof data === hitDataType;
   });

--- a/src/util/other/isDateValue.ts
+++ b/src/util/other/isDateValue.ts
@@ -1,0 +1,8 @@
+const isDateValue = (value: unknown): value is Date => {
+  return (
+    value instanceof Date ||
+    Object.prototype.toString.call(value) === "[object Date]"
+  );
+};
+
+export { isDateValue };

--- a/src/util/other/isValueEqual.ts
+++ b/src/util/other/isValueEqual.ts
@@ -1,5 +1,7 @@
+import { isDateValue } from "./isDateValue";
+
 const isValueEqual = (a: unknown, b: unknown): boolean => {
-  if (a instanceof Date && b instanceof Date) {
+  if (isDateValue(a) && isDateValue(b)) {
     return a.getTime() === b.getTime();
   }
   return a === b;

--- a/src/util/relation/collectKeys.ts
+++ b/src/util/relation/collectKeys.ts
@@ -1,10 +1,11 @@
 import type { GassmaAny } from "../../types/coreTypes";
+import { isDateValue } from "../other/isDateValue";
 
 const isGassmaAny = (value: unknown): value is GassmaAny => {
   if (value === null || value === undefined) return false;
   const t = typeof value;
   return (
-    t === "string" || t === "number" || t === "boolean" || value instanceof Date
+    t === "string" || t === "number" || t === "boolean" || isDateValue(value)
   );
 };
 


### PR DESCRIPTION
## 概要

GAS 実機で D-1 統合テストの precondition が検知した **クロス realm 問題**の修正です。Gassma を GAS **ライブラリ**として使うと別スクリプトコンテキスト(別 realm)で実行されるため、利用者スクリプトの Date はライブラリ内の `instanceof Date` に落ち、逆も然り(`got object` エラーの正体)。

これにより **#139 が実機では無効化**されていました(フィルタの Date が `instanceof` に落ち参照比較へフォールバック)。モック検証は単一 realm のため検出できず、**実機でしか出ない挙動を統合テストが設計通り捕捉**した形です。

## 修正

realm 安全な `isDateValue`(`instanceof Date || Object.prototype.toString.call(v) === "[object Date]"`)を新設し、境界を跨ぐ Date 判定に適用:

| 箇所 | 影響 |
|---|---|
| `isValueEqual` | equals/直値/in/notIn/not/cursor の Date 一致(#139 の実機有効化) |
| `collectKeys`(isGassmaAny) | 利用者 Date FK の nested write 伝播 |
| `getHitsDataType` | ライブラリ内完結だが統一 |

**境界を跨ぐ型判定の全数調査**を実施(PR コミット参照)。`isDict` は `constructor.name` フォールバックで既に realm 安全(クロス realm Date がフィルタオブジェクトに誤分類されないことを vm 実証・ガードテストで固定)。typeof / `Array.isArray` / `in` / 関係演算子 / JSON.stringify 系はすべて realm 安全と確認。

## テスト(TDD: Red 14件を実測 → Green)

- **Node の `vm` で別 realm の Date/オブジェクトを実生成**するヘルパーを追加(`crossDate instanceof Date === false` をテスト内で明示確認)— 今後クロス realm 退行は単体テストで検知可能。
- クロス realm の equals/直値/in/notIn/not、**where オブジェクトごと別 realm** の findMany、isGassmaAny、集計型判定など28件追加。
- **103 suites / 1243 tests 全 green**(+28)、`tsc --noEmit` clean、biome clean。

## 残存(所見・別途)

- 利用者コード側で戻り値に `instanceof Date` を書くと同様に落ちる(gassma-test の precondition は realm 安全化済み・別 push)。reference への注意書き追加を推奨。
- `Symbol.toStringTag` 偽装は検知不能(lodash 等と同等の割り切り)。

## マージ後

本体デプロイ(`npm run push`)→ gassma-test の realm 安全化済み precondition で GAS 再実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja