### PR TITLE
fix: changeSettings column letters use true base-26 (BA and beyond were wrong)

### DIFF
--- a/src/__test__/util/changeSettings/changeSettings.test.ts
+++ b/src/__test__/util/changeSettings/changeSettings.test.ts
@@ -1,0 +1,24 @@
+import { changeSettingsFunc } from "../../../util/changeSettings/changeSettings";
+
+describe("changeSettingsFunc", () => {
+  test("should keep numbers as-is", () => {
+    expect(changeSettingsFunc(2, 5)).toEqual({
+      startColumnNumber: 2,
+      endColumnNumber: 5,
+    });
+  });
+
+  test("should convert single letter columns", () => {
+    expect(changeSettingsFunc("A", "Z")).toEqual({
+      startColumnNumber: 1,
+      endColumnNumber: 26,
+    });
+  });
+
+  test("should convert two letter columns beyond AZ", () => {
+    expect(changeSettingsFunc("AA", "BA")).toEqual({
+      startColumnNumber: 27,
+      endColumnNumber: 53,
+    });
+  });
+});

--- a/src/__test__/util/changeSettings/convertToNumber.test.ts
+++ b/src/__test__/util/changeSettings/convertToNumber.test.ts
@@ -1,0 +1,49 @@
+import { convertToNumber } from "../../../util/changeSettings/changeSettingsUtil/convertToNumber";
+
+const invalidColumnValueMessage =
+  "startColumnValue and endColumnValue can only use number, [a-z] and [A-Z].";
+
+describe("convertToNumber", () => {
+  test("should return the number as-is", () => {
+    expect(convertToNumber(1)).toBe(1);
+    expect(convertToNumber(100)).toBe(100);
+  });
+
+  test("should convert single letters", () => {
+    expect(convertToNumber("A")).toBe(1);
+    expect(convertToNumber("B")).toBe(2);
+    expect(convertToNumber("Z")).toBe(26);
+  });
+
+  test("should convert two letters starting with A", () => {
+    expect(convertToNumber("AA")).toBe(27);
+    expect(convertToNumber("AB")).toBe(28);
+    expect(convertToNumber("AZ")).toBe(52);
+  });
+
+  test("should convert two letters beyond AZ", () => {
+    expect(convertToNumber("BA")).toBe(53);
+    expect(convertToNumber("BZ")).toBe(78);
+    expect(convertToNumber("ZA")).toBe(677);
+    expect(convertToNumber("ZZ")).toBe(702);
+  });
+
+  test("should convert three letters", () => {
+    expect(convertToNumber("AAA")).toBe(703);
+    expect(convertToNumber("AAB")).toBe(704);
+    expect(convertToNumber("ABA")).toBe(729);
+  });
+
+  test("should normalize lowercase letters", () => {
+    expect(convertToNumber("a")).toBe(1);
+    expect(convertToNumber("ba")).toBe(53);
+    expect(convertToNumber("Ba")).toBe(53);
+  });
+
+  test("should throw for invalid strings", () => {
+    expect(() => convertToNumber("")).toThrow(invalidColumnValueMessage);
+    expect(() => convertToNumber("A1")).toThrow(invalidColumnValueMessage);
+    expect(() => convertToNumber("1A")).toThrow(invalidColumnValueMessage);
+    expect(() => convertToNumber("A B")).toThrow(invalidColumnValueMessage);
+  });
+});

--- a/src/util/changeSettings/changeSettingsUtil/convertToNumber.ts
+++ b/src/util/changeSettings/changeSettingsUtil/convertToNumber.ts
@@ -9,11 +9,9 @@ const convertToNumber = (ColumnValue: number | string) => {
   const upperAlphabets = ColumnValue.toUpperCase();
   const alphabetsList = upperAlphabets.split("");
 
-  const resultNumber = alphabetsList.reduce((pre, alphabet, index) => {
+  const resultNumber = alphabetsList.reduce((pre, alphabet) => {
     const alphabetNum = alphabet.codePointAt(0) - 64;
-    if (index === 0) return pre + alphabetNum;
-
-    return pre + alphabetNum + 25;
+    return pre * 26 + alphabetNum;
   }, 0);
 
   return resultNumber;


### PR DESCRIPTION
## 概要

型/実装乖離シリーズ **件3**: `changeSettings` の英字列指定の変換(`convertToNumber`)が誤った式(`index===0 ? pre+n : pre+n+25`)で、**"BA" 以降と3文字以上がすべてズレる**バグの修正です。

| 入力 | 旧 | 正(A1 記法) |
|---|---|---|
| A〜Z / AA〜AZ | 正しい(偶然一致) | 同左 |
| **BA** | 28 | **53** |
| ZZ | 77 | 702 |
| AAA | 53 | 703 |

## 修正

正しい26進位取り(`pre * 26 + n`)に置換。小文字は既存の `toUpperCase` 正規化を踏襲。`getRange`(1-based)との整合も確認済み。

## テスト(TDD: Red 4件実測 → Green)

`convertToNumber` は**単体テストゼロ**だったため新設(BA=53 / ZZ=702 / AAA=703 / 小文字 / 不正文字列エラー等 7件)+ changeSettingsFunc 統合3件(2文字列含む)。**113 suites / 1363 tests 全 green**、tsc clean、biome clean。

## スコープ外(報告のみ)

- 公開型の `changeSettings` が number のみ(実装は string 可)の是正は仕様判断のため未変更。
- gassma-test の実機テストは BA=53列以上のシートが必要(3点セット追加が要る)ため別途。
- 副次発見: ES5 target のためエラークラスの prototype チェーンが壊れており `toThrow(コンストラクタ)` が効かない(既存全エラー共通・メッセージ照合で代替中)。

並行の件1/2/4 とファイル重複なし・マージ順不同可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja