### PR TITLE
build: raise TypeScript target to ES2019 (fix Error prototype chains)

### DIFF
--- a/src/__test__/errors/errorPrototypeChain.test.ts
+++ b/src/__test__/errors/errorPrototypeChain.test.ts
@@ -1,0 +1,91 @@
+import {
+  GassmaAggregateMaxError,
+  GassmaAggregateMinError,
+} from "../../errors/aggregate/aggregateError";
+import { GassmaInValidColumnValueError } from "../../errors/changeSettings/changeSettingsError";
+import {
+  GassmaFindFirstTakeError,
+  NotFoundError,
+} from "../../errors/find/findError";
+import { GassmaGroupByHavingDontWriteByError } from "../../errors/groupBy/groupByError";
+import { NestedWriteTargetNotFoundError } from "../../errors/relation/nestedWriteError";
+import { RelationOnDeleteRestrictError } from "../../errors/relation/relationError";
+import { GassmaUndefinedValueError } from "../../errors/skip/skipError";
+
+type ErrorCase = {
+  className: string;
+  ctor: new (
+    // biome-ignore lint/suspicious/noExplicitAny: コンストラクタ引数は各ケースの create 側で担保する
+    ...args: any[]
+  ) => Error;
+  create: () => Error;
+};
+
+const cases: ErrorCase[] = [
+  {
+    className: "GassmaFindFirstTakeError",
+    ctor: GassmaFindFirstTakeError,
+    create: () => new GassmaFindFirstTakeError(),
+  },
+  {
+    className: "NotFoundError",
+    ctor: NotFoundError,
+    create: () => new NotFoundError(),
+  },
+  {
+    className: "NestedWriteTargetNotFoundError",
+    ctor: NestedWriteTargetNotFoundError,
+    create: () => new NestedWriteTargetNotFoundError("Users", "update"),
+  },
+  {
+    className: "GassmaUndefinedValueError",
+    ctor: GassmaUndefinedValueError,
+    create: () => new GassmaUndefinedValueError("where.name"),
+  },
+  {
+    className: "RelationOnDeleteRestrictError",
+    ctor: RelationOnDeleteRestrictError,
+    create: () => new RelationOnDeleteRestrictError("posts"),
+  },
+  {
+    className: "GassmaInValidColumnValueError",
+    ctor: GassmaInValidColumnValueError,
+    create: () => new GassmaInValidColumnValueError(),
+  },
+  {
+    className: "GassmaGroupByHavingDontWriteByError",
+    ctor: GassmaGroupByHavingDontWriteByError,
+    create: () => new GassmaGroupByHavingDontWriteByError(),
+  },
+  {
+    className: "GassmaAggregateMinError",
+    ctor: GassmaAggregateMinError,
+    create: () => new GassmaAggregateMinError(),
+  },
+];
+
+describe("エラークラスの prototype チェーン", () => {
+  cases.forEach(({ className, ctor, create }) => {
+    describe(className, () => {
+      it("toThrow(コンストラクタ) でキャッチできる", () => {
+        expect(() => {
+          throw create();
+        }).toThrow(ctor);
+      });
+
+      it("instanceof が成立する", () => {
+        expect(create() instanceof ctor).toBe(true);
+      });
+
+      it("インスタンスの prototype がコンストラクタの prototype と一致する", () => {
+        expect(Object.getPrototypeOf(create())).toBe(ctor.prototype);
+      });
+    });
+  });
+
+  it("GassmaAggregateMinError は親クラス GassmaAggregateMaxError としても instanceof が成立する", () => {
+    const err = new GassmaAggregateMinError();
+
+    expect(err instanceof GassmaAggregateMaxError).toBe(true);
+  });
+});

--- a/src/__test__/util/aggregate/aggregateUtil/avg.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/avg.test.ts
@@ -1,3 +1,7 @@
+import {
+  GassmaAggregateAvgError,
+  GassmaAggregateAvgTypeError,
+} from "../../../../errors/aggregate/aggregateError";
 import { getAvg } from "../../../../util/aggregate/aggregateUtil/avg";
 
 describe("getAvg", () => {
@@ -45,12 +49,9 @@ describe("getAvg", () => {
   test("should throw GassmaAggregateAvgError for mixed data types", () => {
     const rows = [{ field: 10 }, { field: "string" }, { field: 30 }];
 
-    try {
-      getAvg(rows, { field: true });
-      fail("Expected function to throw an error");
-    } catch (error: any) {
-      expect(error.name).toBe("GassmaAggregateAvgError");
-    }
+    expect(() => getAvg(rows, { field: true })).toThrow(
+      GassmaAggregateAvgError,
+    );
   });
 
   test("should throw GassmaAggregateAvgTypeError for non-numeric uniform data types", () => {
@@ -60,23 +61,17 @@ describe("getAvg", () => {
       { field: "string3" },
     ];
 
-    try {
-      getAvg(rows, { field: true });
-      fail("Expected function to throw an error");
-    } catch (error: any) {
-      expect(error.name).toBe("GassmaAggregateAvgTypeError");
-    }
+    expect(() => getAvg(rows, { field: true })).toThrow(
+      GassmaAggregateAvgTypeError,
+    );
   });
 
   test("should throw GassmaAggregateAvgTypeError for boolean data", () => {
     const rows = [{ field: true }, { field: false }, { field: true }];
 
-    try {
-      getAvg(rows, { field: true });
-      fail("Expected function to throw an error");
-    } catch (error: any) {
-      expect(error.name).toBe("GassmaAggregateAvgTypeError");
-    }
+    expect(() => getAvg(rows, { field: true })).toThrow(
+      GassmaAggregateAvgTypeError,
+    );
   });
 
   test("should throw GassmaAggregateAvgTypeError for Date data", () => {
@@ -84,12 +79,9 @@ describe("getAvg", () => {
     const date2 = new Date("2023-01-02");
     const rows = [{ field: date1 }, { field: date2 }];
 
-    try {
-      getAvg(rows, { field: true });
-      fail("Expected function to throw an error");
-    } catch (error: any) {
-      expect(error.name).toBe("GassmaAggregateAvgTypeError");
-    }
+    expect(() => getAvg(rows, { field: true })).toThrow(
+      GassmaAggregateAvgTypeError,
+    );
   });
 
   test("should handle empty rows array", () => {
@@ -107,12 +99,9 @@ describe("getAvg", () => {
       { numeric: 20, allNull: null, mixed: "string" },
     ];
 
-    try {
-      getAvg(rows, { numeric: true, allNull: true, mixed: true });
-      fail("Expected function to throw an error");
-    } catch (error: any) {
-      expect(error.name).toBe("GassmaAggregateAvgError");
-    }
+    expect(() =>
+      getAvg(rows, { numeric: true, allNull: true, mixed: true }),
+    ).toThrow(GassmaAggregateAvgError);
   });
 
   test("should handle single numeric value", () => {

--- a/src/__test__/util/aggregate/aggregateUtil/max.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/max.test.ts
@@ -1,3 +1,4 @@
+import { GassmaAggregateMaxError } from "../../../../errors/aggregate/aggregateError";
 import { getMax } from "../../../../util/aggregate/aggregateUtil/max";
 import { getBooleanMax } from "../../../../util/aggregate/aggregateUtil/max/booleanMax";
 import { getDateMax } from "../../../../util/aggregate/aggregateUtil/max/dateMax";
@@ -238,6 +239,9 @@ describe("max aggregate functionality tests", () => {
 
     test("should handle mixed data types gracefully", () => {
       const rows = [{ value: "string" }, { value: 123 }, { value: true }];
+      expect(() => {
+        getMax(rows, { value: true });
+      }).toThrow(GassmaAggregateMaxError);
       expect(() => {
         getMax(rows, { value: true });
       }).toThrow("Cannot produce a maximum value of more than one type.");

--- a/src/__test__/util/aggregate/aggregateUtil/min.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/min.test.ts
@@ -1,3 +1,4 @@
+import { GassmaAggregateMinError } from "../../../../errors/aggregate/aggregateError";
 import { getMin } from "../../../../util/aggregate/aggregateUtil/min";
 import { getBooleanMin } from "../../../../util/aggregate/aggregateUtil/min/booleanMin";
 import { getDateMin } from "../../../../util/aggregate/aggregateUtil/min/dateMin";
@@ -228,6 +229,9 @@ describe("min aggregate functionality tests", () => {
 
     test("should handle mixed data types gracefully", () => {
       const rows = [{ value: "string" }, { value: 123 }, { value: true }];
+      expect(() => {
+        getMin(rows, { value: true });
+      }).toThrow(GassmaAggregateMinError);
       expect(() => {
         getMin(rows, { value: true });
       }).toThrow("Cannot produce a maximum value of more than one type.");

--- a/src/__test__/util/aggregate/aggregateUtil/sum.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/sum.test.ts
@@ -1,3 +1,7 @@
+import {
+  GassmaAggregateSumError,
+  GassmaAggregateSumTypeError,
+} from "../../../../errors/aggregate/aggregateError";
 import { getSum } from "../../../../util/aggregate/aggregateUtil/sum";
 
 describe("getSum", () => {
@@ -45,12 +49,9 @@ describe("getSum", () => {
   test("should throw GassmaAggregateSumError for mixed data types", () => {
     const rows = [{ field: 10 }, { field: "string" }, { field: 30 }];
 
-    try {
-      getSum(rows, { field: true });
-      fail("Expected function to throw an error");
-    } catch (error: any) {
-      expect(error.name).toBe("GassmaAggregateSumError");
-    }
+    expect(() => getSum(rows, { field: true })).toThrow(
+      GassmaAggregateSumError,
+    );
   });
 
   test("should throw GassmaAggregateSumTypeError for non-numeric uniform data types", () => {
@@ -60,23 +61,17 @@ describe("getSum", () => {
       { field: "string3" },
     ];
 
-    try {
-      getSum(rows, { field: true });
-      fail("Expected function to throw an error");
-    } catch (error: any) {
-      expect(error.name).toBe("GassmaAggregateSumTypeError");
-    }
+    expect(() => getSum(rows, { field: true })).toThrow(
+      GassmaAggregateSumTypeError,
+    );
   });
 
   test("should throw GassmaAggregateSumTypeError for boolean data", () => {
     const rows = [{ field: true }, { field: false }, { field: true }];
 
-    try {
-      getSum(rows, { field: true });
-      fail("Expected function to throw an error");
-    } catch (error: any) {
-      expect(error.name).toBe("GassmaAggregateSumTypeError");
-    }
+    expect(() => getSum(rows, { field: true })).toThrow(
+      GassmaAggregateSumTypeError,
+    );
   });
 
   test("should throw GassmaAggregateSumTypeError for Date data", () => {
@@ -84,12 +79,9 @@ describe("getSum", () => {
     const date2 = new Date("2023-01-02");
     const rows = [{ field: date1 }, { field: date2 }];
 
-    try {
-      getSum(rows, { field: true });
-      fail("Expected function to throw an error");
-    } catch (error: any) {
-      expect(error.name).toBe("GassmaAggregateSumTypeError");
-    }
+    expect(() => getSum(rows, { field: true })).toThrow(
+      GassmaAggregateSumTypeError,
+    );
   });
 
   test("should handle empty rows array", () => {
@@ -134,11 +126,8 @@ describe("getSum", () => {
       { numeric: 20, allNull: null, mixed: "string" },
     ];
 
-    try {
-      getSum(rows, { numeric: true, allNull: true, mixed: true });
-      fail("Expected function to throw an error");
-    } catch (error: any) {
-      expect(error.name).toBe("GassmaAggregateSumError");
-    }
+    expect(() =>
+      getSum(rows, { numeric: true, allNull: true, mixed: true }),
+    ).toThrow(GassmaAggregateSumError);
   });
 });

--- a/src/__test__/util/create/nestedWrite/processAfterCreate.test.ts
+++ b/src/__test__/util/create/nestedWrite/processAfterCreate.test.ts
@@ -1,3 +1,4 @@
+import { NestedWriteConnectNotFoundError } from "../../../../errors/relation/nestedWriteError";
 import { processAfterCreate } from "../../../../util/create/nestedWrite/processAfterCreate";
 import type {
   RelationDefinition,
@@ -129,6 +130,13 @@ describe("processAfterCreate", () => {
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("posts", { connect: { id: 999 } });
 
+    expect(() =>
+      processAfterCreate(
+        { id: 1, name: "田中" },
+        relationOps,
+        makeContext({ posts: oneToManyRelation }),
+      ),
+    ).toThrow(NestedWriteConnectNotFoundError);
     expect(() =>
       processAfterCreate(
         { id: 1, name: "田中" },

--- a/src/__test__/util/create/nestedWrite/processBeforeCreate.test.ts
+++ b/src/__test__/util/create/nestedWrite/processBeforeCreate.test.ts
@@ -1,3 +1,4 @@
+import { NestedWriteConnectNotFoundError } from "../../../../errors/relation/nestedWriteError";
 import { processBeforeCreate } from "../../../../util/create/nestedWrite/processBeforeCreate";
 import type {
   RelationDefinition,
@@ -72,6 +73,13 @@ describe("processBeforeCreate", () => {
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("author", { connect: { id: 999 } });
 
+    expect(() =>
+      processBeforeCreate(
+        { title: "記事A" },
+        relationOps,
+        makeContext({ author: manyToOneRelation }),
+      ),
+    ).toThrow(NestedWriteConnectNotFoundError);
     expect(() =>
       processBeforeCreate(
         { title: "記事A" },

--- a/src/__test__/util/create/nestedWrite/processManyToMany.test.ts
+++ b/src/__test__/util/create/nestedWrite/processManyToMany.test.ts
@@ -1,3 +1,4 @@
+import { NestedWriteConnectNotFoundError } from "../../../../errors/relation/nestedWriteError";
 import { processManyToMany } from "../../../../util/create/nestedWrite/processManyToMany";
 import type {
   RelationDefinition,
@@ -107,6 +108,13 @@ describe("processManyToMany", () => {
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("tags", { connect: { id: 999 } });
 
+    expect(() =>
+      processManyToMany(
+        { id: 1, title: "記事A" },
+        relationOps,
+        makeContext({ tags: manyToManyRelation }),
+      ),
+    ).toThrow(NestedWriteConnectNotFoundError);
     expect(() =>
       processManyToMany(
         { id: 1, title: "記事A" },

--- a/src/__test__/util/create/nestedWrite/processOneToOne.test.ts
+++ b/src/__test__/util/create/nestedWrite/processOneToOne.test.ts
@@ -1,3 +1,7 @@
+import {
+  NestedWriteConnectNotFoundError,
+  NestedWriteInvalidOperationError,
+} from "../../../../errors/relation/nestedWriteError";
 import { processOneToOne } from "../../../../util/create/nestedWrite/processOneToOne";
 import type {
   RelationDefinition,
@@ -81,6 +85,13 @@ describe("processOneToOne", () => {
         makeOps({ connect: { id: 999 } }),
         makeContext({ profile: oneToOneRelation }),
       ),
+    ).toThrow(NestedWriteConnectNotFoundError);
+    expect(() =>
+      processOneToOne(
+        { id: 1, name: "田中" },
+        makeOps({ connect: { id: 999 } }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
     ).toThrow('no record found in "Profiles"');
     expect(mockUpdateManyOnSheet).not.toHaveBeenCalled();
   });
@@ -133,10 +144,24 @@ describe("processOneToOne", () => {
         makeOps({ createMany: { data: [{ bio: "自己紹介" }] } }),
         makeContext({ profile: oneToOneRelation }),
       ),
+    ).toThrow(NestedWriteInvalidOperationError);
+    expect(() =>
+      processOneToOne(
+        { id: 1, name: "田中" },
+        makeOps({ createMany: { data: [{ bio: "自己紹介" }] } }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
     ).toThrow('operation "createMany" is not valid');
   });
 
   it("配列 create は NestedWriteInvalidOperationError", () => {
+    expect(() =>
+      processOneToOne(
+        { id: 1, name: "田中" },
+        makeOps({ create: [{ bio: "自己紹介" }] }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
+    ).toThrow(NestedWriteInvalidOperationError);
     expect(() =>
       processOneToOne(
         { id: 1, name: "田中" },
@@ -153,10 +178,26 @@ describe("processOneToOne", () => {
         makeOps({ connect: [{ id: 5 }] }),
         makeContext({ profile: oneToOneRelation }),
       ),
+    ).toThrow(NestedWriteInvalidOperationError);
+    expect(() =>
+      processOneToOne(
+        { id: 1, name: "田中" },
+        makeOps({ connect: [{ id: 5 }] }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
     ).toThrow('operation "connect" is not valid');
   });
 
   it("配列 connectOrCreate は NestedWriteInvalidOperationError", () => {
+    expect(() =>
+      processOneToOne(
+        { id: 1, name: "田中" },
+        makeOps({
+          connectOrCreate: [{ where: { id: 5 }, create: { bio: "a" } }],
+        }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
+    ).toThrow(NestedWriteInvalidOperationError);
     expect(() =>
       processOneToOne(
         { id: 1, name: "田中" },

--- a/src/__test__/util/create/nestedWrite/resolveNestedCreate.test.ts
+++ b/src/__test__/util/create/nestedWrite/resolveNestedCreate.test.ts
@@ -1,3 +1,4 @@
+import { NestedWriteWithoutRelationsError } from "../../../../errors/relation/nestedWriteError";
 import { resolveNestedCreate } from "../../../../util/create/nestedWrite/resolveNestedCreate";
 import type {
   RelationDefinition,
@@ -186,7 +187,7 @@ describe("resolveNestedCreate", () => {
         mockCreateFunc,
         undefined,
       ),
-    ).toThrow("Cannot use nested write");
+    ).toThrow(NestedWriteWithoutRelationsError);
   });
 
   const oneToOneRelation: RelationDefinition = {

--- a/src/__test__/util/find/findUtil/applySelectOmit.test.ts
+++ b/src/__test__/util/find/findUtil/applySelectOmit.test.ts
@@ -1,3 +1,4 @@
+import { GassmaFindSelectOmitConflictError } from "../../../../errors/find/findError";
 import { applySelectOmit } from "../../../../util/find/findUtil/applySelectOmit";
 
 const data = [
@@ -29,7 +30,7 @@ describe("applySelectOmit", () => {
 
   test("should throw when both select and omit specified", () => {
     expect(() => applySelectOmit(data, { name: true }, { city: true })).toThrow(
-      "Cannot use both select and omit",
+      GassmaFindSelectOmitConflictError,
     );
   });
 });

--- a/src/__test__/util/find/findUtil/resolveRelationOrderBy.test.ts
+++ b/src/__test__/util/find/findUtil/resolveRelationOrderBy.test.ts
@@ -1,3 +1,7 @@
+import {
+  RelationOrderByCountUnsupportedTypeError,
+  RelationOrderByUnsupportedTypeError,
+} from "../../../../errors/find/findError";
 import { resolveRelationOrderBy } from "../../../../util/find/findUtil/resolveRelationOrderBy";
 import type { RelationContext } from "../../../../types/relationTypes";
 import type { OrderBy } from "../../../../types/coreTypes";
@@ -199,7 +203,7 @@ describe("resolveRelationOrderBy", () => {
 
     expect(() =>
       resolveRelationOrderBy([{ id: 1 }], orderByArr, context),
-    ).toThrow("Only manyToOne and oneToOne are supported");
+    ).toThrow(RelationOrderByUnsupportedTypeError);
   });
 
   test("should return records as-is when empty", () => {
@@ -406,6 +410,6 @@ describe("resolveRelationOrderBy", () => {
 
     expect(() =>
       resolveRelationOrderBy([{ id: 1, authorId: 1 }], orderByArr, context),
-    ).toThrow("Only oneToMany and manyToMany are supported");
+    ).toThrow(RelationOrderByCountUnsupportedTypeError);
   });
 });

--- a/src/__test__/util/groupby/groupbyUtil/having/normalHavingFilter/notPatternFilter.test.ts
+++ b/src/__test__/util/groupby/groupbyUtil/having/normalHavingFilter/notPatternFilter.test.ts
@@ -1,3 +1,4 @@
+import { GassmaGroupByHavingDontWriteByError } from "../../../../../../errors/groupBy/groupByError";
 import { notPatternFilter } from "../../../../../../util/groupby/groubyUtil/having/normalHavingFilter/notPatternFilter";
 import type {
   HitByClassificationedRowData,
@@ -558,12 +559,9 @@ describe("notPatternFilter function tests", () => {
         nonExistentField: "value",
       };
 
-      try {
-        notPatternFilter(mockClassificationedRows, havingData, ["age", "name"]);
-        fail("Expected function to throw an error");
-      } catch (error: any) {
-        expect(error.name).toBe("GassmaGroupByHavingDontWriteByError");
-      }
+      expect(() =>
+        notPatternFilter(mockClassificationedRows, havingData, ["age", "name"]),
+      ).toThrow(GassmaGroupByHavingDontWriteByError);
     });
 
     test("should throw error for complex condition with field not in by array", () => {
@@ -571,12 +569,9 @@ describe("notPatternFilter function tests", () => {
         nonExistentField: { equals: "value" },
       };
 
-      try {
-        notPatternFilter(mockClassificationedRows, havingData, ["age", "name"]);
-        fail("Expected function to throw an error");
-      } catch (error: any) {
-        expect(error.name).toBe("GassmaGroupByHavingDontWriteByError");
-      }
+      expect(() =>
+        notPatternFilter(mockClassificationedRows, havingData, ["age", "name"]),
+      ).toThrow(GassmaGroupByHavingDontWriteByError);
     });
 
     test("should handle empty rows array", () => {

--- a/src/__test__/util/relation/onDelete/resolveOnDelete.test.ts
+++ b/src/__test__/util/relation/onDelete/resolveOnDelete.test.ts
@@ -1,3 +1,4 @@
+import { RelationOnDeleteRestrictError } from "../../../../errors/relation/relationError";
 import { resolveOnDelete } from "../../../../util/relation/onDelete/resolveOnDelete";
 import type {
   RelationDefinition,
@@ -147,6 +148,9 @@ describe("resolveOnDelete", () => {
     mockFindMany.mockReturnValue([{ id: 101, authorId: 1 }]);
 
     expect(() => resolveOnDelete([{ id: 1 }], baseContext(relations))).toThrow(
+      RelationOnDeleteRestrictError,
+    );
+    expect(() => resolveOnDelete([{ id: 1 }], baseContext(relations))).toThrow(
       "posts",
     );
   });
@@ -214,6 +218,9 @@ describe("resolveOnDelete", () => {
 
     mockFindMany.mockReturnValue([{ id: 201, userId: 1 }]);
 
+    expect(() => resolveOnDelete([{ id: 1 }], baseContext(relations))).toThrow(
+      RelationOnDeleteRestrictError,
+    );
     expect(() => resolveOnDelete([{ id: 1 }], baseContext(relations))).toThrow(
       "comments",
     );

--- a/src/__test__/util/relation/onUpdate/resolveOnUpdate.test.ts
+++ b/src/__test__/util/relation/onUpdate/resolveOnUpdate.test.ts
@@ -1,3 +1,4 @@
+import { RelationOnUpdateRestrictError } from "../../../../errors/relation/relationError";
 import { resolveOnUpdate } from "../../../../util/relation/onUpdate/resolveOnUpdate";
 import type {
   RelationDefinition,
@@ -179,6 +180,9 @@ describe("resolveOnUpdate", () => {
 
     expect(() =>
       resolveOnUpdate([{ id: 1 }], [{ id: 10 }], baseContext(relations)),
+    ).toThrow(RelationOnUpdateRestrictError);
+    expect(() =>
+      resolveOnUpdate([{ id: 1 }], [{ id: 10 }], baseContext(relations)),
     ).toThrow("posts");
   });
 
@@ -263,6 +267,9 @@ describe("resolveOnUpdate", () => {
 
     mockFindMany.mockReturnValue([{ id: 201, userId: 1 }]);
 
+    expect(() =>
+      resolveOnUpdate([{ id: 1 }], [{ id: 10 }], baseContext(relations)),
+    ).toThrow(RelationOnUpdateRestrictError);
     expect(() =>
       resolveOnUpdate([{ id: 1 }], [{ id: 10 }], baseContext(relations)),
     ).toThrow("comments");

--- a/src/__test__/util/relation/validation/validateIncludeOptions.test.ts
+++ b/src/__test__/util/relation/validation/validateIncludeOptions.test.ts
@@ -1,3 +1,7 @@
+import {
+  IncludeSelectIncludeConflictError,
+  IncludeSelectOmitConflictError,
+} from "../../../../errors/relation/relationValidationError";
 import { validateIncludeOptions } from "../../../../util/relation/validation/validateIncludeOptions";
 import type { IncludeData } from "../../../../types/relationTypes";
 
@@ -38,7 +42,7 @@ describe("validateIncludeOptions", () => {
         validateIncludeOptions({
           posts: { select: { id: true }, omit: { title: true } },
         }),
-      ).toThrow("cannot use both select and omit");
+      ).toThrow(IncludeSelectOmitConflictError);
     });
 
     it("select のみの場合エラーを投げない", () => {
@@ -207,7 +211,7 @@ describe("validateIncludeOptions", () => {
         validateIncludeOptions({
           posts: { select: { id: true }, include: { comments: true } },
         }),
-      ).toThrow("cannot use both select and include");
+      ).toThrow(IncludeSelectIncludeConflictError);
     });
 
     it("ネストされた include を再帰的にバリデーションする", () => {

--- a/src/__test__/util/relation/validation/validateRelationDefinition.test.ts
+++ b/src/__test__/util/relation/validation/validateRelationDefinition.test.ts
@@ -1,3 +1,7 @@
+import {
+  RelationInvalidOnDeleteError,
+  RelationInvalidOnUpdateError,
+} from "../../../../errors/relation/relationValidationError";
 import { validateRelationDefinition } from "../../../../util/relation/validation/validateRelationDefinition";
 
 describe("validateRelationDefinition", () => {
@@ -260,6 +264,14 @@ describe("validateRelationDefinition", () => {
           definition,
           allSheetNames,
         ),
+      ).toThrow(RelationInvalidOnUpdateError);
+      expect(() =>
+        validateRelationDefinition(
+          sheetName,
+          "posts",
+          definition,
+          allSheetNames,
+        ),
       ).toThrow("InvalidAction");
     });
   });
@@ -296,6 +308,14 @@ describe("validateRelationDefinition", () => {
         onDelete: "InvalidAction",
       };
 
+      expect(() =>
+        validateRelationDefinition(
+          sheetName,
+          "posts",
+          definition,
+          allSheetNames,
+        ),
+      ).toThrow(RelationInvalidOnDeleteError);
       expect(() =>
         validateRelationDefinition(
           sheetName,

--- a/src/__test__/util/update/nestedWrite/processAfterUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/processAfterUpdate.test.ts
@@ -1,3 +1,4 @@
+import { NestedWriteInvalidOperationError } from "../../../../errors/relation/nestedWriteError";
 import { processAfterUpdate } from "../../../../util/update/nestedWrite/processAfterUpdate";
 import type {
   RelationDefinition,
@@ -230,6 +231,13 @@ describe("processAfterUpdate", () => {
     const relationOps = new Map<string, NestedWriteOperation>();
     relationOps.set("posts", { disconnect: true });
 
+    expect(() =>
+      processAfterUpdate(
+        { id: 1, name: "田中" },
+        relationOps,
+        makeContext({ posts: oneToManyRelation }),
+      ),
+    ).toThrow(NestedWriteInvalidOperationError);
     expect(() =>
       processAfterUpdate(
         { id: 1, name: "田中" },

--- a/src/__test__/util/update/nestedWrite/processBeforeUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/processBeforeUpdate.test.ts
@@ -1,3 +1,4 @@
+import { NestedWriteInvalidOperationError } from "../../../../errors/relation/nestedWriteError";
 import { processBeforeUpdate } from "../../../../util/update/nestedWrite/processBeforeUpdate";
 import type {
   RelationDefinition,
@@ -174,6 +175,14 @@ describe("processBeforeUpdate", () => {
         relationOps,
         makeContext({ author: manyToOneRelation }),
       ),
+    ).toThrow(NestedWriteInvalidOperationError);
+    expect(() =>
+      processBeforeUpdate(
+        { title: "記事A", authorId: 1 },
+        enrichedData,
+        relationOps,
+        makeContext({ author: manyToOneRelation }),
+      ),
     ).toThrow("disconnect");
   });
 
@@ -186,6 +195,14 @@ describe("processBeforeUpdate", () => {
       profileId: 5,
     };
 
+    expect(() =>
+      processBeforeUpdate(
+        { name: "田中", profileId: 5 },
+        enrichedData,
+        relationOps,
+        makeContext({ profile: fkSideProfileRelation }),
+      ),
+    ).toThrow(NestedWriteInvalidOperationError);
     expect(() =>
       processBeforeUpdate(
         { name: "田中", profileId: 5 },

--- a/src/__test__/util/update/nestedWrite/processOneToOneUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/processOneToOneUpdate.test.ts
@@ -1,3 +1,7 @@
+import {
+  NestedWriteInvalidOperationError,
+  NestedWriteTargetNotFoundError,
+} from "../../../../errors/relation/nestedWriteError";
 import { processOneToOneUpdate } from "../../../../util/update/nestedWrite/processOneToOneUpdate";
 import type {
   RelationDefinition,
@@ -65,21 +69,16 @@ describe("processOneToOneUpdate", () => {
     ).toThrow('Nested write update failed: no record found in "Profiles"');
   });
 
-  it("update 相手不在エラーの name は NestedWriteTargetNotFoundError", () => {
+  it("update 相手不在エラーは NestedWriteTargetNotFoundError", () => {
     mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
 
-    let caught: unknown;
-    try {
+    expect(() =>
       processOneToOneUpdate(
         { id: 1, name: "田中" },
         makeOps({ update: { bio: "変更後" } }),
         makeContext({ profile: oneToOneRelation }),
-      );
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBeInstanceOf(Error);
-    expect((caught as Error).name).toBe("NestedWriteTargetNotFoundError");
+      ),
+    ).toThrow(NestedWriteTargetNotFoundError);
   });
 
   it("disconnect: true で相手の reference 列が null 化される", () => {
@@ -116,6 +115,13 @@ describe("processOneToOneUpdate", () => {
         makeOps({ disconnect: { id: 5 } }),
         makeContext({ profile: oneToOneRelation }),
       ),
+    ).toThrow(NestedWriteInvalidOperationError);
+    expect(() =>
+      processOneToOneUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ disconnect: { id: 5 } }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
     ).toThrow('operation "disconnect" is not valid');
   });
 
@@ -142,10 +148,24 @@ describe("processOneToOneUpdate", () => {
         makeOps({ delete: true }),
         makeContext({ profile: oneToOneRelation }),
       ),
+    ).toThrow(NestedWriteTargetNotFoundError);
+    expect(() =>
+      processOneToOneUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ delete: true }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
     ).toThrow('Nested write delete failed: no record found in "Profiles"');
   });
 
   it("delete に true 以外を渡すとエラー", () => {
+    expect(() =>
+      processOneToOneUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ delete: { id: 5 } }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
+    ).toThrow(NestedWriteInvalidOperationError);
     expect(() =>
       processOneToOneUpdate(
         { id: 1, name: "田中" },
@@ -162,10 +182,24 @@ describe("processOneToOneUpdate", () => {
         makeOps({ update: [{ where: { id: 5 }, data: { bio: "a" } }] }),
         makeContext({ profile: oneToOneRelation }),
       ),
+    ).toThrow(NestedWriteInvalidOperationError);
+    expect(() =>
+      processOneToOneUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ update: [{ where: { id: 5 }, data: { bio: "a" } }] }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
     ).toThrow('operation "update" is not valid');
   });
 
   it("where/data 形式の update はエラー", () => {
+    expect(() =>
+      processOneToOneUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ update: { where: { id: 5 }, data: { bio: "a" } } }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
+    ).toThrow(NestedWriteInvalidOperationError);
     expect(() =>
       processOneToOneUpdate(
         { id: 1, name: "田中" },
@@ -182,10 +216,24 @@ describe("processOneToOneUpdate", () => {
         makeOps({ set: [{ id: 5 }] }),
         makeContext({ profile: oneToOneRelation }),
       ),
+    ).toThrow(NestedWriteInvalidOperationError);
+    expect(() =>
+      processOneToOneUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ set: [{ id: 5 }] }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
     ).toThrow('operation "set" is not valid');
   });
 
   it("deleteMany はエラー", () => {
+    expect(() =>
+      processOneToOneUpdate(
+        { id: 1, name: "田中" },
+        makeOps({ deleteMany: { id: 5 } }),
+        makeContext({ profile: oneToOneRelation }),
+      ),
+    ).toThrow(NestedWriteInvalidOperationError);
     expect(() =>
       processOneToOneUpdate(
         { id: 1, name: "田中" },

--- a/src/__test__/util/update/nestedWrite/resolveNestedUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/resolveNestedUpdate.test.ts
@@ -1,3 +1,7 @@
+import {
+  NestedWriteTargetNotFoundError,
+  NestedWriteWithoutRelationsError,
+} from "../../../../errors/relation/nestedWriteError";
 import { resolveNestedUpdate } from "../../../../util/update/nestedWrite/resolveNestedUpdate";
 import type {
   RelationDefinition,
@@ -325,7 +329,7 @@ describe("resolveNestedUpdate", () => {
         },
         undefined,
       ),
-    ).toThrow("Cannot use nested write");
+    ).toThrow(NestedWriteWithoutRelationsError);
   });
 
   const oneToOneRelation: RelationDefinition = {
@@ -362,6 +366,16 @@ describe("resolveNestedUpdate", () => {
     expect(() =>
       resolveNestedUpdate(
         util,
+        {
+          where: { id: 1 },
+          data: { profile: { update: { bio: "変更後" } } },
+        },
+        makeContext({ profile: oneToOneRelation }),
+      ),
+    ).toThrow(NestedWriteTargetNotFoundError);
+    expect(() =>
+      resolveNestedUpdate(
+        setupSheet(["id", "name"], [[1, "田中"]]),
         {
           where: { id: 1 },
           data: { profile: { update: { bio: "変更後" } } },
@@ -417,6 +431,16 @@ describe("resolveNestedUpdate", () => {
     expect(() =>
       resolveNestedUpdate(
         util,
+        {
+          where: { id: 1 },
+          data: { profile: { delete: true } },
+        },
+        makeContext({ profile: oneToOneRelation }),
+      ),
+    ).toThrow(NestedWriteTargetNotFoundError);
+    expect(() =>
+      resolveNestedUpdate(
+        setupSheet(["id", "name"], [[1, "田中"]]),
         {
           where: { id: 1 },
           data: { profile: { delete: true } },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["src"],
   "compilerOptions": {
     "lib": ["ES2021"],
-    "target": "ES5",
+    "target": "ES2019",
     "module": "CommonJS"
   }
 }


### PR DESCRIPTION
## 概要

compile target を **ES5 → ES2019** に上げ、全エラークラスの prototype チェーン破損(`class X extends Error` の ES5 降格で `instanceof` / `toThrow(コンストラクタ)` が一切効かない問題)を根治します(ユーザー承認済み。setPrototypeOf を全クラスに撒く案は不採用)。

## 安全性の根拠

- デプロイ先は `runtimeVersion: "V8"`。gassma-test は既に target es2015 で同 V8 上で全グループ稼働実績あり
- webpack の bootstrap/ラッパー自体が従来からアロー関数等 ES2015+ を出力しており(browserslist 未指定)、実質 V8 前提だった。今回 TS 出力もそれに揃った形
- `super()` 前 this 参照・class フィールド初期化順などの挙動差が出るコードは無し(全エラークラスが素直な `super()` → `this.name` のみ)。**挙動が変わるのは意図どおり prototype チェーンのみ**

## 変更(2コミット)

1. **`25c8599`**: tsconfig target 変更 + prototype チェーンのピン留めスイート新設(8クラス × toThrow(ctor)/instanceof/getPrototypeOf + 2段継承。**ES5 で 25/25 fail → ES2019 で 25/25 pass を実測**、ES5/ES2019 両バンドルでも対比実証)
2. **`71def46`**: 既存テストのエラーアサーション移行(48箇所): try/catch+name 文字列 13 変換(`as Error` 1箇所と jest-circus の `fail()` 未定義頼みも解消)、静的メッセージ代理 7 置換、動的値メッセージ 28 は照合維持+ctor 追加(Min/Max/Sum/Avg は共通メッセージでクラス識別不能だったため ctor 照合が初めて有意味に)。**Prisma パリティ完全一致メッセージは照合維持**

## 実バンドル検証(clasp が push する実物)

- `dist/bundle.js` の gas-webpack-plugin トップレベル関数宣言・グローバル代入 181 シンボルが **ES5 版と完全一致**。`__extends` ヘルパー 52→0、ネイティブ `class extends Error` 46 箇所を確認。サイズ 355KB→320KB
- **webpack が出した bundle.js をそのまま mock GAS(vm)にロード**し、gassma-test の生成クライアント + 全12シートのシードで read/create/update・upsert/delete/error/$extends(#152)の 6 シナリオ **68 assertions 全 pass**

## テスト

1487 → **1512(+25)**、tsc / lint(警告数ベースライン同数)/ format / build 全 green。

## 報告事項(既存問題の発見・本 PR 未対応)

**gas-webpack-plugin のグローバル公開が GassmaClient 以外壊れている**(ES5 時代から): 各モジュール末尾の global 代入がエントリ側の `__webpack_exports__` を掴み、エラークラス含む 180 シンボルが実行時 undefined(ES5/ES2019 両バンドルで同一を実測)。現状の実利用は `Gassma.GassmaClient` のみで実害なしですが、**index.d.ts は `Gassma.NotFoundError` 等を宣言済み = 利用者が instanceof しようとすると型は通るが実体が無い**状態。別タスクとして起票します。

## マージ後

出力コードが全域で変わるため、デプロイ後に **GAS 実機で全グループの実行**をお願いします(testRead → testCreateAll → testUpdateAll → testUpsertAll → testDeleteAll → testErrorAll → testSettingsAll → testFormulaAll → testSecurityAll → testGlobalOmitWriteAll を順に)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX