### PR TITLE
refactor: drop ownsFk; oneToOne means the non-FK side (FK holder is manyToOne)

### DIFF
--- a/src/__test__/util/create/nestedWrite/processBeforeCreate.test.ts
+++ b/src/__test__/util/create/nestedWrite/processBeforeCreate.test.ts
@@ -29,8 +29,8 @@ describe("processBeforeCreate", () => {
     reference: "id",
   };
 
-  const oneToOneRelation: RelationDefinition = {
-    type: "oneToOne",
+  const fkSideProfileRelation: RelationDefinition = {
+    type: "manyToOne",
     to: "Profiles",
     field: "profileId",
     reference: "id",
@@ -43,12 +43,11 @@ describe("processBeforeCreate", () => {
     reference: "authorId",
   };
 
-  const nonFkOneToOneRelation: RelationDefinition = {
+  const oneToOneRelation: RelationDefinition = {
     type: "oneToOne",
     to: "Profiles",
     field: "id",
     reference: "userId",
-    ownsFk: false,
   };
 
   it("manyToOne + connect で既存レコードのFK値が親データに設定される", () => {
@@ -99,7 +98,7 @@ describe("processBeforeCreate", () => {
     });
   });
 
-  it("oneToOne + connectOrCreate で既存レコードがある場合FK値が設定される", () => {
+  it("FK 保有側 1:1（manyToOne）+ connectOrCreate で既存レコードがある場合FK値が設定される", () => {
     mockFindMany.mockReturnValue([{ id: 5, bio: "自己紹介" }]);
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("profile", {
@@ -112,14 +111,14 @@ describe("processBeforeCreate", () => {
     const result = processBeforeCreate(
       { name: "田中" },
       relationOps,
-      makeContext({ profile: oneToOneRelation }),
+      makeContext({ profile: fkSideProfileRelation }),
     );
 
     expect(result).toEqual({ name: "田中", profileId: 5 });
     expect(mockCreateOnSheet).not.toHaveBeenCalled();
   });
 
-  it("oneToOne + connectOrCreate で既存レコードがない場合新規作成しFK値が設定される", () => {
+  it("FK 保有側 1:1（manyToOne）+ connectOrCreate で既存レコードがない場合新規作成しFK値が設定される", () => {
     mockFindMany.mockReturnValue([]);
     mockCreateOnSheet.mockReturnValue({ id: 5, bio: "自己紹介" });
     const relationOps = new Map<string, NestedWriteOperation>();
@@ -133,7 +132,7 @@ describe("processBeforeCreate", () => {
     const result = processBeforeCreate(
       { name: "田中" },
       relationOps,
-      makeContext({ profile: oneToOneRelation }),
+      makeContext({ profile: fkSideProfileRelation }),
     );
 
     expect(result).toEqual({ name: "田中", profileId: 5 });
@@ -157,7 +156,7 @@ describe("processBeforeCreate", () => {
     expect(mockCreateOnSheet).not.toHaveBeenCalled();
   });
 
-  it("oneToOne(ownsFk: false) + connect は素通りし親データ・関連先に触れない", () => {
+  it("oneToOne + connect は素通りし親データ・関連先に触れない", () => {
     mockFindMany.mockReturnValue([{ id: 5, userId: 99 }]);
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("profile", { connect: { id: 5 } });
@@ -165,7 +164,7 @@ describe("processBeforeCreate", () => {
     const result = processBeforeCreate(
       { id: 1, name: "田中" },
       relationOps,
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(result).toEqual({ id: 1, name: "田中" });
@@ -173,7 +172,7 @@ describe("processBeforeCreate", () => {
     expect(mockCreateOnSheet).not.toHaveBeenCalled();
   });
 
-  it("oneToOne(ownsFk: false) + create は素通りする", () => {
+  it("oneToOne + create は素通りする", () => {
     mockCreateOnSheet.mockReturnValue({ id: 5, userId: 99 });
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("profile", { create: { bio: "自己紹介" } });
@@ -181,14 +180,14 @@ describe("processBeforeCreate", () => {
     const result = processBeforeCreate(
       { id: 1, name: "田中" },
       relationOps,
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(result).toEqual({ id: 1, name: "田中" });
     expect(mockCreateOnSheet).not.toHaveBeenCalled();
   });
 
-  it("oneToOne(ownsFk: false) + connectOrCreate は素通りする", () => {
+  it("oneToOne + connectOrCreate は素通りする", () => {
     mockFindMany.mockReturnValue([{ id: 5, userId: 99 }]);
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("profile", {
@@ -198,7 +197,7 @@ describe("processBeforeCreate", () => {
     const result = processBeforeCreate(
       { id: 1, name: "田中" },
       relationOps,
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(result).toEqual({ id: 1, name: "田中" });
@@ -206,7 +205,7 @@ describe("processBeforeCreate", () => {
     expect(mockCreateOnSheet).not.toHaveBeenCalled();
   });
 
-  it("oneToOne(ownsFk: true) は従来どおり before で処理される", () => {
+  it("FK 保有側 1:1 は manyToOne として before で処理される", () => {
     mockFindMany.mockReturnValue([{ id: 5, bio: "自己紹介" }]);
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("profile", { connect: { id: 5 } });
@@ -214,7 +213,7 @@ describe("processBeforeCreate", () => {
     const result = processBeforeCreate(
       { name: "田中" },
       relationOps,
-      makeContext({ profile: { ...oneToOneRelation, ownsFk: true } }),
+      makeContext({ profile: fkSideProfileRelation }),
     );
 
     expect(result).toEqual({ name: "田中", profileId: 5 });

--- a/src/__test__/util/create/nestedWrite/processOneToOne.test.ts
+++ b/src/__test__/util/create/nestedWrite/processOneToOne.test.ts
@@ -1,11 +1,11 @@
-import { processOneToOneNonFk } from "../../../../util/create/nestedWrite/processOneToOneNonFk";
+import { processOneToOne } from "../../../../util/create/nestedWrite/processOneToOne";
 import type {
   RelationDefinition,
   RelationContext,
 } from "../../../../types/relationTypes";
 import type { NestedWriteOperation } from "../../../../types/nestedWriteTypes";
 
-describe("processOneToOneNonFk", () => {
+describe("processOneToOne", () => {
   const mockFindMany = jest.fn();
   const mockCreateOnSheet = jest.fn();
   const mockUpdateManyOnSheet = jest.fn();
@@ -25,12 +25,11 @@ describe("processOneToOneNonFk", () => {
     mockUpdateManyOnSheet.mockReset();
   });
 
-  const nonFkRelation: RelationDefinition = {
+  const oneToOneRelation: RelationDefinition = {
     type: "oneToOne",
     to: "Profiles",
     field: "id",
     reference: "userId",
-    ownsFk: false,
   };
 
   const makeOps = (op: NestedWriteOperation) => {
@@ -42,10 +41,10 @@ describe("processOneToOneNonFk", () => {
   it("create で子が親の field 値付きで作成される", () => {
     mockCreateOnSheet.mockReturnValue({ id: 10, bio: "自己紹介", userId: 1 });
 
-    processOneToOneNonFk(
+    processOneToOne(
       { id: 1, name: "田中" },
       makeOps({ create: { bio: "自己紹介" } }),
-      makeContext({ profile: nonFkRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(mockCreateOnSheet).toHaveBeenCalledWith("Profiles", {
@@ -57,10 +56,10 @@ describe("processOneToOneNonFk", () => {
     mockFindMany.mockReturnValue([{ id: 5, userId: null }]);
     mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
 
-    processOneToOneNonFk(
+    processOneToOne(
       { id: 1, name: "田中" },
       makeOps({ connect: { id: 5 } }),
-      makeContext({ profile: nonFkRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(mockUpdateManyOnSheet).toHaveBeenNthCalledWith(1, "Profiles", {
@@ -77,10 +76,10 @@ describe("processOneToOneNonFk", () => {
     mockFindMany.mockReturnValue([]);
 
     expect(() =>
-      processOneToOneNonFk(
+      processOneToOne(
         { id: 1, name: "田中" },
         makeOps({ connect: { id: 999 } }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('no record found in "Profiles"');
     expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
@@ -90,12 +89,12 @@ describe("processOneToOneNonFk", () => {
     mockFindMany.mockReturnValue([{ id: 5, userId: 99 }]);
     mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
 
-    processOneToOneNonFk(
+    processOneToOne(
       { id: 1, name: "田中" },
       makeOps({
         connectOrCreate: { where: { id: 5 }, create: { bio: "自己紹介" } },
       }),
-      makeContext({ profile: nonFkRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(mockCreateOnSheet).not.toHaveBeenCalled();
@@ -113,12 +112,12 @@ describe("processOneToOneNonFk", () => {
     mockFindMany.mockReturnValue([]);
     mockCreateOnSheet.mockReturnValue({ id: 10, bio: "自己紹介", userId: 1 });
 
-    processOneToOneNonFk(
+    processOneToOne(
       { id: 1, name: "田中" },
       makeOps({
         connectOrCreate: { where: { id: 5 }, create: { bio: "自己紹介" } },
       }),
-      makeContext({ profile: nonFkRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
@@ -129,85 +128,67 @@ describe("processOneToOneNonFk", () => {
 
   it("createMany は NestedWriteInvalidOperationError", () => {
     expect(() =>
-      processOneToOneNonFk(
+      processOneToOne(
         { id: 1, name: "田中" },
         makeOps({ createMany: { data: [{ bio: "自己紹介" }] } }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('operation "createMany" is not valid');
   });
 
   it("配列 create は NestedWriteInvalidOperationError", () => {
     expect(() =>
-      processOneToOneNonFk(
+      processOneToOne(
         { id: 1, name: "田中" },
         makeOps({ create: [{ bio: "自己紹介" }] }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('operation "create" is not valid');
   });
 
   it("配列 connect は NestedWriteInvalidOperationError", () => {
     expect(() =>
-      processOneToOneNonFk(
+      processOneToOne(
         { id: 1, name: "田中" },
         makeOps({ connect: [{ id: 5 }] }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('operation "connect" is not valid');
   });
 
   it("配列 connectOrCreate は NestedWriteInvalidOperationError", () => {
     expect(() =>
-      processOneToOneNonFk(
+      processOneToOne(
         { id: 1, name: "田中" },
         makeOps({
           connectOrCreate: [{ where: { id: 5 }, create: { bio: "a" } }],
         }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('operation "connectOrCreate" is not valid');
   });
 
   it("親の field 値が欠落している場合はスキップ", () => {
-    processOneToOneNonFk(
+    processOneToOne(
       { name: "田中" },
       makeOps({ create: { bio: "自己紹介" } }),
-      makeContext({ profile: nonFkRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(mockCreateOnSheet).not.toHaveBeenCalled();
     expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
   });
 
-  it("ownsFk 未指定の oneToOne は無視される", () => {
-    processOneToOneNonFk(
+  it("manyToOne（FK 保有側）は無視される", () => {
+    processOneToOne(
       { id: 1, name: "田中" },
       makeOps({ create: { bio: "自己紹介" } }),
       makeContext({
         profile: {
-          type: "oneToOne",
+          type: "manyToOne",
           to: "Profiles",
           field: "profileId",
           reference: "id",
-        },
-      }),
-    );
-
-    expect(mockCreateOnSheet).not.toHaveBeenCalled();
-  });
-
-  it("ownsFk: true の oneToOne は無視される", () => {
-    processOneToOneNonFk(
-      { id: 1, name: "田中" },
-      makeOps({ create: { bio: "自己紹介" } }),
-      makeContext({
-        profile: {
-          type: "oneToOne",
-          to: "Profiles",
-          field: "profileId",
-          reference: "id",
-          ownsFk: true,
         },
       }),
     );
@@ -216,7 +197,7 @@ describe("processOneToOneNonFk", () => {
   });
 
   it("oneToMany は無視される", () => {
-    processOneToOneNonFk(
+    processOneToOne(
       { id: 1, name: "田中" },
       makeOps({ create: { title: "記事A" } }),
       makeContext({
@@ -225,7 +206,6 @@ describe("processOneToOneNonFk", () => {
           to: "Posts",
           field: "id",
           reference: "authorId",
-          ownsFk: false,
         },
       }),
     );

--- a/src/__test__/util/create/nestedWrite/resolveNestedCreate.test.ts
+++ b/src/__test__/util/create/nestedWrite/resolveNestedCreate.test.ts
@@ -189,22 +189,21 @@ describe("resolveNestedCreate", () => {
     ).toThrow("Cannot use nested write");
   });
 
-  const nonFkOneToOneRelation: RelationDefinition = {
+  const oneToOneRelation: RelationDefinition = {
     type: "oneToOne",
     to: "Profiles",
     field: "id",
     reference: "userId",
-    ownsFk: false,
   };
 
-  it("oneToOne(ownsFk: false) + create の完全フロー（親 id 無傷・子は after で作成）", () => {
+  it("oneToOne + create の完全フロー（親 id 無傷・子は after で作成）", () => {
     mockCreateFunc.mockReturnValue({ id: 1, name: "田中" });
     mockCreateOnSheet.mockReturnValue({ id: 10, bio: "自己紹介", userId: 1 });
 
     const result = resolveNestedCreate(
       { name: "田中", profile: { create: { bio: "自己紹介" } } },
       mockCreateFunc,
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(result).toEqual({ id: 1, name: "田中" });
@@ -214,7 +213,7 @@ describe("resolveNestedCreate", () => {
     });
   });
 
-  it("oneToOne(ownsFk: false) + connect の完全フロー（親データに FK が混入しない）", () => {
+  it("oneToOne + connect の完全フロー（親データに FK が混入しない）", () => {
     mockCreateFunc.mockReturnValue({ id: 1, name: "田中" });
     mockFindMany.mockReturnValue([{ id: 5, userId: null }]);
     mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
@@ -222,7 +221,7 @@ describe("resolveNestedCreate", () => {
     const result = resolveNestedCreate(
       { name: "田中", profile: { connect: { id: 5 } } },
       mockCreateFunc,
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(result).toEqual({ id: 1, name: "田中" });

--- a/src/__test__/util/find/findUtil/resolveRelationOrderBy.test.ts
+++ b/src/__test__/util/find/findUtil/resolveRelationOrderBy.test.ts
@@ -15,8 +15,8 @@ const createRelationContext = (
     profile: {
       type: "oneToOne",
       to: "Profiles",
-      field: "profileId",
-      reference: "id",
+      field: "id",
+      reference: "userId",
     },
     posts: {
       type: "oneToMany",
@@ -166,15 +166,15 @@ describe("resolveRelationOrderBy", () => {
 
   test("should sort by oneToOne relation field", () => {
     const records = [
-      { id: 1, name: "User A", profileId: 2 },
-      { id: 2, name: "User B", profileId: 1 },
+      { id: 1, name: "User A" },
+      { id: 2, name: "User B" },
     ];
 
     const findManyOnSheet = jest.fn((sheetName: string) => {
       if (sheetName === "Profiles") {
         return [
-          { id: 1, bio: "Zebra" },
-          { id: 2, bio: "Apple" },
+          { id: 10, userId: 1, bio: "Zebra" },
+          { id: 11, userId: 2, bio: "Apple" },
         ];
       }
       return [];
@@ -185,10 +185,10 @@ describe("resolveRelationOrderBy", () => {
 
     const result = resolveRelationOrderBy(records, orderByArr, context);
 
-    // Apple(profileId=2) < Zebra(profileId=1)
+    // Apple(userId=2) < Zebra(userId=1)
     expect(result).toEqual([
-      { id: 1, name: "User A", profileId: 2 },
-      { id: 2, name: "User B", profileId: 1 },
+      { id: 2, name: "User B" },
+      { id: 1, name: "User A" },
     ]);
   });
 

--- a/src/__test__/util/update/nestedWrite/processBeforeUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/processBeforeUpdate.test.ts
@@ -32,8 +32,8 @@ describe("processBeforeUpdate", () => {
     reference: "id",
   };
 
-  const oneToOneRelation: RelationDefinition = {
-    type: "oneToOne",
+  const fkSideProfileRelation: RelationDefinition = {
+    type: "manyToOne",
     to: "Profiles",
     field: "profileId",
     reference: "id",
@@ -65,7 +65,7 @@ describe("processBeforeUpdate", () => {
     });
   });
 
-  it("oneToOne + update で対象レコードが更新される", () => {
+  it("FK 保有側 1:1（manyToOne）+ update で対象レコードが更新される", () => {
     mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("profile", { update: { bio: "新しい自己紹介" } });
@@ -75,7 +75,7 @@ describe("processBeforeUpdate", () => {
       { name: "田中", profileId: 5 },
       enrichedData,
       relationOps,
-      makeContext({ profile: oneToOneRelation }),
+      makeContext({ profile: fkSideProfileRelation }),
     );
 
     expect(mockUpdateManyOnSheet).toHaveBeenCalledWith("Profiles", {
@@ -138,7 +138,7 @@ describe("processBeforeUpdate", () => {
     expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
   });
 
-  it("oneToOne + disconnect: true で FK が null になる", () => {
+  it("FK 保有側 1:1（manyToOne）+ disconnect: true で FK が null になる", () => {
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("profile", { disconnect: true });
 
@@ -150,7 +150,7 @@ describe("processBeforeUpdate", () => {
       { name: "田中", profileId: 5 },
       enrichedData,
       relationOps,
-      makeContext({ profile: oneToOneRelation }),
+      makeContext({ profile: fkSideProfileRelation }),
     );
 
     expect(enrichedData.profileId).toBeNull();
@@ -177,7 +177,7 @@ describe("processBeforeUpdate", () => {
     ).toThrow("disconnect");
   });
 
-  it("oneToOne + disconnect に true 以外を渡すとエラー", () => {
+  it("FK 保有側 1:1（manyToOne）+ disconnect に true 以外を渡すとエラー", () => {
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("profile", { disconnect: { id: 5 } });
 
@@ -191,7 +191,7 @@ describe("processBeforeUpdate", () => {
         { name: "田中", profileId: 5 },
         enrichedData,
         relationOps,
-        makeContext({ profile: oneToOneRelation }),
+        makeContext({ profile: fkSideProfileRelation }),
       ),
     ).toThrow("disconnect");
   });
@@ -214,15 +214,14 @@ describe("processBeforeUpdate", () => {
     expect(mockDeleteManyOnSheet).not.toHaveBeenCalled();
   });
 
-  const nonFkOneToOneRelation: RelationDefinition = {
+  const oneToOneRelation: RelationDefinition = {
     type: "oneToOne",
     to: "Profiles",
     field: "id",
     reference: "userId",
-    ownsFk: false,
   };
 
-  it("oneToOne(ownsFk: false) + update は素通りする", () => {
+  it("oneToOne + update は素通りする", () => {
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("profile", { update: { bio: "変更" } });
 
@@ -231,14 +230,14 @@ describe("processBeforeUpdate", () => {
       { id: 1, name: "田中" },
       enrichedData,
       relationOps,
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
     expect(enrichedData).toEqual({ id: 1, name: "田中" });
   });
 
-  it("oneToOne(ownsFk: false) + disconnect: true は素通りし親の field が null 化されない", () => {
+  it("oneToOne + disconnect: true は素通りし親の field が null 化されない", () => {
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("profile", { disconnect: true });
 
@@ -247,14 +246,14 @@ describe("processBeforeUpdate", () => {
       { id: 1, name: "田中" },
       enrichedData,
       relationOps,
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(enrichedData.id).toBe(1);
     expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
   });
 
-  it("oneToOne(ownsFk: false) + delete: true は素通りし親の field が保たれる", () => {
+  it("oneToOne + delete: true は素通りし親の field が保たれる", () => {
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("profile", { delete: true });
 
@@ -263,7 +262,7 @@ describe("processBeforeUpdate", () => {
       { id: 1, name: "田中" },
       enrichedData,
       relationOps,
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(mockDeleteManyOnSheet).not.toHaveBeenCalled();

--- a/src/__test__/util/update/nestedWrite/processOneToOneUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/processOneToOneUpdate.test.ts
@@ -1,11 +1,11 @@
-import { processOneToOneNonFkUpdate } from "../../../../util/update/nestedWrite/processOneToOneNonFkUpdate";
+import { processOneToOneUpdate } from "../../../../util/update/nestedWrite/processOneToOneUpdate";
 import type {
   RelationDefinition,
   RelationContext,
 } from "../../../../types/relationTypes";
 import type { NestedWriteOperation } from "../../../../types/nestedWriteTypes";
 
-describe("processOneToOneNonFkUpdate", () => {
+describe("processOneToOneUpdate", () => {
   const mockFindMany = jest.fn();
   const mockUpdateManyOnSheet = jest.fn();
   const mockDeleteManyOnSheet = jest.fn();
@@ -25,12 +25,11 @@ describe("processOneToOneNonFkUpdate", () => {
     mockDeleteManyOnSheet.mockReset();
   });
 
-  const nonFkRelation: RelationDefinition = {
+  const oneToOneRelation: RelationDefinition = {
     type: "oneToOne",
     to: "Profiles",
     field: "id",
     reference: "userId",
-    ownsFk: false,
   };
 
   const makeOps = (op: NestedWriteOperation) => {
@@ -42,10 +41,10 @@ describe("processOneToOneNonFkUpdate", () => {
   it("update（裸 data）で相手行が更新される", () => {
     mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
 
-    processOneToOneNonFkUpdate(
+    processOneToOneUpdate(
       { id: 1, name: "田中" },
       makeOps({ update: { bio: "変更後" } }),
-      makeContext({ profile: nonFkRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(mockUpdateManyOnSheet).toHaveBeenCalledWith("Profiles", {
@@ -58,10 +57,10 @@ describe("processOneToOneNonFkUpdate", () => {
     mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
 
     expect(() =>
-      processOneToOneNonFkUpdate(
+      processOneToOneUpdate(
         { id: 1, name: "田中" },
         makeOps({ update: { bio: "変更後" } }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('Nested write update failed: no record found in "Profiles"');
   });
@@ -71,10 +70,10 @@ describe("processOneToOneNonFkUpdate", () => {
 
     let caught: unknown;
     try {
-      processOneToOneNonFkUpdate(
+      processOneToOneUpdate(
         { id: 1, name: "田中" },
         makeOps({ update: { bio: "変更後" } }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       );
     } catch (e) {
       caught = e;
@@ -86,10 +85,10 @@ describe("processOneToOneNonFkUpdate", () => {
   it("disconnect: true で相手の reference 列が null 化される", () => {
     mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
 
-    processOneToOneNonFkUpdate(
+    processOneToOneUpdate(
       { id: 1, name: "田中" },
       makeOps({ disconnect: true }),
-      makeContext({ profile: nonFkRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(mockUpdateManyOnSheet).toHaveBeenCalledWith("Profiles", {
@@ -102,20 +101,20 @@ describe("processOneToOneNonFkUpdate", () => {
     mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
 
     expect(() =>
-      processOneToOneNonFkUpdate(
+      processOneToOneUpdate(
         { id: 1, name: "田中" },
         makeOps({ disconnect: true }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).not.toThrow();
   });
 
   it("disconnect に true 以外を渡すとエラー", () => {
     expect(() =>
-      processOneToOneNonFkUpdate(
+      processOneToOneUpdate(
         { id: 1, name: "田中" },
         makeOps({ disconnect: { id: 5 } }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('operation "disconnect" is not valid');
   });
@@ -123,10 +122,10 @@ describe("processOneToOneNonFkUpdate", () => {
   it("delete: true で相手行が削除される", () => {
     mockDeleteManyOnSheet.mockReturnValue({ count: 1 });
 
-    processOneToOneNonFkUpdate(
+    processOneToOneUpdate(
       { id: 1, name: "田中" },
       makeOps({ delete: true }),
-      makeContext({ profile: nonFkRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(mockDeleteManyOnSheet).toHaveBeenCalledWith("Profiles", {
@@ -138,83 +137,66 @@ describe("processOneToOneNonFkUpdate", () => {
     mockDeleteManyOnSheet.mockReturnValue({ count: 0 });
 
     expect(() =>
-      processOneToOneNonFkUpdate(
+      processOneToOneUpdate(
         { id: 1, name: "田中" },
         makeOps({ delete: true }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('Nested write delete failed: no record found in "Profiles"');
   });
 
   it("delete に true 以外を渡すとエラー", () => {
     expect(() =>
-      processOneToOneNonFkUpdate(
+      processOneToOneUpdate(
         { id: 1, name: "田中" },
         makeOps({ delete: { id: 5 } }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('operation "delete" is not valid');
   });
 
   it("配列 update はエラー", () => {
     expect(() =>
-      processOneToOneNonFkUpdate(
+      processOneToOneUpdate(
         { id: 1, name: "田中" },
         makeOps({ update: [{ where: { id: 5 }, data: { bio: "a" } }] }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('operation "update" is not valid');
   });
 
   it("where/data 形式の update はエラー", () => {
     expect(() =>
-      processOneToOneNonFkUpdate(
+      processOneToOneUpdate(
         { id: 1, name: "田中" },
         makeOps({ update: { where: { id: 5 }, data: { bio: "a" } } }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('operation "update" is not valid');
   });
 
   it("set はエラー", () => {
     expect(() =>
-      processOneToOneNonFkUpdate(
+      processOneToOneUpdate(
         { id: 1, name: "田中" },
         makeOps({ set: [{ id: 5 }] }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('operation "set" is not valid');
   });
 
   it("deleteMany はエラー", () => {
     expect(() =>
-      processOneToOneNonFkUpdate(
+      processOneToOneUpdate(
         { id: 1, name: "田中" },
         makeOps({ deleteMany: { id: 5 } }),
-        makeContext({ profile: nonFkRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('operation "deleteMany" is not valid');
   });
 
-  it("ownsFk 未指定の oneToOne は無視される", () => {
-    processOneToOneNonFkUpdate(
-      { id: 1, name: "田中" },
-      makeOps({ update: { bio: "変更後" } }),
-      makeContext({
-        profile: {
-          type: "oneToOne",
-          to: "Profiles",
-          field: "profileId",
-          reference: "id",
-        },
-      }),
-    );
-
-    expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
-  });
-
   it("manyToOne は無視される", () => {
-    processOneToOneNonFkUpdate(
+    processOneToOneUpdate(
       { id: 1, title: "記事A", authorId: 5 },
       makeOps({ update: { name: "変更後" } }),
       makeContext({
@@ -223,7 +205,6 @@ describe("processOneToOneNonFkUpdate", () => {
           to: "Users",
           field: "authorId",
           reference: "id",
-          ownsFk: true,
         },
       }),
     );
@@ -232,10 +213,10 @@ describe("processOneToOneNonFkUpdate", () => {
   });
 
   it("親の field 値が欠落している場合はスキップ", () => {
-    processOneToOneNonFkUpdate(
+    processOneToOneUpdate(
       { name: "田中" },
       makeOps({ delete: true }),
-      makeContext({ profile: nonFkRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(mockDeleteManyOnSheet).not.toHaveBeenCalled();

--- a/src/__test__/util/update/nestedWrite/resolveNestedUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/resolveNestedUpdate.test.ts
@@ -328,15 +328,14 @@ describe("resolveNestedUpdate", () => {
     ).toThrow("Cannot use nested write");
   });
 
-  const nonFkOneToOneRelation: RelationDefinition = {
+  const oneToOneRelation: RelationDefinition = {
     type: "oneToOne",
     to: "Profiles",
     field: "id",
     reference: "userId",
-    ownsFk: false,
   };
 
-  it("oneToOne(ownsFk: false) + update の統合テスト（親 id 無傷）", () => {
+  it("oneToOne + update の統合テスト（親 id 無傷）", () => {
     const util = setupSheet(["id", "name"], [[1, "田中"]]);
     mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
 
@@ -346,7 +345,7 @@ describe("resolveNestedUpdate", () => {
         where: { id: 1 },
         data: { profile: { update: { bio: "変更後" } } },
       },
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(result).toEqual({ id: 1, name: "田中" });
@@ -356,7 +355,7 @@ describe("resolveNestedUpdate", () => {
     });
   });
 
-  it("oneToOne(ownsFk: false) + update で相手不在ならエラー", () => {
+  it("oneToOne + update で相手不在ならエラー", () => {
     const util = setupSheet(["id", "name"], [[1, "田中"]]);
     mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
 
@@ -367,12 +366,12 @@ describe("resolveNestedUpdate", () => {
           where: { id: 1 },
           data: { profile: { update: { bio: "変更後" } } },
         },
-        makeContext({ profile: nonFkOneToOneRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('Nested write update failed: no record found in "Profiles"');
   });
 
-  it("oneToOne(ownsFk: false) + disconnect: true の統合テスト（親 id は null 化されない）", () => {
+  it("oneToOne + disconnect: true の統合テスト（親 id は null 化されない）", () => {
     const util = setupSheet(["id", "name"], [[1, "田中"]]);
     mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
 
@@ -382,7 +381,7 @@ describe("resolveNestedUpdate", () => {
         where: { id: 1 },
         data: { profile: { disconnect: true } },
       },
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(result).toEqual({ id: 1, name: "田中" });
@@ -392,7 +391,7 @@ describe("resolveNestedUpdate", () => {
     });
   });
 
-  it("oneToOne(ownsFk: false) + delete: true の統合テスト（親 id 無傷）", () => {
+  it("oneToOne + delete: true の統合テスト（親 id 無傷）", () => {
     const util = setupSheet(["id", "name"], [[1, "田中"]]);
     mockDeleteManyOnSheet.mockReturnValue({ count: 1 });
 
@@ -402,7 +401,7 @@ describe("resolveNestedUpdate", () => {
         where: { id: 1 },
         data: { profile: { delete: true } },
       },
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(result).toEqual({ id: 1, name: "田中" });
@@ -411,7 +410,7 @@ describe("resolveNestedUpdate", () => {
     });
   });
 
-  it("oneToOne(ownsFk: false) + delete: true で相手不在ならエラー", () => {
+  it("oneToOne + delete: true で相手不在ならエラー", () => {
     const util = setupSheet(["id", "name"], [[1, "田中"]]);
     mockDeleteManyOnSheet.mockReturnValue({ count: 0 });
 
@@ -422,12 +421,12 @@ describe("resolveNestedUpdate", () => {
           where: { id: 1 },
           data: { profile: { delete: true } },
         },
-        makeContext({ profile: nonFkOneToOneRelation }),
+        makeContext({ profile: oneToOneRelation }),
       ),
     ).toThrow('Nested write delete failed: no record found in "Profiles"');
   });
 
-  it("oneToOne(ownsFk: false) + connect の統合テスト（置き換え）", () => {
+  it("oneToOne + connect の統合テスト（置き換え）", () => {
     const util = setupSheet(["id", "name"], [[1, "田中"]]);
     mockFindMany.mockReturnValue([{ id: 5, userId: 99 }]);
     mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
@@ -438,7 +437,7 @@ describe("resolveNestedUpdate", () => {
         where: { id: 1 },
         data: { profile: { connect: { id: 5 } } },
       },
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(result).toEqual({ id: 1, name: "田中" });
@@ -452,7 +451,7 @@ describe("resolveNestedUpdate", () => {
     });
   });
 
-  it("oneToOne(ownsFk: false) + connectOrCreate の統合テスト（不在時 create 相当）", () => {
+  it("oneToOne + connectOrCreate の統合テスト（不在時 create 相当）", () => {
     const util = setupSheet(["id", "name"], [[1, "田中"]]);
     mockFindMany.mockReturnValue([]);
     mockCreateOnSheet.mockReturnValue({ id: 10, bio: "自己紹介", userId: 1 });
@@ -467,7 +466,7 @@ describe("resolveNestedUpdate", () => {
           },
         },
       },
-      makeContext({ profile: nonFkOneToOneRelation }),
+      makeContext({ profile: oneToOneRelation }),
     );
 
     expect(result).toEqual({ id: 1, name: "田中" });
@@ -476,7 +475,7 @@ describe("resolveNestedUpdate", () => {
     });
   });
 
-  it("ownsFk 未指定の oneToOne は従来どおり before 段階で処理される", () => {
+  it("FK 保有側 1:1 は manyToOne として before 段階で処理される", () => {
     const util = setupSheet(["id", "name", "profileId"], [[1, "田中", 5]]);
     mockUpdateManyOnSheet.mockReturnValue({ count: 1 });
 
@@ -488,7 +487,7 @@ describe("resolveNestedUpdate", () => {
       },
       makeContext({
         profile: {
-          type: "oneToOne",
+          type: "manyToOne",
           to: "Profiles",
           field: "profileId",
           reference: "id",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -153,7 +153,6 @@ declare namespace Gassma {
     to: string;
     field: string;
     reference: string;
-    ownsFk?: boolean;
     through?: ManyToManyThrough;
     onDelete?: OnDeleteAction;
     onUpdate?: OnUpdateAction;

--- a/src/types/relationTypes.ts
+++ b/src/types/relationTypes.ts
@@ -25,7 +25,6 @@ type RelationDefinition = {
   to: string;
   field: string;
   reference: string;
-  ownsFk?: boolean;
   through?: ManyToManyThrough;
   onDelete?: OnDeleteAction;
   onUpdate?: OnUpdateAction;

--- a/src/util/create/nestedWrite/isNonFkOneToOne.ts
+++ b/src/util/create/nestedWrite/isNonFkOneToOne.ts
@@ -1,6 +1,0 @@
-import type { RelationDefinition } from "../../../types/relationTypes";
-
-const isNonFkOneToOne = (relation: RelationDefinition): boolean =>
-  relation.type === "oneToOne" && relation.ownsFk === false;
-
-export { isNonFkOneToOne };

--- a/src/util/create/nestedWrite/processBeforeCreate.ts
+++ b/src/util/create/nestedWrite/processBeforeCreate.ts
@@ -1,7 +1,6 @@
 import type { RelationContext } from "../../../types/relationTypes";
 import type { NestedWriteOperation } from "../../../types/nestedWriteTypes";
 import { NestedWriteConnectNotFoundError } from "../../../errors/relation/nestedWriteError";
-import { isNonFkOneToOne } from "./isNonFkOneToOne";
 
 const processBeforeCreate = (
   scalarData: Record<string, unknown>,
@@ -13,8 +12,7 @@ const processBeforeCreate = (
   relationOps.forEach((ops, relationName) => {
     const relation = context.relations[relationName];
     if (!relation) return;
-    if (relation.type !== "manyToOne" && relation.type !== "oneToOne") return;
-    if (isNonFkOneToOne(relation)) return;
+    if (relation.type !== "manyToOne") return;
 
     if (ops.connect) {
       const where = Array.isArray(ops.connect) ? ops.connect[0] : ops.connect;

--- a/src/util/create/nestedWrite/processOneToOne.ts
+++ b/src/util/create/nestedWrite/processOneToOne.ts
@@ -9,7 +9,6 @@ import {
   NestedWriteInvalidOperationError,
 } from "../../../errors/relation/nestedWriteError";
 import { isGassmaAny } from "../../relation/collectKeys";
-import { isNonFkOneToOne } from "./isNonFkOneToOne";
 
 const findInvalidOperation = (ops: NestedWriteOperation): string | null => {
   if (ops.createMany !== undefined) return "createMany";
@@ -49,7 +48,7 @@ const connectByWhere = (
   });
 };
 
-const processOneToOneNonFk = (
+const processOneToOne = (
   writtenRecord: Record<string, unknown>,
   relationOps: Map<string, NestedWriteOperation>,
   context: RelationContext,
@@ -57,7 +56,7 @@ const processOneToOneNonFk = (
   relationOps.forEach((ops, relationName) => {
     const relation = context.relations[relationName];
     if (!relation) return;
-    if (!isNonFkOneToOne(relation)) return;
+    if (relation.type !== "oneToOne") return;
 
     assertValidOps(relationName, relation, ops);
 
@@ -97,4 +96,4 @@ const processOneToOneNonFk = (
   });
 };
 
-export { processOneToOneNonFk };
+export { processOneToOne };

--- a/src/util/create/nestedWrite/resolveNestedCreate.ts
+++ b/src/util/create/nestedWrite/resolveNestedCreate.ts
@@ -6,7 +6,7 @@ import {
 } from "./extractRelationData";
 import { processBeforeCreate } from "./processBeforeCreate";
 import { processAfterCreate } from "./processAfterCreate";
-import { processOneToOneNonFk } from "./processOneToOneNonFk";
+import { processOneToOne } from "./processOneToOne";
 import { processManyToMany } from "./processManyToMany";
 
 const hasNestedWriteFields = (
@@ -46,7 +46,7 @@ const resolveNestedCreate = (
   const createdRecord = createFunc(enrichedData);
 
   processAfterCreate(createdRecord, relationOps, relationContext!);
-  processOneToOneNonFk(createdRecord, relationOps, relationContext!);
+  processOneToOne(createdRecord, relationOps, relationContext!);
   processManyToMany(createdRecord, relationOps, relationContext!);
 
   return createdRecord;

--- a/src/util/update/nestedWrite/processBeforeUpdate.ts
+++ b/src/util/update/nestedWrite/processBeforeUpdate.ts
@@ -3,7 +3,6 @@ import type { RelationContext } from "../../../types/relationTypes";
 import type { NestedWriteOperation } from "../../../types/nestedWriteTypes";
 import { NestedWriteInvalidOperationError } from "../../../errors/relation/nestedWriteError";
 import { isGassmaAny } from "../../relation/collectKeys";
-import { isNonFkOneToOne } from "../../create/nestedWrite/isNonFkOneToOne";
 
 const processBeforeUpdate = (
   currentRecord: Record<string, unknown>,
@@ -14,8 +13,7 @@ const processBeforeUpdate = (
   relationOps.forEach((ops, relationName) => {
     const relation = context.relations[relationName];
     if (!relation) return;
-    if (relation.type !== "manyToOne" && relation.type !== "oneToOne") return;
-    if (isNonFkOneToOne(relation)) return;
+    if (relation.type !== "manyToOne") return;
 
     const fkValue = currentRecord[relation.field];
     if (!isGassmaAny(fkValue)) return;

--- a/src/util/update/nestedWrite/processOneToOneUpdate.ts
+++ b/src/util/update/nestedWrite/processOneToOneUpdate.ts
@@ -6,7 +6,6 @@ import {
   NestedWriteTargetNotFoundError,
 } from "../../../errors/relation/nestedWriteError";
 import { isGassmaAny } from "../../relation/collectKeys";
-import { isNonFkOneToOne } from "../../create/nestedWrite/isNonFkOneToOne";
 
 const isBareUpdateData = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" &&
@@ -27,7 +26,7 @@ const findInvalidOperation = (ops: NestedWriteOperation): string | null => {
   return null;
 };
 
-const processOneToOneNonFkUpdate = (
+const processOneToOneUpdate = (
   updatedRecord: Record<string, unknown>,
   relationOps: Map<string, NestedWriteOperation>,
   context: RelationContext,
@@ -35,7 +34,7 @@ const processOneToOneNonFkUpdate = (
   relationOps.forEach((ops, relationName) => {
     const relation = context.relations[relationName];
     if (!relation) return;
-    if (!isNonFkOneToOne(relation)) return;
+    if (relation.type !== "oneToOne") return;
 
     const invalidOperation = findInvalidOperation(ops);
     if (invalidOperation !== null) {
@@ -78,4 +77,4 @@ const processOneToOneNonFkUpdate = (
   });
 };
 
-export { processOneToOneNonFkUpdate };
+export { processOneToOneUpdate };

--- a/src/util/update/nestedWrite/resolveNestedUpdate.ts
+++ b/src/util/update/nestedWrite/resolveNestedUpdate.ts
@@ -7,7 +7,7 @@ import { getWantUpdateIndex } from "../../core/getWantUpdateIndex";
 import { whereFilter } from "../../core/whereFilter";
 import { processBeforeCreate } from "../../create/nestedWrite/processBeforeCreate";
 import { processAfterCreate } from "../../create/nestedWrite/processAfterCreate";
-import { processOneToOneNonFk } from "../../create/nestedWrite/processOneToOneNonFk";
+import { processOneToOne } from "../../create/nestedWrite/processOneToOne";
 import { processManyToMany } from "../../create/nestedWrite/processManyToMany";
 import {
   extractRelationDataForUpdate,
@@ -15,7 +15,7 @@ import {
 } from "./extractRelationDataForUpdate";
 import { processBeforeUpdate } from "./processBeforeUpdate";
 import { processAfterUpdate } from "./processAfterUpdate";
-import { processOneToOneNonFkUpdate } from "./processOneToOneNonFkUpdate";
+import { processOneToOneUpdate } from "./processOneToOneUpdate";
 import { processManyToManyUpdate } from "./processManyToManyUpdate";
 import {
   isNumberOperation,
@@ -145,8 +145,8 @@ const resolveNestedUpdate = (
 
   processAfterCreate(updatedRecord, relationOps, relationContext!);
   processAfterUpdate(updatedRecord, relationOps, relationContext!);
-  processOneToOneNonFk(updatedRecord, relationOps, relationContext!);
-  processOneToOneNonFkUpdate(updatedRecord, relationOps, relationContext!);
+  processOneToOne(updatedRecord, relationOps, relationContext!);
+  processOneToOneUpdate(updatedRecord, relationOps, relationContext!);
   processManyToMany(updatedRecord, relationOps, relationContext!);
   processManyToManyUpdate(updatedRecord, relationOps, relationContext!);
 


### PR DESCRIPTION
## 概要

**`ownsFk` を完全削除**し、FK の保有をリレーション type そのもので表現する再定義リファクタです(未リリースにつき後方互換なし・承認済み)。

| type | 再定義後の意味 | semantics |
|---|---|---|
| `manyToOne` | **FK を自分が持つ側**(1:1 の `@relation(fields:...)` 側もこちら — 構造的には unique 制約付き many 側) | 従来の FK 側処理 |
| `oneToOne` | **1:1 の FK を持たない側専用** | #141 の子側 semantics を**無条件適用** |

`ownsFk` 未指定のレガシー分岐も削除され、`processBeforeCreate/Update` は manyToOne のみ・`processOneToOne(Update)` は oneToOne で無条件発動、と**コードが単純化**されました(`isNonFkOneToOne` はファイルごと削除)。

## 全数監査

本体 src の `"oneToOne"` 全出現箇所を監査済み(PR コミット参照): resolvers・`_count`・include・where リレーション is/isNot・orderBy・validation は方向非依存 or 元々 to-one 2種を同一処理のため、**FK側 1:1 を manyToOne に retype しても挙動同一**(retype したフィクスチャ + 不変の期待値でピン留め)。

**意図的な挙動差は2点のみ**(いずれも旧 quirk の解消・Prisma 整合方向):
- to-one への `_count` orderBy がエラー化(Prisma も非対応)
- 1:1 の FK 保有側に付けた onDelete/onUpdate は発火しなくなる(Prisma と逆方向に波及する quirk だった。cli は元々 inverse 側にのみ付与するため生成 client は非影響)

## テスト

- **105 suites / 1287 tests 全 green**、`tsc --noEmit` clean、biome clean。
- TDD 4サイクル(before ガード → after 無条件化 → 統合 → リネーム)。

## 互換性

旧 cli 生成 client(FK側 oneToOne + ownsFk)は本 PR 適用後の本体と**非互換**(未リリースのため許容)。**cli 側の対応 PR(gassma-cli #102)とセットでマージし、gassma-test は再生成が必要**です。

## フォロー(別対応)

- reference: oneToOne の定義説明・nestedWrite の to-one 分離・onDelete 注記(リリース時、保持ブランチへ)
- 既存制限(今回未変更・別途相談): 非FK側 oneToOne の `is: null`(関連を持たない親の抽出)が Prisma と異なり不可

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja