### PR TITLE
fix: findFirst honors cursor; groupBy drops cursor from its type

### DIFF
--- a/src/__test__/types/coreTypes.test.ts
+++ b/src/__test__/types/coreTypes.test.ts
@@ -1,3 +1,5 @@
+import type { Gassma } from "../../index";
+import type { AggregateData } from "../../types/aggregateType";
 import type { HavingCore } from "../../types/coreTypes";
 import type { GroupByData } from "../../types/groupByType";
 
@@ -29,6 +31,26 @@ describe("HavingCore aggregate filter types", () => {
     };
 
     expect(havingCore).toBeDefined();
+  });
+
+  test("should reject cursor in GroupByData (Prisma groupBy has no cursor)", () => {
+    // @ts-expect-error groupBy に cursor は存在しない
+    const withCursor: GroupByData = { by: "住所", cursor: { 名前: "A" } };
+
+    expect(withCursor).toBeDefined();
+  });
+
+  test("should reject cursor in Gassma.GroupByData (index.d.ts)", () => {
+    // @ts-expect-error groupBy に cursor は存在しない
+    const dtsGroupBy: Gassma.GroupByData = { by: "住所", cursor: {} };
+
+    expect(dtsGroupBy).toBeDefined();
+  });
+
+  test("should keep cursor in AggregateData", () => {
+    const aggregateData: AggregateData = { cursor: { 名前: "Alice" } };
+
+    expect(aggregateData).toBeDefined();
   });
 
   test("should reject string operators and string values for _count/_avg/_sum", () => {

--- a/src/__test__/util/find/findFirstCursor.test.ts
+++ b/src/__test__/util/find/findFirstCursor.test.ts
@@ -1,0 +1,92 @@
+import { findFirstFunc } from "../../../util/find/findFirst";
+import { getExtendedMockControllerUtil } from "../../consts/mockControllerUtil";
+
+describe("findFirst cursor", () => {
+  const mockUtil = getExtendedMockControllerUtil();
+
+  it("cursor 行自身を返す（inclusive）", () => {
+    const result = findFirstFunc(mockUtil, { cursor: { 名前: "Charlie" } });
+
+    expect(result).toEqual({
+      名前: "Charlie",
+      年齢: 22,
+      住所: "Tokyo",
+      郵便番号: "100-0002",
+      職業: "Student",
+    });
+  });
+
+  it("orderBy なしはシート順で最初に一致した行を返す", () => {
+    const result = findFirstFunc(mockUtil, { cursor: { 職業: "Designer" } });
+
+    expect(result).toEqual({
+      名前: "Bob",
+      年齢: 35,
+      住所: "Osaka",
+      郵便番号: "550-0001",
+      職業: "Designer",
+    });
+  });
+
+  it("orderBy 適用後の並びで cursor を探す", () => {
+    const result = findFirstFunc(mockUtil, {
+      orderBy: { 年齢: "desc" },
+      cursor: { 住所: "Tokyo" },
+    });
+
+    expect(result).toEqual({
+      名前: "Grace",
+      年齢: 31,
+      住所: "Tokyo",
+      郵便番号: "100-0004",
+      職業: "Designer",
+    });
+  });
+
+  it("where で絞った結果に cursor を適用する", () => {
+    const result = findFirstFunc(mockUtil, {
+      where: { 住所: "Tokyo" },
+      cursor: { 名前: "Eve" },
+    });
+
+    expect(result).toEqual({
+      名前: "Eve",
+      年齢: 28,
+      住所: "Tokyo",
+      郵便番号: "100-0003",
+      職業: "Engineer",
+    });
+  });
+
+  it("cursor が一致しない場合は null を返す", () => {
+    const result = findFirstFunc(mockUtil, { cursor: { 名前: "Zoe" } });
+
+    expect(result).toBeNull();
+  });
+
+  it("複合 cursor が部分一致のみの場合は null を返す", () => {
+    const result = findFirstFunc(mockUtil, {
+      cursor: { 名前: "Alice", 年齢: 99 },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("select と併用できる", () => {
+    const result = findFirstFunc(mockUtil, {
+      cursor: { 名前: "Bob" },
+      select: { 名前: true },
+    });
+
+    expect(result).toEqual({ 名前: "Bob" });
+  });
+
+  it("omit と併用できる", () => {
+    const result = findFirstFunc(mockUtil, {
+      cursor: { 名前: "Bob" },
+      omit: { 郵便番号: true, 職業: true },
+    });
+
+    expect(result).toEqual({ 名前: "Bob", 年齢: 35, 住所: "Osaka" });
+  });
+});

--- a/src/__test__/util/find/findFirstWithRelationOrderBy.test.ts
+++ b/src/__test__/util/find/findFirstWithRelationOrderBy.test.ts
@@ -1,0 +1,109 @@
+import { findFirstWithRelationOrderBy } from "../../../util/find/findFirstWithRelationOrderBy";
+import type { OrderBy } from "../../../types/coreTypes";
+import type { RelationContext } from "../../../types/relationTypes";
+import { getExtendedMockControllerUtil } from "../../consts/mockControllerUtil";
+
+// 郵便番号 → rank（シート順の逆順になるように付与）
+const addressRanks = [
+  { code: "100-0001", rank: 8 },
+  { code: "550-0001", rank: 7 },
+  { code: "100-0002", rank: 6 },
+  { code: "600-8000", rank: 5 },
+  { code: "100-0003", rank: 4 },
+  { code: "550-0002", rank: 3 },
+  { code: "100-0004", rank: 2 },
+  { code: "600-8001", rank: 1 },
+];
+
+const createRelationContext = (): RelationContext => ({
+  relations: {
+    address: {
+      type: "manyToOne",
+      to: "Addresses",
+      field: "郵便番号",
+      reference: "code",
+    },
+  },
+  findManyOnSheet: (sheetName: string) =>
+    sheetName === "Addresses" ? addressRanks : [],
+});
+
+const orderByArr: OrderBy[] = [{ address: { rank: "asc" } }];
+
+describe("findFirstWithRelationOrderBy cursor", () => {
+  const mockUtil = getExtendedMockControllerUtil();
+  const context = createRelationContext();
+
+  it("cursor なしはソート後の先頭を返す", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      {},
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({
+      名前: "Henry",
+      年齢: 28,
+      住所: "Kyoto",
+      郵便番号: "600-8001",
+      職業: "Engineer",
+    });
+  });
+
+  it("cursor 行自身を返す（inclusive）", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { cursor: { 名前: "Eve" } },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({
+      名前: "Eve",
+      年齢: 28,
+      住所: "Tokyo",
+      郵便番号: "100-0003",
+      職業: "Engineer",
+    });
+  });
+
+  it("relation orderBy 適用後の並びで cursor を探す", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { cursor: { 住所: "Tokyo" } },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({
+      名前: "Grace",
+      年齢: 31,
+      住所: "Tokyo",
+      郵便番号: "100-0004",
+      職業: "Designer",
+    });
+  });
+
+  it("cursor が一致しない場合は null を返す", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { cursor: { 名前: "Zoe" } },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("select と併用できる", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { cursor: { 名前: "Eve" }, select: { 名前: true } },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({ 名前: "Eve" });
+  });
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -406,7 +406,16 @@ declare namespace Gassma {
     NOT?: HavingUse[] | HavingUse;
   };
 
-  type GroupByData = AggregateData & {
+  type GroupByData = {
+    where?: WhereUse | SkipValue;
+    orderBy?: OrderBy | OrderBy[] | SkipValue;
+    take?: number | SkipValue;
+    skip?: number | SkipValue;
+    _avg?: Select | SkipValue;
+    _count?: Select | SkipValue;
+    _max?: Select | SkipValue;
+    _min?: Select | SkipValue;
+    _sum?: Select | SkipValue;
     by: string[] | string;
     having?: HavingUse | SkipValue;
   };

--- a/src/types/groupByType.ts
+++ b/src/types/groupByType.ts
@@ -1,7 +1,7 @@
 import type { AggregateData } from "./aggregateType";
 import type { HavingUse } from "./coreTypes";
 
-type GroupByData = AggregateData & {
+type GroupByData = Omit<AggregateData, "cursor"> & {
   by: string[] | string;
   having?: HavingUse;
 };

--- a/src/util/find/findFirst.ts
+++ b/src/util/find/findFirst.ts
@@ -6,6 +6,7 @@ import { whereFilter } from "../core/whereFilter";
 import { findedDataSelect } from "./findUtil/findDataSelect";
 import { omitFunc } from "./findUtil/omit";
 import { orderByFunc } from "./findUtil/orderBy";
+import { applyCursor } from "./findUtil/applyCursor";
 
 const findFirstFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
@@ -37,6 +38,12 @@ const findFirstFunc = (
       findDataDictArray,
       Array.isArray(orderBy) ? orderBy : [orderBy],
     );
+
+  // Apply cursor after orderBy, before taking first
+  const cursor = "cursor" in findData ? findData.cursor : null;
+  if (cursor) {
+    findDataDictArray = applyCursor(findDataDictArray, cursor, null);
+  }
 
   // Get the first result
   const firstResult = findDataDictArray[0];

--- a/src/util/find/findFirstWithRelationOrderBy.ts
+++ b/src/util/find/findFirstWithRelationOrderBy.ts
@@ -5,6 +5,7 @@ import type { OrderBy } from "../../types/coreTypes";
 import { findManyFunc } from "./findMany";
 import { resolveRelationOrderBy } from "./findUtil/resolveRelationOrderBy";
 import { applySelectOmit } from "./findUtil/applySelectOmit";
+import { applyCursor } from "./findUtil/applyCursor";
 
 const findFirstWithRelationOrderBy = (
   controllerUtil: GassmaControllerUtil,
@@ -27,11 +28,15 @@ const findFirstWithRelationOrderBy = (
     relationContext,
   );
 
-  // Step 3: take first
-  const first = sorted[0];
+  // Step 3: apply cursor
+  const cursor = "cursor" in findData ? findData.cursor : null;
+  const cursored = cursor ? applyCursor(sorted, cursor, null) : sorted;
+
+  // Step 4: take first
+  const first = cursored[0];
   if (!first) return null;
 
-  // Step 4: apply select/omit
+  // Step 5: apply select/omit
   const applied = applySelectOmit([first], select, omit);
   return applied[0] ?? null;
 };


### PR DESCRIPTION
## 概要

型/実装乖離シリーズ **件1**: `findFirst` の `cursor` が**型のみで実装は完全無視**、`groupBy` は逆に **Prisma に存在しない cursor を型が持っていた**問題の修正です。

## Prisma 実測(調査済み)

- **findFirst の cursor は有効**(SQL: 相関サブクエリ方式、cursor 行を**含む** inclusive。findMany と同意味論)
- **groupBy に cursor は無い**(型に存在せず、実行時も Unknown argument)。aggregate には**ある**(gassma も対応済みで正しい — 不変)

## 修正

- `findFirst.ts` / `findFirstWithRelationOrderBy.ts`: orderBy 適用後に `applyCursor` を適用(findMany と同パターン・両経路対称)。cursor 行自身を返し、**不一致は null**。
- `GroupByData` から cursor を削除: モジュール型は組み込み `Omit`、公開 d.ts は namespace 内に独自 Omit があるためインライン展開。

## テスト(TDD: 全 Red 先行、index.d.ts 分は一時 revert で Red 実証)

+16件(findFirst cursor 8: inclusive/orderBy 後適用/where 併用/不一致 null/複合部分一致 null/select/omit + relation orderBy 経路 5 + 型テスト 3: GroupByData 拒否 ×2・AggregateData 維持)。**113 suites / 1369 tests 全 green**、tsc clean、biome clean。

## フォロー(別途)

- **cli 追随**: 生成 GroupByData の cursor 除去(`Omit<AggregateData, "cursor">` 化)。生成 FindFirstData の cursor は実装が追いついたので不変で OK。
- gassma-test: findFirst cursor の統合テスト追加可。
- groupBy 実行時の未知引数バリデーション(Prisma は throw、gassma は silent ignore)は仕様追加のため対象外。

並行の件2/3/4 とファイル重複なし(#146/#147 と同シリーズ)・マージ順不同可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja