### PR TITLE
fix: non-FK-side oneToOne nested write follows child semantics (Prisma parity)

### DIFF
--- a/src/__test__/util/create/nestedWrite/processBeforeCreate.test.ts
+++ b/src/__test__/util/create/nestedWrite/processBeforeCreate.test.ts
@@ -43,6 +43,14 @@ describe("processBeforeCreate", () => {
     reference: "authorId",
   };
 
+  const nonFkOneToOneRelation: RelationDefinition = {
+    type: "oneToOne",
+    to: "Profiles",
+    field: "id",
+    reference: "userId",
+    ownsFk: false,
+  };
+
   it("manyToOne + connect で既存レコードのFK値が親データに設定される", () => {
     mockFindMany.mockReturnValue([{ id: 1, name: "田中" }]);
     const relationOps = new Map<string, NestedWriteOperation>();
@@ -147,5 +155,68 @@ describe("processBeforeCreate", () => {
     expect(result).toEqual({ id: 1, name: "田中" });
     expect(mockFindMany).not.toHaveBeenCalled();
     expect(mockCreateOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("oneToOne(ownsFk: false) + connect は素通りし親データ・関連先に触れない", () => {
+    mockFindMany.mockReturnValue([{ id: 5, userId: 99 }]);
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("profile", { connect: { id: 5 } });
+
+    const result = processBeforeCreate(
+      { id: 1, name: "田中" },
+      relationOps,
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中" });
+    expect(mockFindMany).not.toHaveBeenCalled();
+    expect(mockCreateOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("oneToOne(ownsFk: false) + create は素通りする", () => {
+    mockCreateOnSheet.mockReturnValue({ id: 5, userId: 99 });
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("profile", { create: { bio: "自己紹介" } });
+
+    const result = processBeforeCreate(
+      { id: 1, name: "田中" },
+      relationOps,
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中" });
+    expect(mockCreateOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("oneToOne(ownsFk: false) + connectOrCreate は素通りする", () => {
+    mockFindMany.mockReturnValue([{ id: 5, userId: 99 }]);
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("profile", {
+      connectOrCreate: { where: { id: 5 }, create: { bio: "自己紹介" } },
+    });
+
+    const result = processBeforeCreate(
+      { id: 1, name: "田中" },
+      relationOps,
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中" });
+    expect(mockFindMany).not.toHaveBeenCalled();
+    expect(mockCreateOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("oneToOne(ownsFk: true) は従来どおり before で処理される", () => {
+    mockFindMany.mockReturnValue([{ id: 5, bio: "自己紹介" }]);
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("profile", { connect: { id: 5 } });
+
+    const result = processBeforeCreate(
+      { name: "田中" },
+      relationOps,
+      makeContext({ profile: { ...oneToOneRelation, ownsFk: true } }),
+    );
+
+    expect(result).toEqual({ name: "田中", profileId: 5 });
   });
 });

--- a/src/__test__/util/create/nestedWrite/processOneToOneNonFk.test.ts
+++ b/src/__test__/util/create/nestedWrite/processOneToOneNonFk.test.ts
@@ -1,0 +1,235 @@
+import { processOneToOneNonFk } from "../../../../util/create/nestedWrite/processOneToOneNonFk";
+import type {
+  RelationDefinition,
+  RelationContext,
+} from "../../../../types/relationTypes";
+import type { NestedWriteOperation } from "../../../../types/nestedWriteTypes";
+
+describe("processOneToOneNonFk", () => {
+  const mockFindMany = jest.fn();
+  const mockCreateOnSheet = jest.fn();
+  const mockUpdateManyOnSheet = jest.fn();
+
+  const makeContext = (
+    relations: Record<string, RelationDefinition>,
+  ): RelationContext => ({
+    relations,
+    findManyOnSheet: mockFindMany,
+    createOnSheet: mockCreateOnSheet,
+    updateManyOnSheet: mockUpdateManyOnSheet,
+  });
+
+  beforeEach(() => {
+    mockFindMany.mockReset();
+    mockCreateOnSheet.mockReset();
+    mockUpdateManyOnSheet.mockReset();
+  });
+
+  const nonFkRelation: RelationDefinition = {
+    type: "oneToOne",
+    to: "Profiles",
+    field: "id",
+    reference: "userId",
+    ownsFk: false,
+  };
+
+  const makeOps = (op: NestedWriteOperation) => {
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("profile", op);
+    return relationOps;
+  };
+
+  it("create で子が親の field 値付きで作成される", () => {
+    mockCreateOnSheet.mockReturnValue({ id: 10, bio: "自己紹介", userId: 1 });
+
+    processOneToOneNonFk(
+      { id: 1, name: "田中" },
+      makeOps({ create: { bio: "自己紹介" } }),
+      makeContext({ profile: nonFkRelation }),
+    );
+
+    expect(mockCreateOnSheet).toHaveBeenCalledWith("Profiles", {
+      data: { bio: "自己紹介", userId: 1 },
+    });
+  });
+
+  it("connect で既接続行の解除後に対象行へ親値が設定される", () => {
+    mockFindMany.mockReturnValue([{ id: 5, userId: null }]);
+    mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
+
+    processOneToOneNonFk(
+      { id: 1, name: "田中" },
+      makeOps({ connect: { id: 5 } }),
+      makeContext({ profile: nonFkRelation }),
+    );
+
+    expect(mockUpdateManyOnSheet).toHaveBeenNthCalledWith(1, "Profiles", {
+      where: { userId: 1 },
+      data: { userId: null },
+    });
+    expect(mockUpdateManyOnSheet).toHaveBeenNthCalledWith(2, "Profiles", {
+      where: { id: 5 },
+      data: { userId: 1 },
+    });
+  });
+
+  it("connect 対象不在で NestedWriteConnectNotFoundError", () => {
+    mockFindMany.mockReturnValue([]);
+
+    expect(() =>
+      processOneToOneNonFk(
+        { id: 1, name: "田中" },
+        makeOps({ connect: { id: 999 } }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('no record found in "Profiles"');
+    expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("connectOrCreate で対象ありなら connect 相当（置き換え含む）", () => {
+    mockFindMany.mockReturnValue([{ id: 5, userId: 99 }]);
+    mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
+
+    processOneToOneNonFk(
+      { id: 1, name: "田中" },
+      makeOps({
+        connectOrCreate: { where: { id: 5 }, create: { bio: "自己紹介" } },
+      }),
+      makeContext({ profile: nonFkRelation }),
+    );
+
+    expect(mockCreateOnSheet).not.toHaveBeenCalled();
+    expect(mockUpdateManyOnSheet).toHaveBeenNthCalledWith(1, "Profiles", {
+      where: { userId: 1 },
+      data: { userId: null },
+    });
+    expect(mockUpdateManyOnSheet).toHaveBeenNthCalledWith(2, "Profiles", {
+      where: { id: 5 },
+      data: { userId: 1 },
+    });
+  });
+
+  it("connectOrCreate で対象なしなら create 相当", () => {
+    mockFindMany.mockReturnValue([]);
+    mockCreateOnSheet.mockReturnValue({ id: 10, bio: "自己紹介", userId: 1 });
+
+    processOneToOneNonFk(
+      { id: 1, name: "田中" },
+      makeOps({
+        connectOrCreate: { where: { id: 5 }, create: { bio: "自己紹介" } },
+      }),
+      makeContext({ profile: nonFkRelation }),
+    );
+
+    expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
+    expect(mockCreateOnSheet).toHaveBeenCalledWith("Profiles", {
+      data: { bio: "自己紹介", userId: 1 },
+    });
+  });
+
+  it("createMany は NestedWriteInvalidOperationError", () => {
+    expect(() =>
+      processOneToOneNonFk(
+        { id: 1, name: "田中" },
+        makeOps({ createMany: { data: [{ bio: "自己紹介" }] } }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('operation "createMany" is not valid');
+  });
+
+  it("配列 create は NestedWriteInvalidOperationError", () => {
+    expect(() =>
+      processOneToOneNonFk(
+        { id: 1, name: "田中" },
+        makeOps({ create: [{ bio: "自己紹介" }] }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('operation "create" is not valid');
+  });
+
+  it("配列 connect は NestedWriteInvalidOperationError", () => {
+    expect(() =>
+      processOneToOneNonFk(
+        { id: 1, name: "田中" },
+        makeOps({ connect: [{ id: 5 }] }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('operation "connect" is not valid');
+  });
+
+  it("配列 connectOrCreate は NestedWriteInvalidOperationError", () => {
+    expect(() =>
+      processOneToOneNonFk(
+        { id: 1, name: "田中" },
+        makeOps({
+          connectOrCreate: [{ where: { id: 5 }, create: { bio: "a" } }],
+        }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('operation "connectOrCreate" is not valid');
+  });
+
+  it("親の field 値が欠落している場合はスキップ", () => {
+    processOneToOneNonFk(
+      { name: "田中" },
+      makeOps({ create: { bio: "自己紹介" } }),
+      makeContext({ profile: nonFkRelation }),
+    );
+
+    expect(mockCreateOnSheet).not.toHaveBeenCalled();
+    expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("ownsFk 未指定の oneToOne は無視される", () => {
+    processOneToOneNonFk(
+      { id: 1, name: "田中" },
+      makeOps({ create: { bio: "自己紹介" } }),
+      makeContext({
+        profile: {
+          type: "oneToOne",
+          to: "Profiles",
+          field: "profileId",
+          reference: "id",
+        },
+      }),
+    );
+
+    expect(mockCreateOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("ownsFk: true の oneToOne は無視される", () => {
+    processOneToOneNonFk(
+      { id: 1, name: "田中" },
+      makeOps({ create: { bio: "自己紹介" } }),
+      makeContext({
+        profile: {
+          type: "oneToOne",
+          to: "Profiles",
+          field: "profileId",
+          reference: "id",
+          ownsFk: true,
+        },
+      }),
+    );
+
+    expect(mockCreateOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("oneToMany は無視される", () => {
+    processOneToOneNonFk(
+      { id: 1, name: "田中" },
+      makeOps({ create: { title: "記事A" } }),
+      makeContext({
+        profile: {
+          type: "oneToMany",
+          to: "Posts",
+          field: "id",
+          reference: "authorId",
+          ownsFk: false,
+        },
+      }),
+    );
+
+    expect(mockCreateOnSheet).not.toHaveBeenCalled();
+  });
+});

--- a/src/__test__/util/create/nestedWrite/resolveNestedCreate.test.ts
+++ b/src/__test__/util/create/nestedWrite/resolveNestedCreate.test.ts
@@ -188,4 +188,52 @@ describe("resolveNestedCreate", () => {
       ),
     ).toThrow("Cannot use nested write");
   });
+
+  const nonFkOneToOneRelation: RelationDefinition = {
+    type: "oneToOne",
+    to: "Profiles",
+    field: "id",
+    reference: "userId",
+    ownsFk: false,
+  };
+
+  it("oneToOne(ownsFk: false) + create の完全フロー（親 id 無傷・子は after で作成）", () => {
+    mockCreateFunc.mockReturnValue({ id: 1, name: "田中" });
+    mockCreateOnSheet.mockReturnValue({ id: 10, bio: "自己紹介", userId: 1 });
+
+    const result = resolveNestedCreate(
+      { name: "田中", profile: { create: { bio: "自己紹介" } } },
+      mockCreateFunc,
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中" });
+    expect(mockCreateFunc).toHaveBeenCalledWith({ name: "田中" });
+    expect(mockCreateOnSheet).toHaveBeenCalledWith("Profiles", {
+      data: { bio: "自己紹介", userId: 1 },
+    });
+  });
+
+  it("oneToOne(ownsFk: false) + connect の完全フロー（親データに FK が混入しない）", () => {
+    mockCreateFunc.mockReturnValue({ id: 1, name: "田中" });
+    mockFindMany.mockReturnValue([{ id: 5, userId: null }]);
+    mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
+
+    const result = resolveNestedCreate(
+      { name: "田中", profile: { connect: { id: 5 } } },
+      mockCreateFunc,
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中" });
+    expect(mockCreateFunc).toHaveBeenCalledWith({ name: "田中" });
+    expect(mockUpdateManyOnSheet).toHaveBeenNthCalledWith(1, "Profiles", {
+      where: { userId: 1 },
+      data: { userId: null },
+    });
+    expect(mockUpdateManyOnSheet).toHaveBeenNthCalledWith(2, "Profiles", {
+      where: { id: 5 },
+      data: { userId: 1 },
+    });
+  });
 });

--- a/src/__test__/util/update/nestedWrite/processBeforeUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/processBeforeUpdate.test.ts
@@ -213,4 +213,60 @@ describe("processBeforeUpdate", () => {
     expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
     expect(mockDeleteManyOnSheet).not.toHaveBeenCalled();
   });
+
+  const nonFkOneToOneRelation: RelationDefinition = {
+    type: "oneToOne",
+    to: "Profiles",
+    field: "id",
+    reference: "userId",
+    ownsFk: false,
+  };
+
+  it("oneToOne(ownsFk: false) + update は素通りする", () => {
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("profile", { update: { bio: "変更" } });
+
+    const enrichedData: Record<string, unknown> = { id: 1, name: "田中" };
+    processBeforeUpdate(
+      { id: 1, name: "田中" },
+      enrichedData,
+      relationOps,
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
+    expect(enrichedData).toEqual({ id: 1, name: "田中" });
+  });
+
+  it("oneToOne(ownsFk: false) + disconnect: true は素通りし親の field が null 化されない", () => {
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("profile", { disconnect: true });
+
+    const enrichedData: Record<string, unknown> = { id: 1, name: "田中" };
+    processBeforeUpdate(
+      { id: 1, name: "田中" },
+      enrichedData,
+      relationOps,
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(enrichedData.id).toBe(1);
+    expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("oneToOne(ownsFk: false) + delete: true は素通りし親の field が保たれる", () => {
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("profile", { delete: true });
+
+    const enrichedData: Record<string, unknown> = { id: 1, name: "田中" };
+    processBeforeUpdate(
+      { id: 1, name: "田中" },
+      enrichedData,
+      relationOps,
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(mockDeleteManyOnSheet).not.toHaveBeenCalled();
+    expect(enrichedData.id).toBe(1);
+  });
 });

--- a/src/__test__/util/update/nestedWrite/processOneToOneNonFkUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/processOneToOneNonFkUpdate.test.ts
@@ -1,0 +1,243 @@
+import { processOneToOneNonFkUpdate } from "../../../../util/update/nestedWrite/processOneToOneNonFkUpdate";
+import type {
+  RelationDefinition,
+  RelationContext,
+} from "../../../../types/relationTypes";
+import type { NestedWriteOperation } from "../../../../types/nestedWriteTypes";
+
+describe("processOneToOneNonFkUpdate", () => {
+  const mockFindMany = jest.fn();
+  const mockUpdateManyOnSheet = jest.fn();
+  const mockDeleteManyOnSheet = jest.fn();
+
+  const makeContext = (
+    relations: Record<string, RelationDefinition>,
+  ): RelationContext => ({
+    relations,
+    findManyOnSheet: mockFindMany,
+    updateManyOnSheet: mockUpdateManyOnSheet,
+    deleteManyOnSheet: mockDeleteManyOnSheet,
+  });
+
+  beforeEach(() => {
+    mockFindMany.mockReset();
+    mockUpdateManyOnSheet.mockReset();
+    mockDeleteManyOnSheet.mockReset();
+  });
+
+  const nonFkRelation: RelationDefinition = {
+    type: "oneToOne",
+    to: "Profiles",
+    field: "id",
+    reference: "userId",
+    ownsFk: false,
+  };
+
+  const makeOps = (op: NestedWriteOperation) => {
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("profile", op);
+    return relationOps;
+  };
+
+  it("update（裸 data）で相手行が更新される", () => {
+    mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
+
+    processOneToOneNonFkUpdate(
+      { id: 1, name: "田中" },
+      makeOps({ update: { bio: "変更後" } }),
+      makeContext({ profile: nonFkRelation }),
+    );
+
+    expect(mockUpdateManyOnSheet).toHaveBeenCalledWith("Profiles", {
+      where: { userId: 1 },
+      data: { bio: "変更後" },
+    });
+  });
+
+  it("update で相手不在なら NestedWriteTargetNotFoundError", () => {
+    mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
+
+    expect(() =>
+      processOneToOneNonFkUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ update: { bio: "変更後" } }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('Nested write update failed: no record found in "Profiles"');
+  });
+
+  it("update 相手不在エラーの name は NestedWriteTargetNotFoundError", () => {
+    mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
+
+    let caught: unknown;
+    try {
+      processOneToOneNonFkUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ update: { bio: "変更後" } }),
+        makeContext({ profile: nonFkRelation }),
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).name).toBe("NestedWriteTargetNotFoundError");
+  });
+
+  it("disconnect: true で相手の reference 列が null 化される", () => {
+    mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
+
+    processOneToOneNonFkUpdate(
+      { id: 1, name: "田中" },
+      makeOps({ disconnect: true }),
+      makeContext({ profile: nonFkRelation }),
+    );
+
+    expect(mockUpdateManyOnSheet).toHaveBeenCalledWith("Profiles", {
+      where: { userId: 1 },
+      data: { userId: null },
+    });
+  });
+
+  it("disconnect: true で相手不在は no-op", () => {
+    mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
+
+    expect(() =>
+      processOneToOneNonFkUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ disconnect: true }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("disconnect に true 以外を渡すとエラー", () => {
+    expect(() =>
+      processOneToOneNonFkUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ disconnect: { id: 5 } }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('operation "disconnect" is not valid');
+  });
+
+  it("delete: true で相手行が削除される", () => {
+    mockDeleteManyOnSheet.mockReturnValue({ count: 1 });
+
+    processOneToOneNonFkUpdate(
+      { id: 1, name: "田中" },
+      makeOps({ delete: true }),
+      makeContext({ profile: nonFkRelation }),
+    );
+
+    expect(mockDeleteManyOnSheet).toHaveBeenCalledWith("Profiles", {
+      where: { userId: 1 },
+    });
+  });
+
+  it("delete: true で相手不在なら NestedWriteTargetNotFoundError", () => {
+    mockDeleteManyOnSheet.mockReturnValue({ count: 0 });
+
+    expect(() =>
+      processOneToOneNonFkUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ delete: true }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('Nested write delete failed: no record found in "Profiles"');
+  });
+
+  it("delete に true 以外を渡すとエラー", () => {
+    expect(() =>
+      processOneToOneNonFkUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ delete: { id: 5 } }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('operation "delete" is not valid');
+  });
+
+  it("配列 update はエラー", () => {
+    expect(() =>
+      processOneToOneNonFkUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ update: [{ where: { id: 5 }, data: { bio: "a" } }] }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('operation "update" is not valid');
+  });
+
+  it("where/data 形式の update はエラー", () => {
+    expect(() =>
+      processOneToOneNonFkUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ update: { where: { id: 5 }, data: { bio: "a" } } }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('operation "update" is not valid');
+  });
+
+  it("set はエラー", () => {
+    expect(() =>
+      processOneToOneNonFkUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ set: [{ id: 5 }] }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('operation "set" is not valid');
+  });
+
+  it("deleteMany はエラー", () => {
+    expect(() =>
+      processOneToOneNonFkUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ deleteMany: { id: 5 } }),
+        makeContext({ profile: nonFkRelation }),
+      ),
+    ).toThrow('operation "deleteMany" is not valid');
+  });
+
+  it("ownsFk 未指定の oneToOne は無視される", () => {
+    processOneToOneNonFkUpdate(
+      { id: 1, name: "田中" },
+      makeOps({ update: { bio: "変更後" } }),
+      makeContext({
+        profile: {
+          type: "oneToOne",
+          to: "Profiles",
+          field: "profileId",
+          reference: "id",
+        },
+      }),
+    );
+
+    expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("manyToOne は無視される", () => {
+    processOneToOneNonFkUpdate(
+      { id: 1, title: "記事A", authorId: 5 },
+      makeOps({ update: { name: "変更後" } }),
+      makeContext({
+        profile: {
+          type: "manyToOne",
+          to: "Users",
+          field: "authorId",
+          reference: "id",
+          ownsFk: true,
+        },
+      }),
+    );
+
+    expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("親の field 値が欠落している場合はスキップ", () => {
+    processOneToOneNonFkUpdate(
+      { name: "田中" },
+      makeOps({ delete: true }),
+      makeContext({ profile: nonFkRelation }),
+    );
+
+    expect(mockDeleteManyOnSheet).not.toHaveBeenCalled();
+  });
+});

--- a/src/__test__/util/update/nestedWrite/resolveNestedUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/resolveNestedUpdate.test.ts
@@ -328,6 +328,181 @@ describe("resolveNestedUpdate", () => {
     ).toThrow("Cannot use nested write");
   });
 
+  const nonFkOneToOneRelation: RelationDefinition = {
+    type: "oneToOne",
+    to: "Profiles",
+    field: "id",
+    reference: "userId",
+    ownsFk: false,
+  };
+
+  it("oneToOne(ownsFk: false) + update の統合テスト（親 id 無傷）", () => {
+    const util = setupSheet(["id", "name"], [[1, "田中"]]);
+    mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
+
+    const result = resolveNestedUpdate(
+      util,
+      {
+        where: { id: 1 },
+        data: { profile: { update: { bio: "変更後" } } },
+      },
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中" });
+    expect(mockUpdateManyOnSheet).toHaveBeenCalledWith("Profiles", {
+      where: { userId: 1 },
+      data: { bio: "変更後" },
+    });
+  });
+
+  it("oneToOne(ownsFk: false) + update で相手不在ならエラー", () => {
+    const util = setupSheet(["id", "name"], [[1, "田中"]]);
+    mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
+
+    expect(() =>
+      resolveNestedUpdate(
+        util,
+        {
+          where: { id: 1 },
+          data: { profile: { update: { bio: "変更後" } } },
+        },
+        makeContext({ profile: nonFkOneToOneRelation }),
+      ),
+    ).toThrow('Nested write update failed: no record found in "Profiles"');
+  });
+
+  it("oneToOne(ownsFk: false) + disconnect: true の統合テスト（親 id は null 化されない）", () => {
+    const util = setupSheet(["id", "name"], [[1, "田中"]]);
+    mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
+
+    const result = resolveNestedUpdate(
+      util,
+      {
+        where: { id: 1 },
+        data: { profile: { disconnect: true } },
+      },
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中" });
+    expect(mockUpdateManyOnSheet).toHaveBeenCalledWith("Profiles", {
+      where: { userId: 1 },
+      data: { userId: null },
+    });
+  });
+
+  it("oneToOne(ownsFk: false) + delete: true の統合テスト（親 id 無傷）", () => {
+    const util = setupSheet(["id", "name"], [[1, "田中"]]);
+    mockDeleteManyOnSheet.mockReturnValue({ count: 1 });
+
+    const result = resolveNestedUpdate(
+      util,
+      {
+        where: { id: 1 },
+        data: { profile: { delete: true } },
+      },
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中" });
+    expect(mockDeleteManyOnSheet).toHaveBeenCalledWith("Profiles", {
+      where: { userId: 1 },
+    });
+  });
+
+  it("oneToOne(ownsFk: false) + delete: true で相手不在ならエラー", () => {
+    const util = setupSheet(["id", "name"], [[1, "田中"]]);
+    mockDeleteManyOnSheet.mockReturnValue({ count: 0 });
+
+    expect(() =>
+      resolveNestedUpdate(
+        util,
+        {
+          where: { id: 1 },
+          data: { profile: { delete: true } },
+        },
+        makeContext({ profile: nonFkOneToOneRelation }),
+      ),
+    ).toThrow('Nested write delete failed: no record found in "Profiles"');
+  });
+
+  it("oneToOne(ownsFk: false) + connect の統合テスト（置き換え）", () => {
+    const util = setupSheet(["id", "name"], [[1, "田中"]]);
+    mockFindMany.mockReturnValue([{ id: 5, userId: 99 }]);
+    mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
+
+    const result = resolveNestedUpdate(
+      util,
+      {
+        where: { id: 1 },
+        data: { profile: { connect: { id: 5 } } },
+      },
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中" });
+    expect(mockUpdateManyOnSheet).toHaveBeenNthCalledWith(1, "Profiles", {
+      where: { userId: 1 },
+      data: { userId: null },
+    });
+    expect(mockUpdateManyOnSheet).toHaveBeenNthCalledWith(2, "Profiles", {
+      where: { id: 5 },
+      data: { userId: 1 },
+    });
+  });
+
+  it("oneToOne(ownsFk: false) + connectOrCreate の統合テスト（不在時 create 相当）", () => {
+    const util = setupSheet(["id", "name"], [[1, "田中"]]);
+    mockFindMany.mockReturnValue([]);
+    mockCreateOnSheet.mockReturnValue({ id: 10, bio: "自己紹介", userId: 1 });
+
+    const result = resolveNestedUpdate(
+      util,
+      {
+        where: { id: 1 },
+        data: {
+          profile: {
+            connectOrCreate: { where: { id: 5 }, create: { bio: "自己紹介" } },
+          },
+        },
+      },
+      makeContext({ profile: nonFkOneToOneRelation }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中" });
+    expect(mockCreateOnSheet).toHaveBeenCalledWith("Profiles", {
+      data: { bio: "自己紹介", userId: 1 },
+    });
+  });
+
+  it("ownsFk 未指定の oneToOne は従来どおり before 段階で処理される", () => {
+    const util = setupSheet(["id", "name", "profileId"], [[1, "田中", 5]]);
+    mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
+
+    const result = resolveNestedUpdate(
+      util,
+      {
+        where: { id: 1 },
+        data: { profile: { update: { bio: "変更後" } } },
+      },
+      makeContext({
+        profile: {
+          type: "oneToOne",
+          to: "Profiles",
+          field: "profileId",
+          reference: "id",
+        },
+      }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中", profileId: 5 });
+    expect(mockUpdateManyOnSheet).toHaveBeenCalledWith("Profiles", {
+      where: { id: 5 },
+      data: { bio: "変更後" },
+    });
+  });
+
   it("manyToOne + oneToMany 同時処理", () => {
     const util = setupSheet(["id", "title", "authorId"], [[1, "記事A", 1]]);
     mockFindMany.mockReturnValue([{ id: 5, name: "佐藤" }]);

--- a/src/errors/relation/nestedWriteError.ts
+++ b/src/errors/relation/nestedWriteError.ts
@@ -30,9 +30,19 @@ class NestedWriteWithoutRelationsError extends Error {
   }
 }
 
+class NestedWriteTargetNotFoundError extends Error {
+  constructor(sheetName: string, operation: string) {
+    super(
+      `Nested write ${operation} failed: no record found in "${sheetName}"`,
+    );
+    this.name = "NestedWriteTargetNotFoundError";
+  }
+}
+
 export {
   NestedWriteConnectNotFoundError,
   NestedWriteRelationNotFoundError,
   NestedWriteInvalidOperationError,
   NestedWriteWithoutRelationsError,
+  NestedWriteTargetNotFoundError,
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -153,6 +153,7 @@ declare namespace Gassma {
     to: string;
     field: string;
     reference: string;
+    ownsFk?: boolean;
     through?: ManyToManyThrough;
     onDelete?: OnDeleteAction;
     onUpdate?: OnUpdateAction;
@@ -476,6 +477,9 @@ declare namespace Gassma {
   }
   class NestedWriteWithoutRelationsError extends Error {
     constructor();
+  }
+  class NestedWriteTargetNotFoundError extends Error {
+    constructor(sheetName: string, operation: string);
   }
   class RelationOrderByUnsupportedTypeError extends Error {
     constructor(relationName: string, relationType: string);

--- a/src/types/relationTypes.ts
+++ b/src/types/relationTypes.ts
@@ -25,6 +25,7 @@ type RelationDefinition = {
   to: string;
   field: string;
   reference: string;
+  ownsFk?: boolean;
   through?: ManyToManyThrough;
   onDelete?: OnDeleteAction;
   onUpdate?: OnUpdateAction;

--- a/src/util/create/nestedWrite/isNonFkOneToOne.ts
+++ b/src/util/create/nestedWrite/isNonFkOneToOne.ts
@@ -1,0 +1,6 @@
+import type { RelationDefinition } from "../../../types/relationTypes";
+
+const isNonFkOneToOne = (relation: RelationDefinition): boolean =>
+  relation.type === "oneToOne" && relation.ownsFk === false;
+
+export { isNonFkOneToOne };

--- a/src/util/create/nestedWrite/processBeforeCreate.ts
+++ b/src/util/create/nestedWrite/processBeforeCreate.ts
@@ -1,6 +1,7 @@
 import type { RelationContext } from "../../../types/relationTypes";
 import type { NestedWriteOperation } from "../../../types/nestedWriteTypes";
 import { NestedWriteConnectNotFoundError } from "../../../errors/relation/nestedWriteError";
+import { isNonFkOneToOne } from "./isNonFkOneToOne";
 
 const processBeforeCreate = (
   scalarData: Record<string, unknown>,
@@ -13,6 +14,7 @@ const processBeforeCreate = (
     const relation = context.relations[relationName];
     if (!relation) return;
     if (relation.type !== "manyToOne" && relation.type !== "oneToOne") return;
+    if (isNonFkOneToOne(relation)) return;
 
     if (ops.connect) {
       const where = Array.isArray(ops.connect) ? ops.connect[0] : ops.connect;

--- a/src/util/create/nestedWrite/processOneToOneNonFk.ts
+++ b/src/util/create/nestedWrite/processOneToOneNonFk.ts
@@ -1,0 +1,100 @@
+import type { GassmaAny, WhereUse } from "../../../types/coreTypes";
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../types/relationTypes";
+import type { NestedWriteOperation } from "../../../types/nestedWriteTypes";
+import {
+  NestedWriteConnectNotFoundError,
+  NestedWriteInvalidOperationError,
+} from "../../../errors/relation/nestedWriteError";
+import { isGassmaAny } from "../../relation/collectKeys";
+import { isNonFkOneToOne } from "./isNonFkOneToOne";
+
+const findInvalidOperation = (ops: NestedWriteOperation): string | null => {
+  if (ops.createMany !== undefined) return "createMany";
+  if (Array.isArray(ops.create)) return "create";
+  if (Array.isArray(ops.connect)) return "connect";
+  if (Array.isArray(ops.connectOrCreate)) return "connectOrCreate";
+  return null;
+};
+
+const assertValidOps = (
+  relationName: string,
+  relation: RelationDefinition,
+  ops: NestedWriteOperation,
+): void => {
+  const invalidOperation = findInvalidOperation(ops);
+  if (invalidOperation === null) return;
+  throw new NestedWriteInvalidOperationError(
+    relationName,
+    invalidOperation,
+    relation.type,
+  );
+};
+
+const connectByWhere = (
+  relation: RelationDefinition,
+  where: WhereUse,
+  parentValue: GassmaAny,
+  context: RelationContext,
+): void => {
+  context.updateManyOnSheet!(relation.to, {
+    where: { [relation.reference]: parentValue },
+    data: { [relation.reference]: null },
+  });
+  context.updateManyOnSheet!(relation.to, {
+    where,
+    data: { [relation.reference]: parentValue },
+  });
+};
+
+const processOneToOneNonFk = (
+  writtenRecord: Record<string, unknown>,
+  relationOps: Map<string, NestedWriteOperation>,
+  context: RelationContext,
+): void => {
+  relationOps.forEach((ops, relationName) => {
+    const relation = context.relations[relationName];
+    if (!relation) return;
+    if (!isNonFkOneToOne(relation)) return;
+
+    assertValidOps(relationName, relation, ops);
+
+    const rawParentValue = writtenRecord[relation.field];
+    if (!isGassmaAny(rawParentValue)) return;
+    const parentValue = rawParentValue;
+
+    if (ops.create && !Array.isArray(ops.create)) {
+      context.createOnSheet!(relation.to, {
+        data: { ...ops.create, [relation.reference]: parentValue },
+      });
+    }
+
+    if (ops.connect && !Array.isArray(ops.connect)) {
+      const found = context.findManyOnSheet(relation.to, {
+        where: ops.connect,
+      });
+      if (found.length === 0) {
+        throw new NestedWriteConnectNotFoundError(relation.to);
+      }
+      connectByWhere(relation, ops.connect, parentValue, context);
+    }
+
+    if (ops.connectOrCreate && !Array.isArray(ops.connectOrCreate)) {
+      const input = ops.connectOrCreate;
+      const found = context.findManyOnSheet(relation.to, {
+        where: input.where,
+      });
+      if (found.length > 0) {
+        connectByWhere(relation, input.where, parentValue, context);
+      } else {
+        context.createOnSheet!(relation.to, {
+          data: { ...input.create, [relation.reference]: parentValue },
+        });
+      }
+    }
+  });
+};
+
+export { processOneToOneNonFk };

--- a/src/util/create/nestedWrite/resolveNestedCreate.ts
+++ b/src/util/create/nestedWrite/resolveNestedCreate.ts
@@ -6,6 +6,7 @@ import {
 } from "./extractRelationData";
 import { processBeforeCreate } from "./processBeforeCreate";
 import { processAfterCreate } from "./processAfterCreate";
+import { processOneToOneNonFk } from "./processOneToOneNonFk";
 import { processManyToMany } from "./processManyToMany";
 
 const hasNestedWriteFields = (
@@ -45,6 +46,7 @@ const resolveNestedCreate = (
   const createdRecord = createFunc(enrichedData);
 
   processAfterCreate(createdRecord, relationOps, relationContext!);
+  processOneToOneNonFk(createdRecord, relationOps, relationContext!);
   processManyToMany(createdRecord, relationOps, relationContext!);
 
   return createdRecord;

--- a/src/util/update/nestedWrite/processBeforeUpdate.ts
+++ b/src/util/update/nestedWrite/processBeforeUpdate.ts
@@ -3,6 +3,7 @@ import type { RelationContext } from "../../../types/relationTypes";
 import type { NestedWriteOperation } from "../../../types/nestedWriteTypes";
 import { NestedWriteInvalidOperationError } from "../../../errors/relation/nestedWriteError";
 import { isGassmaAny } from "../../relation/collectKeys";
+import { isNonFkOneToOne } from "../../create/nestedWrite/isNonFkOneToOne";
 
 const processBeforeUpdate = (
   currentRecord: Record<string, unknown>,
@@ -14,6 +15,7 @@ const processBeforeUpdate = (
     const relation = context.relations[relationName];
     if (!relation) return;
     if (relation.type !== "manyToOne" && relation.type !== "oneToOne") return;
+    if (isNonFkOneToOne(relation)) return;
 
     const fkValue = currentRecord[relation.field];
     if (!isGassmaAny(fkValue)) return;

--- a/src/util/update/nestedWrite/processOneToOneNonFkUpdate.ts
+++ b/src/util/update/nestedWrite/processOneToOneNonFkUpdate.ts
@@ -1,0 +1,81 @@
+import type { AnyUse } from "../../../types/coreTypes";
+import type { RelationContext } from "../../../types/relationTypes";
+import type { NestedWriteOperation } from "../../../types/nestedWriteTypes";
+import {
+  NestedWriteInvalidOperationError,
+  NestedWriteTargetNotFoundError,
+} from "../../../errors/relation/nestedWriteError";
+import { isGassmaAny } from "../../relation/collectKeys";
+import { isNonFkOneToOne } from "../../create/nestedWrite/isNonFkOneToOne";
+
+const isBareUpdateData = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  !("where" in value && "data" in value);
+
+const findInvalidOperation = (ops: NestedWriteOperation): string | null => {
+  if (ops.set !== undefined) return "set";
+  if (ops.deleteMany !== undefined) return "deleteMany";
+  if (ops.update !== undefined && !isBareUpdateData(ops.update)) {
+    return "update";
+  }
+  if (ops.disconnect !== undefined && ops.disconnect !== true) {
+    return "disconnect";
+  }
+  if (ops.delete !== undefined && ops.delete !== true) return "delete";
+  return null;
+};
+
+const processOneToOneNonFkUpdate = (
+  updatedRecord: Record<string, unknown>,
+  relationOps: Map<string, NestedWriteOperation>,
+  context: RelationContext,
+): void => {
+  relationOps.forEach((ops, relationName) => {
+    const relation = context.relations[relationName];
+    if (!relation) return;
+    if (!isNonFkOneToOne(relation)) return;
+
+    const invalidOperation = findInvalidOperation(ops);
+    if (invalidOperation !== null) {
+      throw new NestedWriteInvalidOperationError(
+        relationName,
+        invalidOperation,
+        relation.type,
+      );
+    }
+
+    const rawParentValue = updatedRecord[relation.field];
+    if (!isGassmaAny(rawParentValue)) return;
+    const parentValue = rawParentValue;
+
+    if (ops.update !== undefined && isBareUpdateData(ops.update)) {
+      const result = context.updateManyOnSheet!(relation.to, {
+        where: { [relation.reference]: parentValue },
+        data: ops.update as AnyUse,
+      });
+      if (result.count === 0) {
+        throw new NestedWriteTargetNotFoundError(relation.to, "update");
+      }
+    }
+
+    if (ops.disconnect === true) {
+      context.updateManyOnSheet!(relation.to, {
+        where: { [relation.reference]: parentValue },
+        data: { [relation.reference]: null },
+      });
+    }
+
+    if (ops.delete === true) {
+      const result = context.deleteManyOnSheet!(relation.to, {
+        where: { [relation.reference]: parentValue },
+      });
+      if (result.count === 0) {
+        throw new NestedWriteTargetNotFoundError(relation.to, "delete");
+      }
+    }
+  });
+};
+
+export { processOneToOneNonFkUpdate };

--- a/src/util/update/nestedWrite/resolveNestedUpdate.ts
+++ b/src/util/update/nestedWrite/resolveNestedUpdate.ts
@@ -7,6 +7,7 @@ import { getWantUpdateIndex } from "../../core/getWantUpdateIndex";
 import { whereFilter } from "../../core/whereFilter";
 import { processBeforeCreate } from "../../create/nestedWrite/processBeforeCreate";
 import { processAfterCreate } from "../../create/nestedWrite/processAfterCreate";
+import { processOneToOneNonFk } from "../../create/nestedWrite/processOneToOneNonFk";
 import { processManyToMany } from "../../create/nestedWrite/processManyToMany";
 import {
   extractRelationDataForUpdate,
@@ -14,6 +15,7 @@ import {
 } from "./extractRelationDataForUpdate";
 import { processBeforeUpdate } from "./processBeforeUpdate";
 import { processAfterUpdate } from "./processAfterUpdate";
+import { processOneToOneNonFkUpdate } from "./processOneToOneNonFkUpdate";
 import { processManyToManyUpdate } from "./processManyToManyUpdate";
 import {
   isNumberOperation,
@@ -143,6 +145,8 @@ const resolveNestedUpdate = (
 
   processAfterCreate(updatedRecord, relationOps, relationContext!);
   processAfterUpdate(updatedRecord, relationOps, relationContext!);
+  processOneToOneNonFk(updatedRecord, relationOps, relationContext!);
+  processOneToOneNonFkUpdate(updatedRecord, relationOps, relationContext!);
   processManyToMany(updatedRecord, relationOps, relationContext!);
   processManyToManyUpdate(updatedRecord, relationOps, relationContext!);
 


### PR DESCRIPTION
## 概要

**非FK保有側 oneToOne の nested write が親の主キーを破壊するバグ**の修正です(gassma-test B-3 実装時に発覚)。例: `User.profile`(relation.field=自分の id)経由の `disconnect: true` が `User.id` を null にし、create 文脈の `create`/`connect`/`connectOrCreate` でも親 id を上書きしていました(create/update/upsert すべてに波及)。

## Prisma 実測(optional/required 1:1 両側で裏取り)

非FK側の全操作は**子行のみに作用し親は完全無傷**: disconnect=子 FK null、delete=子行削除、connect=子の付け替え、update/delete の相手不在=P2025 エラー、disconnect の不在=no-op。

## 設計: `ownsFk?`(optional)の追加

- `RelationDefinition.ownsFk?: boolean` = **Prisma スキーマの `@relation(fields:...)` 位置情報のランタイム表現**(独自概念ではなくスキーマ由来情報)。
- **cli 生成 client は既に relations JSON に ownsFk を出力済み**(extractRelations 由来)→ 本体対応だけで**再生成不要で即修正**。
- 手動設定は `ownsFk: false` でオプトイン。**未指定は従来挙動**(完全後方互換 — 現在正しく動く構成はすべて FK 保有側の形)。
- 構造からの自動判別は不可能(対称 oneToOne ペアの反例)、「常に相手側」案は FK 保有側で逆向き破壊 — 調査で棄却済み。

## 実装

`oneToOne && ownsFk === false` のとき before 段階は親に触れず素通りし、**親行書き込み後の after 段階**で子側 semantics(ユーザー承認済み仕様):

| op | 挙動 |
|---|---|
| create / connectOrCreate(create 側) | 子を `[reference] = 親値` で作成 |
| connect | **置き換え**: 既接続の子 FK を null → 対象行に親値(不在は `NestedWriteConnectNotFoundError`) |
| update(裸 data) | 子を更新。**不在は `NestedWriteTargetNotFoundError`(新設、P2025 準拠)** |
| disconnect: true | 子 FK null。不在は no-op |
| delete: true | 子行削除。**不在はエラー** |
| 無効形(createMany/set/deleteMany/配列/非 true) | `NestedWriteInvalidOperationError` |

ownsFk 未指定/true・manyToOne・oneToMany・manyToMany は全経路無変更。

## テスト(TDD: Red → Green)

- 追加46件: before 素通りガード、after 各 op(親 id 無傷・connect 置き換え・不在エラー/no-op)、resolveNested 統合、**ownsFk 未指定の従来挙動明示**。
- **105 suites / 1289 tests 全 green**(+46)、`tsc --noEmit` clean、biome clean。

## フォロー(別対応)

- **cli 追随**: 生成 d.ts のエラークラス宣言に `NestedWriteTargetNotFoundError` を追加(後続 cli PR)。
- reference(リリース時): ownsFk 説明・非FK側の挙動表・新エラー・制約の追記。
- gassma-test: 非FK側(User.profile)の統合テスト追加(マージ・デプロイ後)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja