### PR TITLE
feat: direct { relation: null } shorthand in where (Prisma parity)

### DIFF
--- a/src/__test__/util/relation/whereRelation/relationNullShorthand.test.ts
+++ b/src/__test__/util/relation/whereRelation/relationNullShorthand.test.ts
@@ -1,0 +1,149 @@
+import { resolveWhereRelation } from "../../../../util/relation/whereRelation/resolveWhereRelation";
+import type {
+  RelationDefinition,
+  RelationContext,
+} from "../../../../types/relationTypes";
+import type { WhereUse } from "../../../../types/coreTypes";
+
+describe("where 直値 null ショートハンド（resolveWhereRelation 単体）", () => {
+  const mockFindMany = jest.fn();
+
+  const relations: { [relationName: string]: RelationDefinition } = {
+    posts: {
+      type: "oneToMany",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+    },
+    author: {
+      type: "manyToOne",
+      to: "Users",
+      field: "authorId",
+      reference: "id",
+    },
+    profile: {
+      type: "oneToOne",
+      to: "Profiles",
+      field: "id",
+      reference: "userId",
+    },
+    tags: {
+      type: "manyToMany",
+      to: "Tags",
+      field: "id",
+      reference: "id",
+      through: {
+        sheet: "PostTags",
+        field: "postId",
+        reference: "tagId",
+      },
+    },
+  };
+
+  const context: RelationContext = {
+    relations,
+    findManyOnSheet: mockFindMany,
+  };
+
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  it("manyToOne の直値 null は is: null と同義（FK が null）", () => {
+    const where: WhereUse = { author: null };
+
+    const result = resolveWhereRelation(where, context);
+
+    expect(result).toEqual({ AND: [{ authorId: null }] });
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("oneToOne(非FK側)の直値 null は is: null と同義（reference 値の notIn）", () => {
+    const where: WhereUse = { profile: null };
+
+    mockFindMany.mockReturnValue([
+      { id: 301, userId: 1 },
+      { id: 302, userId: 2 },
+    ]);
+
+    const result = resolveWhereRelation(where, context);
+
+    expect(result).toEqual({ AND: [{ id: { notIn: [1, 2] } }] });
+    expect(mockFindMany).toHaveBeenCalledWith("Profiles", { where: {} });
+  });
+
+  it("通常条件と直値 null を組み合わせられる", () => {
+    const where: WhereUse = { name: "Alice", author: null };
+
+    const result = resolveWhereRelation(where, context);
+
+    expect(result).toEqual({ AND: [{ name: "Alice" }, { authorId: null }] });
+  });
+
+  it("oneToMany への直値 null はエラーを投げる", () => {
+    const where: WhereUse = { posts: null };
+
+    expect(() => resolveWhereRelation(where, context)).toThrow(
+      'Filter "null" cannot be used on relation "posts" of type "oneToMany"',
+    );
+  });
+
+  it("manyToMany への直値 null はエラーを投げる", () => {
+    const where: WhereUse = { tags: null };
+
+    expect(() => resolveWhereRelation(where, context)).toThrow(
+      'Filter "null" cannot be used on relation "tags" of type "manyToMany"',
+    );
+  });
+
+  it("AND 内の直値 null を解決する", () => {
+    const where: WhereUse = { AND: [{ author: null }] };
+
+    const result = resolveWhereRelation(where, context);
+
+    expect(result).toEqual({ AND: [{ AND: [{ authorId: null }] }] });
+  });
+
+  it("OR 内の直値 null を解決する", () => {
+    const where: WhereUse = { OR: [{ author: null }, { name: "Alice" }] };
+
+    const result = resolveWhereRelation(where, context);
+
+    expect(result).toEqual({
+      OR: [{ AND: [{ authorId: null }] }, { name: "Alice" }],
+    });
+  });
+
+  it("NOT 内の直値 null を解決する", () => {
+    const where: WhereUse = { NOT: { author: null } };
+
+    const result = resolveWhereRelation(where, context);
+
+    expect(result).toEqual({ NOT: { AND: [{ authorId: null }] } });
+  });
+
+  it("AND 内の list リレーション直値 null もエラーを投げる", () => {
+    const where: WhereUse = { AND: [{ posts: null }] };
+
+    expect(() => resolveWhereRelation(where, context)).toThrow(
+      'Filter "null" cannot be used on relation "posts" of type "oneToMany"',
+    );
+  });
+
+  it("リレーション名でないキーの null は通常条件のまま扱う", () => {
+    const where: WhereUse = { deletedAt: null };
+
+    const result = resolveWhereRelation(where, context);
+
+    expect(result).toEqual({ deletedAt: null });
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("relationContext が null の場合は直値 null を素通しする", () => {
+    const where: WhereUse = { profile: null };
+
+    const result = resolveWhereRelation(where, null);
+
+    expect(result).toEqual({ profile: null });
+  });
+});

--- a/src/__test__/util/relation/whereRelation/relationNullShorthandIntegration.test.ts
+++ b/src/__test__/util/relation/whereRelation/relationNullShorthandIntegration.test.ts
@@ -1,0 +1,192 @@
+import { GassmaClient } from "../../../../gassma";
+import type { GassmaController } from "../../../../gassmaController";
+import type { RelationsConfig } from "../../../../types/relationTypes";
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => { getValues: () => unknown[][] };
+  getDataRange: () => { getValues: () => unknown[][] };
+};
+
+const makeSheet = (name: string, data: unknown[][]): MockSheet => ({
+  getName: () => name,
+  getLastRow: () => data.length,
+  getLastColumn: () => data[0].length,
+  getRange: (row, col, numRows, numCols) => ({
+    getValues: () =>
+      data
+        .slice(row - 1, row - 1 + numRows)
+        .map((r) => r.slice(col - 1, col - 1 + numCols)),
+  }),
+  getDataRange: () => ({ getValues: () => data }),
+});
+
+const sheets = [
+  makeSheet("Users", [
+    ["id", "name"],
+    [1, "Alice"],
+    [2, "Bob"],
+    [3, "Carol"],
+  ]),
+  makeSheet("Profiles", [
+    ["id", "userId", "bio"],
+    [301, 1, "Alice bio"],
+    [302, 2, "Bob bio"],
+    [303, "", "orphan bio"],
+  ]),
+  makeSheet("Posts", [
+    ["id", "authorId", "title"],
+    [401, 1, "Alice post"],
+  ]),
+];
+
+const mockSpreadsheet = {
+  getId: () => "test-spreadsheet",
+  getSheets: () => sheets,
+  getSheetByName: (name: string) =>
+    sheets.find((sheet) => sheet.getName() === name) ?? null,
+};
+
+const relations: RelationsConfig = {
+  Users: {
+    profile: {
+      type: "oneToOne",
+      to: "Profiles",
+      field: "id",
+      reference: "userId",
+    },
+    posts: {
+      type: "oneToMany",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+    },
+  },
+  Profiles: {
+    user: {
+      type: "manyToOne",
+      to: "Users",
+      field: "userId",
+      reference: "id",
+    },
+  },
+};
+
+const isGassmaController = (value: unknown): value is GassmaController =>
+  typeof value === "object" &&
+  value !== null &&
+  "findMany" in value &&
+  typeof value.findMany === "function";
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!isGassmaController(controller)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+describe("where 直値 null ショートハンド（統合）", () => {
+  let client: GassmaClient;
+
+  beforeAll(() => {
+    Object.assign(globalThis, {
+      SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+    });
+    client = new GassmaClient({ relations });
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, { SpreadsheetApp: undefined });
+  });
+
+  describe("oneToOne（非FK側）", () => {
+    it("直値 null は is: null と同じ結果を返す", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { profile: null },
+      });
+
+      expect(result).toEqual([{ id: 3, name: "Carol" }]);
+    });
+
+    it("通常条件と組み合わせられる", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { name: "Carol", profile: null },
+      });
+
+      expect(result).toEqual([{ id: 3, name: "Carol" }]);
+    });
+
+    it("AND 内で機能する", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { AND: [{ profile: null }] },
+      });
+
+      expect(result).toEqual([{ id: 3, name: "Carol" }]);
+    });
+
+    it("OR 内で機能する", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { OR: [{ profile: null }, { name: "Alice" }] },
+      });
+
+      expect(result).toEqual([
+        { id: 3, name: "Carol" },
+        { id: 1, name: "Alice" },
+      ]);
+    });
+
+    it("NOT 内で機能する（関連を持つ親のみ返る）", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { NOT: { profile: null } },
+      });
+
+      expect(result).toEqual([
+        { id: 1, name: "Alice" },
+        { id: 2, name: "Bob" },
+      ]);
+    });
+  });
+
+  describe("manyToOne（FK側）", () => {
+    it("直値 null は FK が null の行を返す", () => {
+      const result = sheetOf(client, "Profiles").findMany({
+        where: { user: null },
+      });
+
+      expect(result).toEqual([{ id: 303, userId: null, bio: "orphan bio" }]);
+    });
+
+    it("NOT 内で機能する（FK が null でない行を返す）", () => {
+      const result = sheetOf(client, "Profiles").findMany({
+        where: { NOT: { user: null } },
+      });
+
+      expect(result).toEqual([
+        { id: 301, userId: 1, bio: "Alice bio" },
+        { id: 302, userId: 2, bio: "Bob bio" },
+      ]);
+    });
+  });
+
+  describe("list リレーション", () => {
+    it("oneToMany への直値 null はエラーを投げる", () => {
+      expect(() =>
+        sheetOf(client, "Users").findMany({ where: { posts: null } }),
+      ).toThrow(
+        'Filter "null" cannot be used on relation "posts" of type "oneToMany"',
+      );
+    });
+  });
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -104,6 +104,7 @@ declare namespace Gassma {
   type WhereUse = {
     [key: string]:
       | GassmaAny
+      | null
       | FilterConditions
       | WhereUse[]
       | WhereUse

--- a/src/types/relationTypes.ts
+++ b/src/types/relationTypes.ts
@@ -138,7 +138,7 @@ type RelationSingleFilter = {
   isNot?: WhereUse | null;
 };
 
-type WhereRelationFilter = RelationListFilter | RelationSingleFilter;
+type WhereRelationFilter = RelationListFilter | RelationSingleFilter | null;
 
 export type {
   RelationType,

--- a/src/util/relation/whereRelation/filters/dispatchFilter.ts
+++ b/src/util/relation/whereRelation/filters/dispatchFilter.ts
@@ -1,0 +1,99 @@
+import type { RelationDefinition } from "../../../../types/relationTypes";
+import type { WhereUse } from "../../../../types/coreTypes";
+import { WhereRelationInvalidFilterError } from "../../../../errors/relation/whereRelationError";
+import { applySomeFilter } from "./someFilter";
+import { applyNoneFilter } from "./noneFilter";
+import { applyEveryFilter } from "./everyFilter";
+import { applyIsFilter } from "./isFilter";
+import { applyIsNotFilter } from "./isNotFilter";
+
+type FindManyOnSheet = (
+  sheetName: string,
+  findData: { where?: WhereUse },
+) => Record<string, unknown>[];
+
+const LIST_FILTER_SET = new Set(["some", "every", "none"]);
+const SINGLE_FILTER_SET = new Set(["is", "isNot"]);
+const LIST_RELATION_TYPES = new Set(["oneToMany", "manyToMany"]);
+const SINGLE_RELATION_TYPES = new Set(["oneToOne", "manyToOne"]);
+
+const isFilterKey = (k: string): boolean =>
+  LIST_FILTER_SET.has(k) || SINGLE_FILTER_SET.has(k);
+
+const validateFilterType = (
+  relation: RelationDefinition,
+  relationName: string,
+  filterKey: string,
+): void => {
+  if (
+    LIST_FILTER_SET.has(filterKey) &&
+    !LIST_RELATION_TYPES.has(relation.type)
+  ) {
+    throw new WhereRelationInvalidFilterError(
+      relationName,
+      relation.type,
+      filterKey,
+    );
+  }
+  if (
+    SINGLE_FILTER_SET.has(filterKey) &&
+    !SINGLE_RELATION_TYPES.has(relation.type)
+  ) {
+    throw new WhereRelationInvalidFilterError(
+      relationName,
+      relation.type,
+      filterKey,
+    );
+  }
+};
+
+const dispatchFilter = (
+  relation: RelationDefinition,
+  relationName: string,
+  filterKey: string,
+  filterValue: WhereUse | null,
+  findManyOnSheet: FindManyOnSheet,
+): WhereUse => {
+  if (filterKey === "some") {
+    return applySomeFilter(
+      relation,
+      relationName,
+      filterValue!,
+      findManyOnSheet,
+    );
+  }
+  if (filterKey === "every") {
+    return applyEveryFilter(
+      relation,
+      relationName,
+      filterValue!,
+      findManyOnSheet,
+    );
+  }
+  if (filterKey === "none") {
+    return applyNoneFilter(
+      relation,
+      relationName,
+      filterValue!,
+      findManyOnSheet,
+    );
+  }
+  if (filterKey === "is") {
+    return applyIsFilter(relation, relationName, filterValue, findManyOnSheet);
+  }
+  if (filterKey === "isNot") {
+    return applyIsNotFilter(
+      relation,
+      relationName,
+      filterValue,
+      findManyOnSheet,
+    );
+  }
+  throw new WhereRelationInvalidFilterError(
+    relationName,
+    relation.type,
+    filterKey,
+  );
+};
+
+export { isFilterKey, validateFilterType, dispatchFilter };

--- a/src/util/relation/whereRelation/filters/nullShorthandFilter.ts
+++ b/src/util/relation/whereRelation/filters/nullShorthandFilter.ts
@@ -1,0 +1,26 @@
+import type { RelationDefinition } from "../../../../types/relationTypes";
+import type { WhereUse } from "../../../../types/coreTypes";
+import { WhereRelationInvalidFilterError } from "../../../../errors/relation/whereRelationError";
+import { applyIsFilter } from "./isFilter";
+
+type FindManyOnSheet = (
+  sheetName: string,
+  findData: { where?: WhereUse },
+) => Record<string, unknown>[];
+
+const applyNullShorthand = (
+  relation: RelationDefinition,
+  relationName: string,
+  findManyOnSheet: FindManyOnSheet,
+): WhereUse => {
+  if (relation.type === "oneToMany" || relation.type === "manyToMany") {
+    throw new WhereRelationInvalidFilterError(
+      relationName,
+      relation.type,
+      "null",
+    );
+  }
+  return applyIsFilter(relation, relationName, null, findManyOnSheet);
+};
+
+export { applyNullShorthand };

--- a/src/util/relation/whereRelation/resolveWhereRelation.ts
+++ b/src/util/relation/whereRelation/resolveWhereRelation.ts
@@ -3,30 +3,16 @@ import type {
   RelationDefinition,
 } from "../../../types/relationTypes";
 import type { WhereUse } from "../../../types/coreTypes";
-import {
-  WhereRelationInvalidFilterError,
-  WhereRelationWithoutContextError,
-} from "../../../errors/relation/whereRelationError";
+import { WhereRelationWithoutContextError } from "../../../errors/relation/whereRelationError";
 import { isDict } from "../../other/isDict";
-import { applySomeFilter } from "./filters/someFilter";
-import { applyNoneFilter } from "./filters/noneFilter";
-import { applyEveryFilter } from "./filters/everyFilter";
-import { applyIsFilter } from "./filters/isFilter";
-import { applyIsNotFilter } from "./filters/isNotFilter";
+import {
+  dispatchFilter,
+  isFilterKey,
+  validateFilterType,
+} from "./filters/dispatchFilter";
+import { applyNullShorthand } from "./filters/nullShorthandFilter";
 
-type FindManyOnSheet = (
-  sheetName: string,
-  findData: { where?: WhereUse },
-) => Record<string, unknown>[];
-
-const LIST_FILTER_SET = new Set(["some", "every", "none"]);
-const SINGLE_FILTER_SET = new Set(["is", "isNot"]);
-const LIST_RELATION_TYPES = new Set(["oneToMany", "manyToMany"]);
-const SINGLE_RELATION_TYPES = new Set(["oneToOne", "manyToOne"]);
 const LOGICAL_KEYS = new Set(["AND", "OR", "NOT"]);
-
-const isFilterKey = (k: string): boolean =>
-  LIST_FILTER_SET.has(k) || SINGLE_FILTER_SET.has(k);
 
 const toDict = (value: unknown): Record<string, unknown> | null => {
   if (isDict(value)) return value as Record<string, unknown>;
@@ -42,82 +28,6 @@ const isRelationFilter = (
   const dict = toDict(value);
   if (!dict) return false;
   return Object.keys(dict).some(isFilterKey);
-};
-
-const dispatchFilter = (
-  relation: RelationDefinition,
-  relationName: string,
-  filterKey: string,
-  filterValue: WhereUse | null,
-  findManyOnSheet: FindManyOnSheet,
-): WhereUse => {
-  if (filterKey === "some") {
-    return applySomeFilter(
-      relation,
-      relationName,
-      filterValue!,
-      findManyOnSheet,
-    );
-  }
-  if (filterKey === "every") {
-    return applyEveryFilter(
-      relation,
-      relationName,
-      filterValue!,
-      findManyOnSheet,
-    );
-  }
-  if (filterKey === "none") {
-    return applyNoneFilter(
-      relation,
-      relationName,
-      filterValue!,
-      findManyOnSheet,
-    );
-  }
-  if (filterKey === "is") {
-    return applyIsFilter(relation, relationName, filterValue, findManyOnSheet);
-  }
-  if (filterKey === "isNot") {
-    return applyIsNotFilter(
-      relation,
-      relationName,
-      filterValue,
-      findManyOnSheet,
-    );
-  }
-  throw new WhereRelationInvalidFilterError(
-    relationName,
-    relation.type,
-    filterKey,
-  );
-};
-
-const validateFilterType = (
-  relation: RelationDefinition,
-  relationName: string,
-  filterKey: string,
-): void => {
-  if (
-    LIST_FILTER_SET.has(filterKey) &&
-    !LIST_RELATION_TYPES.has(relation.type)
-  ) {
-    throw new WhereRelationInvalidFilterError(
-      relationName,
-      relation.type,
-      filterKey,
-    );
-  }
-  if (
-    SINGLE_FILTER_SET.has(filterKey) &&
-    !SINGLE_RELATION_TYPES.has(relation.type)
-  ) {
-    throw new WhereRelationInvalidFilterError(
-      relationName,
-      relation.type,
-      filterKey,
-    );
-  }
 };
 
 const resolveWhereRelation = (
@@ -138,6 +48,16 @@ const resolveWhereRelation = (
 
   Object.entries(where).forEach(([key, value]) => {
     if (LOGICAL_KEYS.has(key)) return;
+
+    if (value === null && key in context.relations) {
+      const resolved = applyNullShorthand(
+        context.relations[key],
+        key,
+        context.findManyOnSheet,
+      );
+      relationConditions.push(resolved);
+      return;
+    }
 
     if (!isRelationFilter(key, value, context.relations)) {
       normalConditions[key] = value;


### PR DESCRIPTION
## 概要

Prisma の where 省略記法 **`{ relation: null }`(= `is: null` と同義)** を実装しました。従来 gassma ではこの書き方が「未知カラム扱いで**黙って捨てられ全件返る**」という静かな罠でした(CLI なし利用者が踏み得る)。

## Prisma 実測(SQL レベル・m:n は一時モデルで実測しチェックサム一致で原状復元)

| ケース | 型 | 実行時 |
|---|---|---|
| 非FK側 1:1 / FK側 nullable の直値 null | OK | **`is: null` と生成 SQL 完全一致**(anti-join / FK IS NULL) |
| list(1:N / m:n)への null | 型エラー | `PrismaClientValidationError: Argument ... must not be null.` |
| AND/OR/NOT 内 | OK | 全て機能(`NOT: { profile: null }` = 関連あり) |
| isNot 側の直値ショートハンド | **存在しない**(`Unknown argument \`not\``) | → 実装せず |

## 実装

- `resolveWhereRelation`: 「relation 名キー & 値 === null」を to-one では **#144 の `applyIsFilter(null)` に委譲**(manyToOne → FK null / oneToOne → 相手 reference の notIn)。**「黙って全件」罠を閉塞**。AND/OR/NOT は既存再帰で自動対応。
- list リレーションへの null は既存 `WhereRelationInvalidFilterError`(filterType="null")で明確にエラー(Prisma の must-not-be-null に最も近い既存クラス・新クラス不要)。
- 非 relation キーの null(`{ num: null }` 等)・relations 未設定時は従来どおり通常カラム条件(後方互換)。
- 型: 公開 `WhereUse` の index signature に `| null` 追加(これが無いと直値 null が型として書けなかった)。200行制限対応で dispatchFilter 等を**無改変で**ファイル分離。

## テスト(TDD: Red 16件実測 → Green)

+19件(単体11 + 実シートモック統合8: `is: null` 同結果・FK IS NULL・AND/OR/NOT・list エラー・非 relation キー素通し・context null 素通し)。**111 suites / 1353 tests 全 green**、`tsc --noEmit` clean、biome 新規違反ゼロ。

## cli 側(後続 PR・セットでマージ)

生成 WhereUse の to-one relation キーに `| null` を追加。**Prisma との意図的差異**: Prisma は required to-one に null を許さないが、gassma は全 to-one に付与 — 既存の `is?: ... | null` が全 to-one に付く型サーフェスと一貫し、かつ**シートには required 制約の実体が無く空 FK セルは実在し得る**ため(不整合行の検索に有用)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja