### PR TITLE
feat: restore take/skip/distinct on findFirst (Prisma parity)

### DIFF
--- a/src/__test__/util/find/findFirstTakeSkipDistinct.test.ts
+++ b/src/__test__/util/find/findFirstTakeSkipDistinct.test.ts
@@ -1,0 +1,370 @@
+import { findFirstFunc } from "../../../util/find/findFirst";
+import { getExtendedMockControllerUtil } from "../../consts/mockControllerUtil";
+
+// シート順: Alice, Bob, Charlie, David, Eve, Frank, Grace, Henry
+describe("findFirst take/skip/distinct", () => {
+  const mockUtil = getExtendedMockControllerUtil();
+
+  describe("take", () => {
+    it("take: 1 は先頭を返す", () => {
+      const result = findFirstFunc(mockUtil, { take: 1 });
+
+      expect(result).toEqual({
+        名前: "Alice",
+        年齢: 28,
+        住所: "Tokyo",
+        郵便番号: "100-0001",
+        職業: "Engineer",
+      });
+    });
+
+    it("take: -1 は並びを反転して末尾を返す", () => {
+      const result = findFirstFunc(mockUtil, { take: -1 });
+
+      expect(result).toEqual({
+        名前: "Henry",
+        年齢: 28,
+        住所: "Kyoto",
+        郵便番号: "600-8001",
+        職業: "Engineer",
+      });
+    });
+
+    it("take: -1 は orderBy 適用後の並びを反転する", () => {
+      const result = findFirstFunc(mockUtil, {
+        orderBy: { 年齢: "asc" },
+        take: -1,
+      });
+
+      expect(result).toEqual({
+        名前: "Frank",
+        年齢: 52,
+        住所: "Osaka",
+        郵便番号: "550-0002",
+        職業: "Director",
+      });
+    });
+
+    it("take: -1 は where で絞った結果の末尾を返す", () => {
+      const result = findFirstFunc(mockUtil, {
+        where: { 住所: "Tokyo" },
+        take: -1,
+      });
+
+      expect(result).toEqual({
+        名前: "Grace",
+        年齢: 31,
+        住所: "Tokyo",
+        郵便番号: "100-0004",
+        職業: "Designer",
+      });
+    });
+
+    it("take: 2 はエラー", () => {
+      expect(() => findFirstFunc(mockUtil, { take: 2 })).toThrow(
+        "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1",
+      );
+    });
+
+    it("take: 0 はエラー", () => {
+      expect(() => findFirstFunc(mockUtil, { take: 0 })).toThrow(
+        "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1",
+      );
+    });
+
+    it("take: -2 はエラー", () => {
+      expect(() => findFirstFunc(mockUtil, { take: -2 })).toThrow(
+        "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1",
+      );
+    });
+  });
+
+  describe("skip", () => {
+    it("skip: 2 は 2 件飛ばした先頭を返す", () => {
+      const result = findFirstFunc(mockUtil, { skip: 2 });
+
+      expect(result).toEqual({
+        名前: "Charlie",
+        年齢: 22,
+        住所: "Tokyo",
+        郵便番号: "100-0002",
+        職業: "Student",
+      });
+    });
+
+    it("skip: 0 は先頭を返す", () => {
+      const result = findFirstFunc(mockUtil, { skip: 0 });
+
+      expect(result).toEqual({
+        名前: "Alice",
+        年齢: 28,
+        住所: "Tokyo",
+        郵便番号: "100-0001",
+        職業: "Engineer",
+      });
+    });
+
+    it("skip が件数を超えると null を返す", () => {
+      const result = findFirstFunc(mockUtil, { skip: 100 });
+
+      expect(result).toBeNull();
+    });
+
+    it("skip: -1 はエラー", () => {
+      expect(() => findFirstFunc(mockUtil, { skip: -1 })).toThrow(
+        "Invalid value for skip argument: Value can only be positive, found: -1",
+      );
+    });
+
+    it("orderBy 適用後に skip する", () => {
+      const result = findFirstFunc(mockUtil, {
+        orderBy: { 年齢: "desc" },
+        skip: 1,
+      });
+
+      expect(result).toEqual({
+        名前: "David",
+        年齢: 45,
+        住所: "Kyoto",
+        郵便番号: "600-8000",
+        職業: "Manager",
+      });
+    });
+
+    it("where で絞った結果に skip する", () => {
+      const result = findFirstFunc(mockUtil, {
+        where: { 住所: "Tokyo" },
+        skip: 3,
+      });
+
+      expect(result).toEqual({
+        名前: "Grace",
+        年齢: 31,
+        住所: "Tokyo",
+        郵便番号: "100-0004",
+        職業: "Designer",
+      });
+    });
+
+    it("take: -1 と skip を併用すると末尾側から skip する", () => {
+      const result = findFirstFunc(mockUtil, { take: -1, skip: 1 });
+
+      expect(result).toEqual({
+        名前: "Grace",
+        年齢: 31,
+        住所: "Tokyo",
+        郵便番号: "100-0004",
+        職業: "Designer",
+      });
+    });
+
+    it("take: -1 と件数超過の skip は null を返す", () => {
+      const result = findFirstFunc(mockUtil, { take: -1, skip: 100 });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("distinct", () => {
+    it("distinct 適用後の先頭を返す", () => {
+      const result = findFirstFunc(mockUtil, { distinct: "住所" });
+
+      expect(result).toEqual({
+        名前: "Alice",
+        年齢: 28,
+        住所: "Tokyo",
+        郵便番号: "100-0001",
+        職業: "Engineer",
+      });
+    });
+
+    it("distinct 適用後に skip する（skip が先だと Charlie になる）", () => {
+      const result = findFirstFunc(mockUtil, { distinct: "住所", skip: 2 });
+
+      expect(result).toEqual({
+        名前: "David",
+        年齢: 45,
+        住所: "Kyoto",
+        郵便番号: "600-8000",
+        職業: "Manager",
+      });
+    });
+
+    it("distinct 適用後の件数を skip が超えると null を返す", () => {
+      const result = findFirstFunc(mockUtil, { distinct: "住所", skip: 3 });
+
+      expect(result).toBeNull();
+    });
+
+    it("distinct は配列で複数フィールドを指定できる", () => {
+      const result = findFirstFunc(mockUtil, {
+        distinct: ["住所", "職業"],
+        skip: 6,
+      });
+
+      expect(result).toEqual({
+        名前: "Henry",
+        年齢: 28,
+        住所: "Kyoto",
+        郵便番号: "600-8001",
+        職業: "Engineer",
+      });
+    });
+
+    it("orderBy 適用後の並びで distinct する", () => {
+      const result = findFirstFunc(mockUtil, {
+        orderBy: { 年齢: "asc" },
+        distinct: "住所",
+        skip: 1,
+      });
+
+      expect(result).toEqual({
+        名前: "Henry",
+        年齢: 28,
+        住所: "Kyoto",
+        郵便番号: "600-8001",
+        職業: "Engineer",
+      });
+    });
+
+    it("take: -1 では反転後の並びで distinct する", () => {
+      const result = findFirstFunc(mockUtil, {
+        take: -1,
+        distinct: "住所",
+        skip: 2,
+      });
+
+      expect(result).toEqual({
+        名前: "Frank",
+        年齢: 52,
+        住所: "Osaka",
+        郵便番号: "550-0002",
+        職業: "Director",
+      });
+    });
+  });
+
+  describe("cursor 併用", () => {
+    it("cursor 位置決めの後に skip する", () => {
+      const result = findFirstFunc(mockUtil, {
+        cursor: { 名前: "Charlie" },
+        skip: 1,
+      });
+
+      expect(result).toEqual({
+        名前: "David",
+        年齢: 45,
+        住所: "Kyoto",
+        郵便番号: "600-8000",
+        職業: "Manager",
+      });
+    });
+
+    it("cursor + skip + take: 1 を併用できる", () => {
+      const result = findFirstFunc(mockUtil, {
+        cursor: { 名前: "Charlie" },
+        skip: 1,
+        take: 1,
+      });
+
+      expect(result).toEqual({
+        名前: "David",
+        年齢: 45,
+        住所: "Kyoto",
+        郵便番号: "600-8000",
+        職業: "Manager",
+      });
+    });
+
+    it("take: -1 でも cursor 行自身を返す（inclusive）", () => {
+      const result = findFirstFunc(mockUtil, {
+        cursor: { 名前: "Eve" },
+        take: -1,
+      });
+
+      expect(result).toEqual({
+        名前: "Eve",
+        年齢: 28,
+        住所: "Tokyo",
+        郵便番号: "100-0003",
+        職業: "Engineer",
+      });
+    });
+
+    it("take: -1 の cursor は反転後の並びで skip する", () => {
+      const result = findFirstFunc(mockUtil, {
+        cursor: { 名前: "Eve" },
+        take: -1,
+        skip: 1,
+      });
+
+      expect(result).toEqual({
+        名前: "David",
+        年齢: 45,
+        住所: "Kyoto",
+        郵便番号: "600-8000",
+        職業: "Manager",
+      });
+    });
+
+    it("take: -1 の cursor は反転後の並びで最初に一致した行に位置決めする", () => {
+      const result = findFirstFunc(mockUtil, {
+        cursor: { 職業: "Designer" },
+        take: -1,
+      });
+
+      expect(result).toEqual({
+        名前: "Grace",
+        年齢: 31,
+        住所: "Tokyo",
+        郵便番号: "100-0004",
+        職業: "Designer",
+      });
+    });
+
+    it("cursor がミスした場合は skip があっても null を返す", () => {
+      const result = findFirstFunc(mockUtil, {
+        cursor: { 名前: "Zoe" },
+        skip: 1,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("cursor 位置決めの後に distinct し、その後 skip する", () => {
+      const result = findFirstFunc(mockUtil, {
+        cursor: { 名前: "Bob" },
+        distinct: "住所",
+        skip: 1,
+      });
+
+      expect(result).toEqual({
+        名前: "Charlie",
+        年齢: 22,
+        住所: "Tokyo",
+        郵便番号: "100-0002",
+        職業: "Student",
+      });
+    });
+  });
+
+  describe("select/omit 併用", () => {
+    it("take: -1 と select を併用できる", () => {
+      const result = findFirstFunc(mockUtil, {
+        take: -1,
+        select: { 名前: true },
+      });
+
+      expect(result).toEqual({ 名前: "Henry" });
+    });
+
+    it("skip と omit を併用できる", () => {
+      const result = findFirstFunc(mockUtil, {
+        skip: 1,
+        omit: { 郵便番号: true, 職業: true },
+      });
+
+      expect(result).toEqual({ 名前: "Bob", 年齢: 35, 住所: "Osaka" });
+    });
+  });
+});

--- a/src/__test__/util/find/findFirstWithRelationOrderByTakeSkipDistinct.test.ts
+++ b/src/__test__/util/find/findFirstWithRelationOrderByTakeSkipDistinct.test.ts
@@ -1,0 +1,205 @@
+import { findFirstWithRelationOrderBy } from "../../../util/find/findFirstWithRelationOrderBy";
+import type { OrderBy } from "../../../types/coreTypes";
+import type { RelationContext } from "../../../types/relationTypes";
+import { getExtendedMockControllerUtil } from "../../consts/mockControllerUtil";
+
+// 郵便番号 → rank（シート順の逆順になるように付与）
+const addressRanks = [
+  { code: "100-0001", rank: 8 },
+  { code: "550-0001", rank: 7 },
+  { code: "100-0002", rank: 6 },
+  { code: "600-8000", rank: 5 },
+  { code: "100-0003", rank: 4 },
+  { code: "550-0002", rank: 3 },
+  { code: "100-0004", rank: 2 },
+  { code: "600-8001", rank: 1 },
+];
+
+const createRelationContext = (): RelationContext => ({
+  relations: {
+    address: {
+      type: "manyToOne",
+      to: "Addresses",
+      field: "郵便番号",
+      reference: "code",
+    },
+  },
+  findManyOnSheet: (sheetName: string) =>
+    sheetName === "Addresses" ? addressRanks : [],
+});
+
+const orderByArr: OrderBy[] = [{ address: { rank: "asc" } }];
+
+// rank asc のソート結果: Henry, Grace, Frank, Eve, David, Charlie, Bob, Alice
+describe("findFirstWithRelationOrderBy take/skip/distinct", () => {
+  const mockUtil = getExtendedMockControllerUtil();
+  const context = createRelationContext();
+
+  it("take: 1 はソート後の先頭を返す", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { take: 1 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({
+      名前: "Henry",
+      年齢: 28,
+      住所: "Kyoto",
+      郵便番号: "600-8001",
+      職業: "Engineer",
+    });
+  });
+
+  it("take: -1 はソート後の並びを反転して末尾を返す", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { take: -1 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({
+      名前: "Alice",
+      年齢: 28,
+      住所: "Tokyo",
+      郵便番号: "100-0001",
+      職業: "Engineer",
+    });
+  });
+
+  it("take: 2 はエラー", () => {
+    expect(() =>
+      findFirstWithRelationOrderBy(mockUtil, { take: 2 }, context, orderByArr),
+    ).toThrow(
+      "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1",
+    );
+  });
+
+  it("skip: 1 はソート後の並びで skip する", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { skip: 1 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({
+      名前: "Grace",
+      年齢: 31,
+      住所: "Tokyo",
+      郵便番号: "100-0004",
+      職業: "Designer",
+    });
+  });
+
+  it("skip が件数を超えると null を返す", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { skip: 100 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("skip: -1 はエラー", () => {
+    expect(() =>
+      findFirstWithRelationOrderBy(mockUtil, { skip: -1 }, context, orderByArr),
+    ).toThrow(
+      "Invalid value for skip argument: Value can only be positive, found: -1",
+    );
+  });
+
+  it("distinct はソート後の並びで適用される", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { distinct: "住所" },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({
+      名前: "Henry",
+      年齢: 28,
+      住所: "Kyoto",
+      郵便番号: "600-8001",
+      職業: "Engineer",
+    });
+  });
+
+  it("distinct 適用後の件数を skip が超えると null を返す（skip が先だと Eve になる）", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { distinct: "住所", skip: 3 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("take: -1 では反転後の並びで distinct する", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { take: -1, distinct: "住所", skip: 2 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({
+      名前: "David",
+      年齢: 45,
+      住所: "Kyoto",
+      郵便番号: "600-8000",
+      職業: "Manager",
+    });
+  });
+
+  it("cursor 位置決めの後に skip する", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { cursor: { 名前: "Grace" }, skip: 1 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({
+      名前: "Frank",
+      年齢: 52,
+      住所: "Osaka",
+      郵便番号: "550-0002",
+      職業: "Director",
+    });
+  });
+
+  it("take: -1 の cursor は反転後の並びで位置決めして skip する", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { cursor: { 名前: "David" }, take: -1, skip: 1 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({
+      名前: "Eve",
+      年齢: 28,
+      住所: "Tokyo",
+      郵便番号: "100-0003",
+      職業: "Engineer",
+    });
+  });
+
+  it("take: -1 と select を併用できる", () => {
+    const result = findFirstWithRelationOrderBy(
+      mockUtil,
+      { take: -1, select: { 名前: true } },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual({ 名前: "Alice" });
+  });
+});

--- a/src/errors/find/findError.ts
+++ b/src/errors/find/findError.ts
@@ -22,6 +22,15 @@ class GassmaSkipNegativeError extends Error {
   }
 }
 
+class GassmaFindFirstTakeError extends Error {
+  constructor() {
+    super(
+      "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1",
+    );
+    this.name = "GassmaFindFirstTakeError";
+  }
+}
+
 class GassmaLimitNegativeError extends Error {
   constructor(value: number) {
     super(
@@ -53,6 +62,7 @@ export {
   GassmaFindSelectOmitConflictError,
   NotFoundError,
   GassmaSkipNegativeError,
+  GassmaFindFirstTakeError,
   GassmaLimitNegativeError,
   RelationOrderByUnsupportedTypeError,
   RelationOrderByCountUnsupportedTypeError,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -308,6 +308,9 @@ declare namespace Gassma {
     select?: FindSelect | SkipValue;
     omit?: Record<string, boolean> | SkipValue;
     orderBy?: OrderBy | OrderBy[] | SkipValue;
+    take?: number | SkipValue;
+    skip?: number | SkipValue;
+    distinct?: string | string[] | SkipValue;
     include?: IncludeData | SkipValue;
     cursor?: Record<string, unknown> | SkipValue;
   };
@@ -430,6 +433,9 @@ declare namespace Gassma {
 
   class GassmaSkipNegativeError extends Error {
     constructor(value: number);
+  }
+  class GassmaFindFirstTakeError extends Error {
+    constructor();
   }
   class GassmaLimitNegativeError extends Error {
     constructor(value: number);

--- a/src/types/findTypes.ts
+++ b/src/types/findTypes.ts
@@ -22,6 +22,9 @@ type FindFirstData = {
   select?: FindSelect;
   omit?: QueryOmit;
   orderBy?: OrderBy | OrderBy[];
+  take?: number;
+  skip?: number;
+  distinct?: string | string[];
   include?: IncludeData;
   cursor?: Record<string, unknown>;
 };

--- a/src/util/find/findFirst.ts
+++ b/src/util/find/findFirst.ts
@@ -7,6 +7,9 @@ import { findedDataSelect } from "./findUtil/findDataSelect";
 import { omitFunc } from "./findUtil/omit";
 import { orderByFunc } from "./findUtil/orderBy";
 import { applyCursor } from "./findUtil/applyCursor";
+import { applyDistinct } from "./findUtil/applyDistinct";
+import { applyFindFirstTake } from "./findUtil/applyFindFirstTake";
+import { applySkipTake } from "./findUtil/applySkipTake";
 
 const findFirstFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
@@ -16,6 +19,9 @@ const findFirstFunc = (
   const select = "select" in findData ? findData.select : null;
   const omit = "omit" in findData ? findData.omit : null;
   const orderBy = "orderBy" in findData ? findData.orderBy : null;
+  const take = "take" in findData ? findData.take : null;
+  const skip = "skip" in findData ? findData.skip : null;
+  const distinct = "distinct" in findData ? findData.distinct : null;
 
   // Use whereFilter for consistent behavior with findMany
   const findedData = whereFilter(where, gassmaControllerUtil);
@@ -32,18 +38,25 @@ const findFirstFunc = (
     return result;
   });
 
-  // Apply orderBy if specified (before taking first)
+  // 適用順は Prisma 実測: orderBy → take(-1 で反転) → cursor → distinct → skip → 先頭
   if (orderBy)
     findDataDictArray = orderByFunc(
       findDataDictArray,
       Array.isArray(orderBy) ? orderBy : [orderBy],
     );
 
-  // Apply cursor after orderBy, before taking first
+  findDataDictArray = applyFindFirstTake(findDataDictArray, take);
+
   const cursor = "cursor" in findData ? findData.cursor : null;
   if (cursor) {
     findDataDictArray = applyCursor(findDataDictArray, cursor, null);
   }
+
+  if (distinct) {
+    findDataDictArray = applyDistinct(findDataDictArray, distinct);
+  }
+
+  findDataDictArray = applySkipTake(findDataDictArray, skip, null);
 
   // Get the first result
   const firstResult = findDataDictArray[0];

--- a/src/util/find/findFirstWithRelationOrderBy.ts
+++ b/src/util/find/findFirstWithRelationOrderBy.ts
@@ -6,6 +6,9 @@ import { findManyFunc } from "./findMany";
 import { resolveRelationOrderBy } from "./findUtil/resolveRelationOrderBy";
 import { applySelectOmit } from "./findUtil/applySelectOmit";
 import { applyCursor } from "./findUtil/applyCursor";
+import { applyDistinct } from "./findUtil/applyDistinct";
+import { applyFindFirstTake } from "./findUtil/applyFindFirstTake";
+import { applySkipTake } from "./findUtil/applySkipTake";
 
 const findFirstWithRelationOrderBy = (
   controllerUtil: GassmaControllerUtil,
@@ -15,6 +18,9 @@ const findFirstWithRelationOrderBy = (
 ): Record<string, unknown> | null => {
   const select = "select" in findData ? findData.select : null;
   const omit = "omit" in findData ? findData.omit : null;
+  const take = "take" in findData ? findData.take : null;
+  const skip = "skip" in findData ? findData.skip : null;
+  const distinct = "distinct" in findData ? findData.distinct : null;
 
   // Step 1: findMany with where only
   const baseRecords = findManyFunc(controllerUtil, {
@@ -28,15 +34,19 @@ const findFirstWithRelationOrderBy = (
     relationContext,
   );
 
-  // Step 3: apply cursor
-  const cursor = "cursor" in findData ? findData.cursor : null;
-  const cursored = cursor ? applyCursor(sorted, cursor, null) : sorted;
+  // Step 3 以降は Prisma 実測順: take(-1 で反転) → cursor → distinct → skip → 先頭
+  const directed = applyFindFirstTake(sorted, take);
 
-  // Step 4: take first
-  const first = cursored[0];
+  const cursor = "cursor" in findData ? findData.cursor : null;
+  const cursored = cursor ? applyCursor(directed, cursor, null) : directed;
+
+  const distincted = distinct ? applyDistinct(cursored, distinct) : cursored;
+
+  const sliced = applySkipTake(distincted, skip, null);
+
+  const first = sliced[0];
   if (!first) return null;
 
-  // Step 5: apply select/omit
   const applied = applySelectOmit([first], select, omit);
   return applied[0] ?? null;
 };

--- a/src/util/find/findMany.ts
+++ b/src/util/find/findMany.ts
@@ -1,15 +1,14 @@
 import type { FindData } from "../../types/findTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
-import {
-  GassmaFindSelectOmitConflictError,
-  GassmaSkipNegativeError,
-} from "../../errors/find/findError";
+import { GassmaFindSelectOmitConflictError } from "../../errors/find/findError";
 import { getTitle } from "../core/getTitle";
 import { whereFilter } from "../core/whereFilter";
 import { findedDataSelect } from "./findUtil/findDataSelect";
 import { omitFunc } from "./findUtil/omit";
 import { orderByFunc } from "./findUtil/orderBy";
 import { applyCursor } from "./findUtil/applyCursor";
+import { applyDistinct } from "./findUtil/applyDistinct";
+import { applySkipTake } from "./findUtil/applySkipTake";
 
 const findManyFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
@@ -46,18 +45,7 @@ const findManyFunc = (
 
   // Apply distinct after orderBy
   if (distinct) {
-    const distinctKeys = Array.isArray(distinct) ? distinct : [distinct];
-    const seen = new Set<string>();
-
-    findDataDictArray = findDataDictArray.filter((row) => {
-      // Create a unique key from the distinct field values
-      const key = distinctKeys.map((k) => JSON.stringify(row[k])).join("|");
-
-      if (seen.has(key)) return false;
-
-      seen.add(key);
-      return true;
-    });
+    findDataDictArray = applyDistinct(findDataDictArray, distinct);
   }
 
   // Apply cursor after orderBy + distinct, before skip/take
@@ -66,26 +54,7 @@ const findManyFunc = (
     findDataDictArray = applyCursor(findDataDictArray, cursor, take);
   }
 
-  // skip 負数バリデーション
-  if (skip !== null && skip !== undefined && skip < 0) {
-    throw new GassmaSkipNegativeError(skip);
-  }
-
-  // skip + take を一括処理
-  if (take !== null && take !== undefined) {
-    if (take === 0) {
-      findDataDictArray = [];
-    } else if (take > 0) {
-      if (skip) findDataDictArray = findDataDictArray.slice(skip);
-      findDataDictArray = findDataDictArray.slice(0, take);
-    } else {
-      // 負方向: skip は末尾から除外 → take は末尾から取得
-      if (skip) findDataDictArray = findDataDictArray.slice(0, -skip);
-      findDataDictArray = findDataDictArray.slice(take);
-    }
-  } else {
-    if (skip) findDataDictArray = findDataDictArray.slice(skip);
-  }
+  findDataDictArray = applySkipTake(findDataDictArray, skip, take);
 
   if (select && omit) {
     throw new GassmaFindSelectOmitConflictError();

--- a/src/util/find/findUtil/applyDistinct.ts
+++ b/src/util/find/findUtil/applyDistinct.ts
@@ -1,0 +1,18 @@
+const applyDistinct = (
+  records: Record<string, unknown>[],
+  distinct: string | string[],
+): Record<string, unknown>[] => {
+  const distinctKeys = Array.isArray(distinct) ? distinct : [distinct];
+  const seen = new Set<string>();
+
+  return records.filter((row) => {
+    const key = distinctKeys.map((k) => JSON.stringify(row[k])).join("|");
+
+    if (seen.has(key)) return false;
+
+    seen.add(key);
+    return true;
+  });
+};
+
+export { applyDistinct };

--- a/src/util/find/findUtil/applyFindFirstTake.ts
+++ b/src/util/find/findUtil/applyFindFirstTake.ts
@@ -1,0 +1,13 @@
+import { GassmaFindFirstTakeError } from "../../../errors/find/findError";
+
+// findFirst の take は 1 | -1 のみ。-1 は並びを反転する（Prisma パリティ）
+const applyFindFirstTake = (
+  records: Record<string, unknown>[],
+  take: number | null | undefined,
+): Record<string, unknown>[] => {
+  if (take === null || take === undefined || take === 1) return records;
+  if (take === -1) return [...records].reverse();
+  throw new GassmaFindFirstTakeError();
+};
+
+export { applyFindFirstTake };


### PR DESCRIPTION
## 概要

**#118 の削除が誤りだった**ため findFirst に take / skip / distinct を復活させます。Prisma の findFirst は実際にはこれらを受け付けます(公式リファレンスにも take 負数の並び反転が明記)。ユーザー承認済み。

## Prisma 実測(7.4.1、SQLite + query event で SQL 観察)

| ケース | Prisma の挙動 |
|---|---|
| take: 1 / 省略 | 先頭 1 件 |
| **take が 1/-1 以外**(2, 0, -2) | **エラー** "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1" |
| take: -1 | **並びを反転して末尾側**(orderBy なしは PK 逆順) |
| skip: N | N 件飛ばし(超過→null、負数→エラー) |
| distinct | distinct 適用後の先頭 |
| 併用時の適用順 | **orderBy → take(反転) → cursor(inclusive) → distinct → skip → 先頭** |

## 実装

- パイプラインを実測順に厳密一致。**#148 の cursor 挙動(inclusive・orderBy 後・ミス→null)は完全維持**(既存 cursor テスト全 green)
- `applyFindFirstTake`(1|-1 検証+反転)/ `applyDistinct`(findMany のインライン distinct を抽出)を新設し、skip は既存 `applySkipTake` を再利用。findMany 側も applyDistinct / applySkipTake へ一本化(挙動不変リファクタ、-29 行)
- 新エラー `GassmaFindFirstTakeError`(メッセージは Prisma 完全一致)。FindFirstData 型(findTypes.ts / index.d.ts)は FindData と同一の並び・形
- controller は `...findData` 委譲のため変更ゼロ

## テスト

- 1404 → **1446(+42)**。逆検証: 実装のみ元に戻すと **35/42 fail** を実測。tsc / lint / format green
- 非 unique cursor + take:-1 は Prisma で検証不能(unique cursor 必須)のため「反転後の並びで最初に一致した行」を採用しテストでピン留め

## 報告事項(スコープ外・別判断)

**findMany 側の既存 Prisma 不一致を発見**: gassma は distinct を cursor より前・常に正順で適用するが、Prisma は cursor 後・take 負数時は反転順で distinct(実測で判別済み)。別タスクとして起票します。

cli 追随 PR: akahoshi1421/gassma-cli#113(生成 FindFirstData に同フィールド追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX