### PR TITLE
fix: accept orderBy arrays in include options (and guard empty orderBy)

### DIFF
--- a/src/__test__/util/find/orderByEmptyArray.test.ts
+++ b/src/__test__/util/find/orderByEmptyArray.test.ts
@@ -1,0 +1,17 @@
+import { orderByFunc } from "../../../util/find/findUtil/orderBy";
+
+describe("orderByFunc の空配列", () => {
+  it("空配列の場合、複数件でもエラーにならず並び順を変えない", () => {
+    const data = [{ id: 2 }, { id: 1 }, { id: 3 }];
+
+    const result = orderByFunc(data, []);
+
+    expect(result).toEqual([{ id: 2 }, { id: 1 }, { id: 3 }]);
+  });
+
+  it("空配列の場合、1件でも並び順を変えない", () => {
+    const data = [{ id: 1 }];
+
+    expect(orderByFunc(data, [])).toEqual([{ id: 1 }]);
+  });
+});

--- a/src/__test__/util/relation/includeOrderByArray.test.ts
+++ b/src/__test__/util/relation/includeOrderByArray.test.ts
@@ -1,0 +1,290 @@
+import { GassmaClient } from "../../../gassma";
+import { GassmaController } from "../../../gassmaController";
+import type {
+  IncludeData,
+  RelationsConfig,
+} from "../../../types/relationTypes";
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => { getValues: () => unknown[][] };
+  getDataRange: () => { getValues: () => unknown[][] };
+};
+
+const makeSheet = (name: string, data: unknown[][]): MockSheet => ({
+  getName: () => name,
+  getLastRow: () => data.length,
+  getLastColumn: () => data[0].length,
+  getRange: (row, col, numRows, numCols) => ({
+    getValues: () =>
+      data
+        .slice(row - 1, row - 1 + numRows)
+        .map((r) => r.slice(col - 1, col - 1 + numCols)),
+  }),
+  getDataRange: () => ({ getValues: () => data }),
+});
+
+const sheets = [
+  makeSheet("Users", [
+    ["id", "name"],
+    [1, "Alice"],
+    [2, "Bob"],
+  ]),
+  makeSheet("Posts", [
+    ["id", "authorId", "title"],
+    [101, 1, "B"],
+    [102, 1, "A"],
+    [103, 1, "B"],
+    [104, 2, "C"],
+  ]),
+  makeSheet("Comments", [
+    ["id", "postId", "body"],
+    [201, 101, "Nice"],
+    [202, 101, "Great"],
+    [203, 101, "Nice"],
+  ]),
+  makeSheet("Categories", [
+    ["id", "name"],
+    [401, "Tech"],
+    [402, "Life"],
+    [403, "Tech"],
+  ]),
+  makeSheet("PostCategories", [
+    ["postId", "categoryId"],
+    [101, 401],
+    [101, 402],
+    [101, 403],
+  ]),
+];
+
+const mockSpreadsheet = {
+  getId: () => "test-spreadsheet",
+  getSheets: () => sheets,
+  getSheetByName: (name: string) =>
+    sheets.find((sheet) => sheet.getName() === name) ?? null,
+};
+
+const relations: RelationsConfig = {
+  Users: {
+    posts: {
+      type: "oneToMany",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+    },
+  },
+  Posts: {
+    comments: {
+      type: "oneToMany",
+      to: "Comments",
+      field: "id",
+      reference: "postId",
+    },
+    categories: {
+      type: "manyToMany",
+      to: "Categories",
+      field: "id",
+      reference: "id",
+      through: {
+        sheet: "PostCategories",
+        field: "postId",
+        reference: "categoryId",
+      },
+    },
+  },
+};
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!(controller instanceof GassmaController)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+describe("include 内 orderBy 配列（統合）", () => {
+  let client: GassmaClient;
+
+  beforeAll(() => {
+    Object.assign(globalThis, {
+      SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+    });
+    client = new GassmaClient({ relations });
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, { SpreadsheetApp: undefined });
+  });
+
+  describe("include の orderBy 配列", () => {
+    it("複数エントリの第2キーがタイブレークとして効く", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: { orderBy: [{ title: "asc" }, { id: "desc" }] } },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          posts: [
+            { id: 102, authorId: 1, title: "A" },
+            { id: 103, authorId: 1, title: "B" },
+            { id: 101, authorId: 1, title: "B" },
+          ],
+        },
+      ]);
+    });
+
+    it("単一 object の orderBy は安定ソートのまま（対比）", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: { orderBy: { title: "asc" } } },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          posts: [
+            { id: 102, authorId: 1, title: "A" },
+            { id: 101, authorId: 1, title: "B" },
+            { id: 103, authorId: 1, title: "B" },
+          ],
+        },
+      ]);
+    });
+
+    it("空配列は並び順を変えない（no-op）", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: { posts: { orderBy: [] } },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          posts: [
+            { id: 101, authorId: 1, title: "B" },
+            { id: 102, authorId: 1, title: "A" },
+            { id: 103, authorId: 1, title: "B" },
+          ],
+        },
+      ]);
+    });
+
+    it("manyToMany でも配列のタイブレークが効く", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { id: 101 },
+        include: {
+          categories: { orderBy: [{ name: "asc" }, { id: "desc" }] },
+        },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 101,
+          authorId: 1,
+          title: "B",
+          categories: [
+            { id: 402, name: "Life" },
+            { id: 403, name: "Tech" },
+            { id: 401, name: "Tech" },
+          ],
+        },
+      ]);
+    });
+
+    it("ネストした include 内でも配列が使える", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        include: {
+          posts: {
+            where: { id: 101 },
+            include: {
+              comments: { orderBy: [{ body: "asc" }, { id: "desc" }] },
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          name: "Alice",
+          posts: [
+            {
+              id: 101,
+              authorId: 1,
+              title: "B",
+              comments: [
+                { id: 202, postId: 101, body: "Great" },
+                { id: 203, postId: 101, body: "Nice" },
+                { id: 201, postId: 101, body: "Nice" },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("配列要素が object 以外の場合はエラーを投げる", () => {
+      const include = {
+        posts: { orderBy: ["invalid"] },
+      } as unknown as IncludeData;
+
+      expect(() =>
+        sheetOf(client, "Users").findMany({ where: { id: 1 }, include }),
+      ).toThrow(
+        'Include "posts": option "orderBy" must be an object or an array of objects',
+      );
+    });
+  });
+
+  describe("select 内 relation の orderBy 配列", () => {
+    it("複数エントリの第2キーがタイブレークとして効く", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        select: {
+          posts: {
+            orderBy: [{ title: "asc" }, { id: "desc" }],
+            select: { id: true, title: true },
+          },
+        },
+      });
+
+      expect(result).toEqual([
+        {
+          posts: [
+            { id: 102, title: "A" },
+            { id: 103, title: "B" },
+            { id: 101, title: "B" },
+          ],
+        },
+      ]);
+    });
+
+    it("空配列は並び順を変えない（no-op）", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { id: 1 },
+        select: { posts: { orderBy: [], select: { id: true } } },
+      });
+
+      expect(result).toEqual([
+        { posts: [{ id: 101 }, { id: 102 }, { id: 103 }] },
+      ]);
+    });
+  });
+});

--- a/src/__test__/util/relation/resolvers/oneToMany.test.ts
+++ b/src/__test__/util/relation/resolvers/oneToMany.test.ts
@@ -100,6 +100,44 @@ describe("resolveOneToMany", () => {
     expect(result[0].posts[1].createdAt).toBe(1);
   });
 
+  it("includeオプションのorderBy配列で第2キーがタイブレークとして効く", () => {
+    const parents = [{ id: 1, name: "Alice" }];
+
+    mockFindMany.mockReturnValue([
+      { id: 101, authorId: 1, title: "B" },
+      { id: 102, authorId: 1, title: "A" },
+      { id: 103, authorId: 1, title: "B" },
+    ]);
+
+    const result = resolveOneToMany(parents, relation, "posts", mockFindMany, {
+      orderBy: [{ title: "asc" }, { id: "desc" }],
+    });
+
+    expect(result[0].posts).toEqual([
+      { id: 102, authorId: 1, title: "A" },
+      { id: 103, authorId: 1, title: "B" },
+      { id: 101, authorId: 1, title: "B" },
+    ]);
+  });
+
+  it("includeオプションのorderBy空配列は並び順を変えずエラーにもならない", () => {
+    const parents = [{ id: 1, name: "Alice" }];
+
+    mockFindMany.mockReturnValue([
+      { id: 102, authorId: 1, title: "B" },
+      { id: 101, authorId: 1, title: "A" },
+    ]);
+
+    const result = resolveOneToMany(parents, relation, "posts", mockFindMany, {
+      orderBy: [],
+    });
+
+    expect(result[0].posts).toEqual([
+      { id: 102, authorId: 1, title: "B" },
+      { id: 101, authorId: 1, title: "A" },
+    ]);
+  });
+
   it("includeオプションのtakeを親ごとに適用する", () => {
     const parents = [{ id: 1, name: "Alice" }];
 

--- a/src/__test__/util/relation/validation/validateIncludeOptions.test.ts
+++ b/src/__test__/util/relation/validation/validateIncludeOptions.test.ts
@@ -115,12 +115,44 @@ describe("validateIncludeOptions", () => {
       ).not.toThrow();
     });
 
-    it("orderBy が object 以外の場合エラーを投げる", () => {
+    it("orderBy が object の配列の場合エラーを投げない", () => {
+      expect(() =>
+        validateIncludeOptions({
+          posts: { orderBy: [{ title: "asc" }, { id: "desc" }] },
+        }),
+      ).not.toThrow();
+    });
+
+    it("orderBy が空配列の場合エラーを投げない", () => {
+      expect(() =>
+        validateIncludeOptions({ posts: { orderBy: [] } }),
+      ).not.toThrow();
+    });
+
+    it("orderBy が object でも配列でもない場合エラーを投げる", () => {
       const include = {
         posts: { orderBy: "invalid" },
       } as unknown as IncludeData;
       expect(() => validateIncludeOptions(include)).toThrow(
-        'option "orderBy" must be an object',
+        'option "orderBy" must be an object or an array of objects',
+      );
+    });
+
+    it("orderBy 配列の要素が object 以外の場合エラーを投げる", () => {
+      const include = {
+        posts: { orderBy: ["invalid"] },
+      } as unknown as IncludeData;
+      expect(() => validateIncludeOptions(include)).toThrow(
+        'option "orderBy" must be an object or an array of objects',
+      );
+    });
+
+    it("orderBy 配列の要素に null が含まれる場合エラーを投げる", () => {
+      const include = {
+        posts: { orderBy: [{ title: "asc" }, null] },
+      } as unknown as IncludeData;
+      expect(() => validateIncludeOptions(include)).toThrow(
+        'option "orderBy" must be an object or an array of objects',
       );
     });
   });

--- a/src/util/find/findUtil/orderBy.ts
+++ b/src/util/find/findUtil/orderBy.ts
@@ -83,6 +83,8 @@ const orderByFunc = (
   result: Record<string, unknown>[],
   orderByOptions: OrderBy[],
 ) => {
+  if (orderByOptions.length === 0) return result;
+
   const orderByOptionArray = orderByOptions.map(parseOrderByEntry);
   const sortedResult = result.sort((a, b) => search(a, b, orderByOptionArray));
   return sortedResult;

--- a/src/util/relation/validation/validateIncludeOptions.ts
+++ b/src/util/relation/validation/validateIncludeOptions.ts
@@ -23,6 +23,18 @@ const validateOptionObject = (
   }
 };
 
+const validateOrderByOption = (relationName: string, value: unknown): void => {
+  if (value === undefined) return;
+  if (isObject(value)) return;
+  if (Array.isArray(value) && value.every(isObject)) return;
+
+  throw new IncludeInvalidOptionTypeError(
+    relationName,
+    "orderBy",
+    "an object or an array of objects",
+  );
+};
+
 const validateIncludeItem = (relationName: string, value: unknown): void => {
   if (value === true) return;
 
@@ -51,7 +63,7 @@ const validateIncludeItem = (relationName: string, value: unknown): void => {
   }
 
   validateOptionObject(relationName, "where", value.where);
-  validateOptionObject(relationName, "orderBy", value.orderBy);
+  validateOrderByOption(relationName, value.orderBy);
   validateOptionObject(relationName, "select", value.select);
   validateOptionObject(relationName, "omit", value.omit);
   validateOptionObject(relationName, "include", value.include);


### PR DESCRIPTION
## 概要

型/実装乖離シリーズ **件2**: include(および select 内 relation)の `orderBy` に**配列を渡すと throw** するバグの修正です。型(`OrderBy | OrderBy[]`)と resolver は既に配列対応済みで、**バリデータ1箇所だけが配列を拒否**していました(コンパイルは通るのにクラッシュ)。Prisma は配列を受理し第2キーがタイブレークに効くことを実測済み。

## 修正

- `validateIncludeOptions`: `orderBy` のみ「object または全要素が object の配列」を許容(他オプションの検証は不変)。select 内 relation も同じバリデータを通るため1箇所で両対応。
- **おまけの潜在バグ修正**: `orderBy: []`(空配列)は Prisma では no-op だが、gassma の comparator は**2行以上で TypeError クラッシュ**していた → `orderByFunc` に空配列ガードを追加。共有関数のため **top-level の `orderBy: []` の同一クラッシュも同時解消**。

## テスト(TDD: Red 14件実測 → Green)

+16件(バリデータ4 + resolver 配列タイブレーク/空配列 + orderByFunc 空配列2 + **統合8**: include 配列タイブレーク・manyToMany・ネスト include・select 内 relation の配列/空配列・非 object 要素エラー)。**113 suites / 1369 tests 全 green**、tsc clean、biome clean。

## フォロー(別途)

- **cli 追随**: 生成 Include / FindSelect の relation オプション `orderBy` に `| OrderBy[]` 追加(現状は単一 object のみで本体型より狭い)。
- gassma-test: include orderBy 配列の統合テスト(cli 追随 + 再生成後)。

並行の件1/3/4 とファイル重複なし(#146/#147/#148 と同シリーズ)・マージ順不同可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja