### PR TITLE
fix: upsert create path applies autoincrement (deferred, create-only)

### DIFF
--- a/src/__test__/util/upsert/upsertAutoincrement.test.ts
+++ b/src/__test__/util/upsert/upsertAutoincrement.test.ts
@@ -1,0 +1,269 @@
+import { GassmaController } from "../../../gassmaController";
+import { upsertFunc } from "../../../util/upsert/upsert";
+import { getMutableMockControllerUtil } from "../../consts/mockControllerUtil";
+
+describe("upsertFunc の prepareCreate", () => {
+  let mockUtil: ReturnType<typeof getMutableMockControllerUtil>;
+
+  beforeEach(() => {
+    mockUtil = getMutableMockControllerUtil();
+    mockUtil.sheet._resetMockData();
+  });
+
+  test("create 分岐では prepareCreate が create データに適用される", () => {
+    const prepareCreate = jest.fn((data: Record<string, unknown>) => ({
+      ...data,
+      職業: "Prepared",
+    }));
+    const result = upsertFunc(
+      mockUtil,
+      {
+        where: { 名前: "NewPerson" },
+        create: {
+          名前: "NewPerson",
+          年齢: 40,
+          住所: "Fukuoka",
+          郵便番号: "810-0001",
+          職業: "Artist",
+        },
+        update: { 職業: "Updated Artist" },
+      },
+      null,
+      prepareCreate,
+    );
+
+    expect(prepareCreate).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      名前: "NewPerson",
+      年齢: 40,
+      住所: "Fukuoka",
+      郵便番号: "810-0001",
+      職業: "Prepared",
+    });
+  });
+
+  test("update 分岐では prepareCreate が呼ばれない", () => {
+    const prepareCreate = jest.fn((data: Record<string, unknown>) => data);
+    upsertFunc(
+      mockUtil,
+      {
+        where: { 名前: "Alice" },
+        create: {
+          名前: "Alice",
+          年齢: 28,
+          住所: "Tokyo",
+          郵便番号: "100-0001",
+          職業: "Engineer",
+        },
+        update: { 職業: "Tech Lead" },
+      },
+      null,
+      prepareCreate,
+    );
+
+    expect(prepareCreate).not.toHaveBeenCalled();
+  });
+
+  test("prepareCreate 未指定なら create データがそのまま使われる", () => {
+    const result = upsertFunc(mockUtil, {
+      where: { 名前: "NewPerson" },
+      create: {
+        名前: "NewPerson",
+        年齢: 40,
+        住所: "Fukuoka",
+        郵便番号: "810-0001",
+        職業: "Artist",
+      },
+      update: { 職業: "Updated Artist" },
+    });
+
+    expect(result).toEqual({
+      名前: "NewPerson",
+      年齢: 40,
+      住所: "Fukuoka",
+      郵便番号: "810-0001",
+      職業: "Artist",
+    });
+  });
+});
+
+type MockRange = {
+  getValues: () => unknown[][];
+  setValues: (values: unknown[][]) => void;
+};
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => MockRange;
+  getDataRange: () => { getValues: () => unknown[][] };
+  deleteRow: (rowIndex: number) => void;
+};
+
+const makeSheet = (name: string, initial: unknown[][]): MockSheet => {
+  const data = initial.map((row) => [...row]);
+  return {
+    getName: () => name,
+    getLastRow: () => data.length,
+    getLastColumn: () => data[0].length,
+    getRange: (row, col, numRows, numCols) => ({
+      getValues: () =>
+        data
+          .slice(row - 1, row - 1 + numRows)
+          .map((r) => r.slice(col - 1, col - 1 + numCols)),
+      setValues: (values) => {
+        values.forEach((rowValues, i) => {
+          while (data.length < row + i) {
+            data.push(Array(data[0].length).fill(""));
+          }
+          rowValues.forEach((value, j) => {
+            data[row - 1 + i][col - 1 + j] = value;
+          });
+        });
+      },
+    }),
+    getDataRange: () => ({ getValues: () => data }),
+    deleteRow: (rowIndex) => {
+      data.splice(rowIndex - 1, 1);
+    },
+  };
+};
+
+const COUNTER_KEY = "gassma_autoincrement_test-ss_Users_id";
+
+describe("GassmaController.upsert の autoincrement", () => {
+  const mockWaitLock = jest.fn();
+  const mockReleaseLock = jest.fn();
+  let propsStore: Record<string, string>;
+  const mockGetProperty = jest.fn(
+    (key: string): string | null => propsStore[key] ?? null,
+  );
+  const mockSetProperty = jest.fn((key: string, value: string) => {
+    propsStore[key] = value;
+  });
+
+  const buildController = (withAutoincrement: boolean): GassmaController => {
+    const sheet = makeSheet("Users", [
+      ["id", "name", "job"],
+      [1, "Alice", "Engineer"],
+    ]);
+    const mockSpreadsheet = {
+      getId: () => "test-ss",
+      getSheets: () => [sheet],
+      getSheetByName: (n: string) => (n === "Users" ? sheet : null),
+    };
+    Object.assign(globalThis, {
+      SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+    });
+    const controller = new GassmaController("Users");
+    if (withAutoincrement) controller._setAutoincrement(["id"]);
+    return controller;
+  };
+
+  beforeEach(() => {
+    propsStore = { [COUNTER_KEY]: "1" };
+    Object.assign(globalThis, {
+      LockService: {
+        getScriptLock: () => ({
+          waitLock: mockWaitLock,
+          releaseLock: mockReleaseLock,
+        }),
+      },
+      PropertiesService: {
+        getScriptProperties: () => ({
+          getProperty: mockGetProperty,
+          setProperty: mockSetProperty,
+        }),
+      },
+    });
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, {
+      SpreadsheetApp: undefined,
+      LockService: undefined,
+      PropertiesService: undefined,
+    });
+  });
+
+  test("create 経路で autoincrement 列が採番される", () => {
+    const controller = buildController(true);
+    const result = controller.upsert({
+      where: { name: "Bob" },
+      create: { name: "Bob", job: "Designer" },
+      update: { job: "Never" },
+    });
+    expect(result).toEqual({ id: 2, name: "Bob", job: "Designer" });
+    expect(propsStore[COUNTER_KEY]).toBe("2");
+  });
+
+  test("採番された値がシートに書き込まれる", () => {
+    const controller = buildController(true);
+    controller.upsert({
+      where: { name: "Bob" },
+      create: { name: "Bob", job: "Designer" },
+      update: { job: "Never" },
+    });
+    const found = controller.findMany({ where: { name: "Bob" } });
+    expect(found).toEqual([{ id: 2, name: "Bob", job: "Designer" }]);
+  });
+
+  test("create 経路が連続するとカウンタが進む", () => {
+    const controller = buildController(true);
+    controller.upsert({
+      where: { name: "Bob" },
+      create: { name: "Bob", job: "Designer" },
+      update: { job: "Never" },
+    });
+    const second = controller.upsert({
+      where: { name: "Carol" },
+      create: { name: "Carol", job: "PM" },
+      update: { job: "Never" },
+    });
+    expect(second).toEqual({ id: 3, name: "Carol", job: "PM" });
+    expect(propsStore[COUNTER_KEY]).toBe("3");
+  });
+
+  test("create に明示値がある列は採番値で上書きしない", () => {
+    const controller = buildController(true);
+    const result = controller.upsert({
+      where: { name: "Carol" },
+      create: { id: 100, name: "Carol", job: "PM" },
+      update: { job: "Never" },
+    });
+    expect(result).toEqual({ id: 100, name: "Carol", job: "PM" });
+  });
+
+  test("update 経路では採番されず Lock/Properties にも触れない", () => {
+    const controller = buildController(true);
+    const result = controller.upsert({
+      where: { name: "Alice" },
+      create: { name: "Alice", job: "Never" },
+      update: { job: "Tech Lead" },
+    });
+    expect(result).toEqual({ id: 1, name: "Alice", job: "Tech Lead" });
+    expect(mockWaitLock).not.toHaveBeenCalled();
+    expect(mockGetProperty).not.toHaveBeenCalled();
+    expect(mockSetProperty).not.toHaveBeenCalled();
+    expect(propsStore[COUNTER_KEY]).toBe("1");
+  });
+
+  test("autoincrement 未設定なら create 経路でも Lock/Properties に触れない", () => {
+    const controller = buildController(false);
+    const result = controller.upsert({
+      where: { name: "Bob" },
+      create: { id: 9, name: "Bob", job: "Designer" },
+      update: { job: "Never" },
+    });
+    expect(result).toEqual({ id: 9, name: "Bob", job: "Designer" });
+    expect(mockWaitLock).not.toHaveBeenCalled();
+    expect(mockGetProperty).not.toHaveBeenCalled();
+    expect(mockSetProperty).not.toHaveBeenCalled();
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -925,6 +925,7 @@ class GassmaController {
         omit: upsertOmitWithIgnore,
       },
       this.relationContext,
+      (data) => this.applyAutoincrementToData(data),
     );
   }
 

--- a/src/util/upsert/upsert.ts
+++ b/src/util/upsert/upsert.ts
@@ -37,6 +37,7 @@ const upsertFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
   upsertData: UpsertSingleData,
   relationContext?: RelationContext | null,
+  prepareCreate?: (data: Record<string, unknown>) => Record<string, unknown>,
 ): Record<string, unknown> => {
   const record = findFirstFunc(gassmaControllerUtil, {
     where: upsertData.where,
@@ -45,8 +46,11 @@ const upsertFunc = (
   if (!record) {
     const wrappedCreate = (data: Record<string, unknown>) =>
       createFunc(gassmaControllerUtil, { data: data as AnyUse });
+    const createData = prepareCreate
+      ? prepareCreate(upsertData.create)
+      : upsertData.create;
     const created = resolveNestedCreate(
-      upsertData.create,
+      createData,
       wrappedCreate,
       relationContext ?? undefined,
     );


### PR DESCRIPTION
## 概要

型/実装乖離シリーズ **件4**: `upsert` の create 経路だけ **autoincrement が適用されず採番されない**バグの修正です(defaults / updatedAt / ignore は適用済みで、漏れは autoincrement のみ。Prisma は upsert の create 分岐で採番する — 実測済み)。

## 実装(遅延適用・Option B)

`upsertFunc` に optional な `prepareCreate` コールバックを追加し、**レコード不在の create 分岐内でのみ**適用。controller は `this.applyAutoincrementToData` を渡すだけ(ロジック追加なし)。

- **update 経路は LockService / PropertiesService に一切触れず連番も消費しない** — `waitLock`/`getProperty`/`setProperty` 不呼び出し + カウンタ値不変をテストでピン留め。
- 明示 id は従来通り採番値で上書きされない(create() と同 semantics)。
- 適用順(defaults → updatedAt → 遅延 autoincrement)は全て fill-missing-only のため create() の順と結果同一(確認済み)。

## テスト(TDD: Red 3段階実測 → Green)

+9件(upsertFunc 単体3 + controller 統合6: 採番・連続採番でカウンタ前進・明示値維持・update 経路カウンタ不変・非 autoincrement モデルで Lock 不使用)。**112 suites / 1362 tests 全 green**、tsc clean、biome clean。

## フォロー(別途)

gassma-test に統合テスト3本(不在 where 採番 / update 経路で id 不変+連番スキップなし / 明示 id 維持)。reset にカウンタキーの再設定処理が要る点に注意。

並行の件1/2/3 とファイル重複なし・マージ順不同可(#146 と同シリーズ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja