### PR TITLE
fix: apply findMany distinct after cursor, reversed under negative take (Prisma parity)

### DIFF
--- a/src/__test__/util/find/findManyDistinctOrder.test.ts
+++ b/src/__test__/util/find/findManyDistinctOrder.test.ts
@@ -1,0 +1,197 @@
+import { findManyFunc } from "../../../util/find/findMany";
+import { getExtendedMockControllerUtil } from "../../consts/mockControllerUtil";
+
+// シート順: Alice, Bob, Charlie, David, Eve, Frank, Grace, Henry
+// 住所: Tokyo, Osaka, Tokyo, Kyoto, Tokyo, Osaka, Tokyo, Kyoto
+const rows = {
+  Alice: {
+    名前: "Alice",
+    年齢: 28,
+    住所: "Tokyo",
+    郵便番号: "100-0001",
+    職業: "Engineer",
+  },
+  Bob: {
+    名前: "Bob",
+    年齢: 35,
+    住所: "Osaka",
+    郵便番号: "550-0001",
+    職業: "Designer",
+  },
+  Charlie: {
+    名前: "Charlie",
+    年齢: 22,
+    住所: "Tokyo",
+    郵便番号: "100-0002",
+    職業: "Student",
+  },
+  David: {
+    名前: "David",
+    年齢: 45,
+    住所: "Kyoto",
+    郵便番号: "600-8000",
+    職業: "Manager",
+  },
+  Eve: {
+    名前: "Eve",
+    年齢: 28,
+    住所: "Tokyo",
+    郵便番号: "100-0003",
+    職業: "Engineer",
+  },
+  Frank: {
+    名前: "Frank",
+    年齢: 52,
+    住所: "Osaka",
+    郵便番号: "550-0002",
+    職業: "Director",
+  },
+  Grace: {
+    名前: "Grace",
+    年齢: 31,
+    住所: "Tokyo",
+    郵便番号: "100-0004",
+    職業: "Designer",
+  },
+  Henry: {
+    名前: "Henry",
+    年齢: 28,
+    住所: "Kyoto",
+    郵便番号: "600-8001",
+    職業: "Engineer",
+  },
+};
+
+// Prisma 実測 (7.4.1): orderBy → (take 負数は反転順で) cursor → distinct → skip → take → 正順出力
+describe("findMany distinct の適用位置 (Prisma パリティ)", () => {
+  const mockUtil = getExtendedMockControllerUtil();
+
+  describe("従来挙動の維持 (cursor / take 負数なし)", () => {
+    it("distinct 単独は正順の first occurrence を返す", () => {
+      const result = findManyFunc(mockUtil, { distinct: ["住所"] });
+
+      expect(result).toEqual([rows.Alice, rows.Bob, rows.David]);
+    });
+
+    it("distinct + skip は distinct 後に skip する", () => {
+      const result = findManyFunc(mockUtil, { distinct: ["住所"], skip: 1 });
+
+      expect(result).toEqual([rows.Bob, rows.David]);
+    });
+
+    it("distinct + take 正数は distinct 後に take する", () => {
+      const result = findManyFunc(mockUtil, { distinct: ["住所"], take: 2 });
+
+      expect(result).toEqual([rows.Alice, rows.Bob]);
+    });
+  });
+
+  describe("distinct × cursor", () => {
+    it("cursor 行の distinct キーが cursor より前に既出でも cursor 行から distinct する", () => {
+      const result = findManyFunc(mockUtil, {
+        cursor: { 名前: "Eve" },
+        distinct: ["住所"],
+      });
+
+      expect(result).toEqual([rows.Eve, rows.Frank, rows.Henry]);
+    });
+
+    it("cursor → distinct → take の順で適用する", () => {
+      const result = findManyFunc(mockUtil, {
+        cursor: { 名前: "Eve" },
+        distinct: ["住所"],
+        take: 2,
+      });
+
+      expect(result).toEqual([rows.Eve, rows.Frank]);
+    });
+
+    it("cursor 後の distinct は skip より先に適用する", () => {
+      const result = findManyFunc(mockUtil, {
+        cursor: { 名前: "Alice" },
+        distinct: ["住所"],
+        skip: 1,
+      });
+
+      expect(result).toEqual([rows.Bob, rows.David]);
+    });
+
+    it("cursor が見つからない場合は distinct があっても空を返す", () => {
+      const result = findManyFunc(mockUtil, {
+        cursor: { 名前: "Zoe" },
+        distinct: ["住所"],
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("distinct × take 負数", () => {
+    it("take 負数は反転順で distinct する (first occurrence が末尾側)", () => {
+      const result = findManyFunc(mockUtil, {
+        take: -2,
+        distinct: ["住所"],
+      });
+
+      expect(result).toEqual([rows.Grace, rows.Henry]);
+    });
+
+    it("take 負数でも最終出力は正順に戻る", () => {
+      const result = findManyFunc(mockUtil, {
+        take: -3,
+        distinct: ["住所"],
+      });
+
+      expect(result).toEqual([rows.Frank, rows.Grace, rows.Henry]);
+    });
+
+    it("take 負数 + skip は反転順で distinct → skip → take の順に適用する", () => {
+      const result = findManyFunc(mockUtil, {
+        take: -2,
+        skip: 1,
+        distinct: ["住所"],
+      });
+
+      expect(result).toEqual([rows.Frank, rows.Grace]);
+    });
+
+    it("orderBy 適用後の並びを反転して distinct する", () => {
+      const result = findManyFunc(mockUtil, {
+        orderBy: { 年齢: "asc" },
+        take: -2,
+        distinct: ["住所"],
+      });
+
+      expect(result).toEqual([rows.David, rows.Frank]);
+    });
+
+    it("take 負数 + cursor は反転順で cursor 位置決め後に distinct する", () => {
+      const result = findManyFunc(mockUtil, {
+        cursor: { 名前: "David" },
+        take: -2,
+        distinct: ["住所"],
+      });
+
+      expect(result).toEqual([rows.Charlie, rows.David]);
+    });
+  });
+
+  describe("distinct なしの回帰確認", () => {
+    it("cursor + take 負数は従来どおり cursor までの末尾 2 件を返す", () => {
+      const result = findManyFunc(mockUtil, {
+        cursor: { 名前: "Charlie" },
+        take: -2,
+      });
+
+      expect(result).toEqual([rows.Bob, rows.Charlie]);
+    });
+
+    it("cursor 単独は cursor 行以降を返す", () => {
+      const result = findManyFunc(mockUtil, {
+        cursor: { 名前: "Frank" },
+      });
+
+      expect(result).toEqual([rows.Frank, rows.Grace, rows.Henry]);
+    });
+  });
+});

--- a/src/__test__/util/find/findManyWithRelationOrderByDistinct.test.ts
+++ b/src/__test__/util/find/findManyWithRelationOrderByDistinct.test.ts
@@ -1,0 +1,171 @@
+import { findManyWithRelationOrderBy } from "../../../util/find/findManyWithRelationOrderBy";
+import type { OrderBy } from "../../../types/coreTypes";
+import type { RelationContext } from "../../../types/relationTypes";
+import { getExtendedMockControllerUtil } from "../../consts/mockControllerUtil";
+
+// 郵便番号 → rank。rank asc のソート結果がシート順とも逆シート順とも一致しないように付与
+const addressRanks = [
+  { code: "100-0003", rank: 1 },
+  { code: "600-8000", rank: 2 },
+  { code: "100-0001", rank: 3 },
+  { code: "550-0002", rank: 4 },
+  { code: "600-8001", rank: 5 },
+  { code: "100-0002", rank: 6 },
+  { code: "550-0001", rank: 7 },
+  { code: "100-0004", rank: 8 },
+];
+
+const createRelationContext = (): RelationContext => ({
+  relations: {
+    address: {
+      type: "manyToOne",
+      to: "Addresses",
+      field: "郵便番号",
+      reference: "code",
+    },
+  },
+  findManyOnSheet: (sheetName: string) =>
+    sheetName === "Addresses" ? addressRanks : [],
+});
+
+const orderByArr: OrderBy[] = [{ address: { rank: "asc" } }];
+
+const rows = {
+  Alice: {
+    名前: "Alice",
+    年齢: 28,
+    住所: "Tokyo",
+    郵便番号: "100-0001",
+    職業: "Engineer",
+  },
+  Bob: {
+    名前: "Bob",
+    年齢: 35,
+    住所: "Osaka",
+    郵便番号: "550-0001",
+    職業: "Designer",
+  },
+  David: {
+    名前: "David",
+    年齢: 45,
+    住所: "Kyoto",
+    郵便番号: "600-8000",
+    職業: "Manager",
+  },
+  Eve: {
+    名前: "Eve",
+    年齢: 28,
+    住所: "Tokyo",
+    郵便番号: "100-0003",
+    職業: "Engineer",
+  },
+  Frank: {
+    名前: "Frank",
+    年齢: 52,
+    住所: "Osaka",
+    郵便番号: "550-0002",
+    職業: "Director",
+  },
+  Grace: {
+    名前: "Grace",
+    年齢: 31,
+    住所: "Tokyo",
+    郵便番号: "100-0004",
+    職業: "Designer",
+  },
+  Henry: {
+    名前: "Henry",
+    年齢: 28,
+    住所: "Kyoto",
+    郵便番号: "600-8001",
+    職業: "Engineer",
+  },
+};
+
+// rank asc のソート結果: Eve, David, Alice, Frank, Henry, Charlie, Bob, Grace
+// 住所:               Tokyo, Kyoto, Tokyo, Osaka, Kyoto, Tokyo,  Osaka, Tokyo
+describe("findManyWithRelationOrderBy distinct の適用位置 (Prisma パリティ)", () => {
+  const mockUtil = getExtendedMockControllerUtil();
+  const context = createRelationContext();
+
+  it("relation ソート後に distinct を適用する", () => {
+    const result = findManyWithRelationOrderBy(
+      mockUtil,
+      { distinct: "住所" },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual([rows.Eve, rows.David, rows.Frank]);
+  });
+
+  it("distinct 後に skip する", () => {
+    const result = findManyWithRelationOrderBy(
+      mockUtil,
+      { distinct: "住所", skip: 1 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual([rows.David, rows.Frank]);
+  });
+
+  it("take 負数はソート後の反転順で distinct し正順で返す", () => {
+    const result = findManyWithRelationOrderBy(
+      mockUtil,
+      { distinct: "住所", take: -2 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual([rows.Bob, rows.Grace]);
+  });
+
+  it("cursor 位置決め後に distinct する", () => {
+    const result = findManyWithRelationOrderBy(
+      mockUtil,
+      { cursor: { 名前: "Alice" }, distinct: "住所" },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual([rows.Alice, rows.Frank, rows.Henry]);
+  });
+
+  it("distinct と select を併用できる", () => {
+    const result = findManyWithRelationOrderBy(
+      mockUtil,
+      { distinct: "住所", select: { 名前: true } },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual([
+      { 名前: "Eve" },
+      { 名前: "David" },
+      { 名前: "Frank" },
+    ]);
+  });
+
+  it("distinct なしの take 負数は従来どおりソート後の末尾 2 件を正順で返す", () => {
+    const result = findManyWithRelationOrderBy(
+      mockUtil,
+      { take: -2 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual([rows.Bob, rows.Grace]);
+  });
+
+  it("distinct なしの cursor + take 負数は従来どおり cursor までの末尾 2 件を返す", () => {
+    const result = findManyWithRelationOrderBy(
+      mockUtil,
+      { cursor: { 名前: "Frank" }, take: -2 },
+      context,
+      orderByArr,
+    );
+
+    expect(result).toEqual([rows.Alice, rows.Frank]);
+  });
+});

--- a/src/util/find/findMany.ts
+++ b/src/util/find/findMany.ts
@@ -6,9 +6,7 @@ import { whereFilter } from "../core/whereFilter";
 import { findedDataSelect } from "./findUtil/findDataSelect";
 import { omitFunc } from "./findUtil/omit";
 import { orderByFunc } from "./findUtil/orderBy";
-import { applyCursor } from "./findUtil/applyCursor";
-import { applyDistinct } from "./findUtil/applyDistinct";
-import { applySkipTake } from "./findUtil/applySkipTake";
+import { applyCursorDistinctSkipTake } from "./findUtil/applyCursorDistinctSkipTake";
 
 const findManyFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
@@ -36,25 +34,21 @@ const findManyFunc = (
     return result;
   });
 
-  // Apply orderBy first (before distinct, skip, take)
+  // 適用順は Prisma 実測: orderBy → (take 負数は反転順で) cursor → distinct → skip → take
   if (orderBy)
     findDataDictArray = orderByFunc(
       findDataDictArray,
       Array.isArray(orderBy) ? orderBy : [orderBy],
     );
 
-  // Apply distinct after orderBy
-  if (distinct) {
-    findDataDictArray = applyDistinct(findDataDictArray, distinct);
-  }
-
-  // Apply cursor after orderBy + distinct, before skip/take
   const cursor = "cursor" in findData ? findData.cursor : null;
-  if (cursor) {
-    findDataDictArray = applyCursor(findDataDictArray, cursor, take);
-  }
-
-  findDataDictArray = applySkipTake(findDataDictArray, skip, take);
+  findDataDictArray = applyCursorDistinctSkipTake(
+    findDataDictArray,
+    cursor,
+    distinct,
+    skip,
+    take,
+  );
 
   if (select && omit) {
     throw new GassmaFindSelectOmitConflictError();

--- a/src/util/find/findManyWithRelationOrderBy.ts
+++ b/src/util/find/findManyWithRelationOrderBy.ts
@@ -3,9 +3,8 @@ import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType"
 import type { RelationContext } from "../../types/relationTypes";
 import { findManyFunc } from "./findMany";
 import { resolveRelationOrderBy } from "./findUtil/resolveRelationOrderBy";
-import { applySkipTake } from "./findUtil/applySkipTake";
 import { applySelectOmit } from "./findUtil/applySelectOmit";
-import { applyCursor } from "./findUtil/applyCursor";
+import { applyCursorDistinctSkipTake } from "./findUtil/applyCursorDistinctSkipTake";
 import type { OrderBy } from "../../types/coreTypes";
 
 const findManyWithRelationOrderBy = (
@@ -18,11 +17,11 @@ const findManyWithRelationOrderBy = (
   const omit = "omit" in findData ? findData.omit : null;
   const take = "take" in findData ? findData.take : null;
   const skip = "skip" in findData ? findData.skip : null;
+  const distinct = "distinct" in findData ? findData.distinct : null;
 
-  // Step 1: findMany with where + distinct only (no orderBy/skip/take/select/omit)
+  // Step 1: findMany with where only
   const baseRecords = findManyFunc(controllerUtil, {
     where: findData.where,
-    distinct: findData.distinct,
   });
 
   // Step 2: resolve relation orderBy (sort)
@@ -32,15 +31,18 @@ const findManyWithRelationOrderBy = (
     relationContext,
   );
 
-  // Step 3: apply cursor
+  // Step 3: Prisma 実測順 (ソート後に cursor → distinct → skip → take)
   const cursor = "cursor" in findData ? findData.cursor : null;
-  const cursored = cursor ? applyCursor(sorted, cursor, take) : sorted;
+  const paged = applyCursorDistinctSkipTake(
+    sorted,
+    cursor,
+    distinct,
+    skip,
+    take,
+  );
 
-  // Step 4: apply skip/take
-  const sliced = applySkipTake(cursored, skip, take);
-
-  // Step 5: apply select/omit
-  return applySelectOmit(sliced, select, omit);
+  // Step 4: apply select/omit
+  return applySelectOmit(paged, select, omit);
 };
 
 export { findManyWithRelationOrderBy };

--- a/src/util/find/findUtil/applyCursorDistinctSkipTake.ts
+++ b/src/util/find/findUtil/applyCursorDistinctSkipTake.ts
@@ -1,0 +1,25 @@
+import { applyCursor } from "./applyCursor";
+import { applyDistinct } from "./applyDistinct";
+import { applySkipTake } from "./applySkipTake";
+
+// Prisma 実測順: take 負数は反転順で cursor → distinct → skip → take し、出力は正順に戻す
+const applyCursorDistinctSkipTake = (
+  records: Record<string, unknown>[],
+  cursor: Record<string, unknown> | null | undefined,
+  distinct: string | string[] | null | undefined,
+  skip: number | null | undefined,
+  take: number | null | undefined,
+): Record<string, unknown>[] => {
+  const backward = typeof take === "number" && take < 0;
+
+  let result = backward ? [...records].reverse() : records;
+
+  if (cursor) result = applyCursor(result, cursor, null);
+  if (distinct) result = applyDistinct(result, distinct);
+
+  result = applySkipTake(result, skip, backward ? -take : take);
+
+  return backward ? [...result].reverse() : result;
+};
+
+export { applyCursorDistinctSkipTake };


### PR DESCRIPTION
## 概要

#150 の実測中に発覚した **findMany の distinct 適用位置の Prisma 不一致**を修正します(ユーザー承認済み)。gassma は distinct を cursor より前・常に正順で適用していましたが、Prisma は違いました。

## Prisma 実測(7.4.1、SQL 観察込み)

データ `a(1),b(1),c(2),d(2),e(3),f(3)` で判別:

| クエリ | Prisma | 判明したこと |
|---|---|---|
| distinct + skip:1 + take:2 | `c,e` | **distinct → skip → take** |
| take:-2 + distinct | `d,f` | **反転順で distinct**(first occurrence が末尾側)。現 gassma は `c,d` |
| take:-3 + distinct | `b,d,f` | **最終出力は正順に戻る** |
| cursor + distinct | cursor 行の distinct キーが cursor 前に既出でも**残る** | **cursor → distinct**(現 gassma は空になる) |
| relation orderBy + distinct | ソート順で first occurrence | **relation ソート → distinct**(現 gassma はソート前) |
| take:-2(distinct なし) | 既存挙動と一致 | **#94 の負数 take は変更不要** |

SQL 観察: distinct 指定時は `LIMIT -1`(cursor/JOIN のみ SQL、distinct/skip/take はメモリ内)= cursor・relation ソートが distinct より前で確定。

**確定パイプライン**: orderBy → (take<0: 反転) → cursor → distinct → skip → |take| → (take<0: 正順に再反転)。findFirst(#150)と同形です。

## 実装

- 新 util `applyCursorDistinctSkipTake`(25行)にパイプラインを一関数化し、**findMany と findManyWithRelationOrderBy の両経路で共有** — 今回のバグ(経路間の適用位置ドリフト)を構造的に再発不能に
- findManyWithRelationOrderBy はベース findMany への distinct pass-down を撤去し、ソート後に適用(findFirst 側 #150 と同形)
- 既存 util(applyCursor / applyDistinct / applySkipTake)を内部で再利用

## 互換性

**既存テストの期待値変更はゼロ**。観測可能な変化は「distinct × cursor / take 負数 / relation orderBy の併用時」のみで、単独 distinct・distinct+skip/take 正数・非 distinct の cursor/take 負数は不変(9 件の不変ピンが旧実装でも pass することを実測)。cli 型変更なし。

## テスト

1446 → **1467(+21)**。逆検証(stash で旧実装に戻して実測): 挙動変更テスト **12 件が fail**・不変ピン 9 件は pass。tsc / lint / format green。

## 報告事項

`applyCursor` の take 引数は全呼び出し元が null を渡すようになりデッドコード化(テストのみ使用)。#150 と同様シグネチャは温存 — 削除はフォローアップ可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX