### PR TITLE
fix: upsert update data accepts NumberOperation (UpdateAnyUse)

### DIFF
--- a/src/__test__/util/upsert/upsert.test.ts
+++ b/src/__test__/util/upsert/upsert.test.ts
@@ -55,6 +55,28 @@ describe("upsertFunc", () => {
     });
   });
 
+  test("update データの NumberOperation で数値を演算して更新する", () => {
+    const result = upsertFunc(mockUtil, {
+      where: { 名前: "Alice" },
+      create: {
+        名前: "Alice",
+        年齢: 28,
+        住所: "Tokyo",
+        郵便番号: "100-0001",
+        職業: "Engineer",
+      },
+      update: { 年齢: { increment: 1 } },
+    });
+
+    expect(result).toEqual({
+      名前: "Alice",
+      年齢: 29,
+      住所: "Tokyo",
+      郵便番号: "100-0001",
+      職業: "Engineer",
+    });
+  });
+
   test("作成後にシートのデータが正しく増えている", () => {
     upsertFunc(mockUtil, {
       where: { 名前: "NewPerson" },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -345,7 +345,7 @@ declare namespace Gassma {
   type UpsertSingleData = {
     where: WhereUse;
     create: AnyUse;
-    update: AnyUse;
+    update: UpdateAnyUse;
     select?: Select | SkipValue;
     include?: IncludeData | SkipValue;
     omit?: Record<string, boolean> | SkipValue;

--- a/src/types/findTypes.ts
+++ b/src/types/findTypes.ts
@@ -58,7 +58,7 @@ type UpdateData = {
 type UpsertSingleData = {
   where: WhereUse;
   create: AnyUse;
-  update: AnyUse;
+  update: UpdateAnyUse;
   select?: Select;
   include?: IncludeData;
   omit?: QueryOmit;


### PR DESCRIPTION
## 概要

NumberOperation 型整備(承認済み)の core 側です。調査で見つかった実ずれ1件の修正: **`UpsertSingleData.update` が `AnyUse` で NumberOperation を型拒否**していました。ランタイム(upsert → updateMany パイプライン、upsert.ts:66-78)・Prisma・cli 生成型はすべて許可しており、型だけが狭い状態でした。

## 変更

`update: AnyUse` → `update: UpdateAnyUse`(index.d.ts / findTypes.ts、各1語)。UpdateData.data と同じ型に揃えます。

## テスト

upsert increment の新テスト1件(TDD: 修正前は TS2353 で suite fail を実測 → 修正後 pass)。1467 → 1468、tsc / lint / format green。

補足: 公開型の「NumberOperation を数値カラム限定にする」件は、core 公開型がインデックスシグネチャ(非 generic)のため表現不能で該当なし — 数値限定は cli 生成型側で対応(akahoshi1421/gassma-cli#114)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX