### PR TITLE
feat: add $extends result component (computed fields, Tier1 top-level)

### DIFF
--- a/src/__test__/util/extends/extendsTestClient.ts
+++ b/src/__test__/util/extends/extendsTestClient.ts
@@ -83,6 +83,14 @@ const buildTestClient = (options?: { relations?: boolean }): GassmaClient => {
           reference: "authorId",
         },
       },
+      Posts: {
+        author: {
+          type: "manyToOne",
+          to: "Users",
+          field: "authorId",
+          reference: "id",
+        },
+      },
     },
   });
 };

--- a/src/__test__/util/extends/result/resultExtendsAllModels.test.ts
+++ b/src/__test__/util/extends/result/resultExtendsAllModels.test.ts
@@ -1,0 +1,198 @@
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "../extendsTestClient";
+
+afterAll(clearSpreadsheetApp);
+
+const idLabelExtension = {
+  result: {
+    $allModels: {
+      idLabel: {
+        needs: { id: true },
+        compute: (record: { id: number }) => `#${record.id}`,
+      },
+    },
+  },
+};
+
+describe("$extends result: $allModels 基本動作", () => {
+  test("findMany で全モデルの各レコードに算出フィールドが付く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(idLabelExtension);
+    expect(extended.Users.findMany({})).toEqual([
+      { id: 1, name: "Alice", age: 20, idLabel: "#1" },
+      { id: 2, name: "Bob", age: 30, idLabel: "#2" },
+      { id: 3, name: "Carol", age: 40, idLabel: "#3" },
+    ]);
+    expect(extended.Posts.findMany({})).toEqual([
+      { id: 101, authorId: 1, title: "Post A", idLabel: "#101" },
+      { id: 102, authorId: 2, title: "Post B", idLabel: "#102" },
+    ]);
+  });
+
+  test("findFirst でも各モデルに付く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(idLabelExtension);
+    expect(extended.Users.findFirst({ where: { id: 2 } })).toEqual({
+      id: 2,
+      name: "Bob",
+      age: 30,
+      idLabel: "#2",
+    });
+    expect(extended.Posts.findFirst({ where: { id: 101 } })).toEqual({
+      id: 101,
+      authorId: 1,
+      title: "Post A",
+      idLabel: "#101",
+    });
+  });
+
+  test("元クライアントには影響しない", () => {
+    const client = buildTestClient();
+    void client.$extends(idLabelExtension);
+    expect(sheetOf(client, "Users").findMany({ where: { id: 1 } })).toEqual([
+      { id: 1, name: "Alice", age: 20 },
+    ]);
+    expect(sheetOf(client, "Posts").findMany({ where: { id: 101 } })).toEqual([
+      { id: 101, authorId: 1, title: "Post A" },
+    ]);
+  });
+});
+
+describe("$extends result: $allModels とモデル固有の合成", () => {
+  test("同名フィールドは定義順によらずモデル固有が勝ち他モデルは $allModels のまま", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      result: {
+        Users: {
+          idLabel: {
+            needs: { id: true },
+            compute: (record: { id: number }) => `User-${record.id}`,
+          },
+        },
+        $allModels: {
+          idLabel: {
+            needs: { id: true },
+            compute: (record: { id: number }) => `#${record.id}`,
+          },
+        },
+      },
+    });
+    expect(
+      extended.Users.findFirst({ where: { id: 1 }, select: { idLabel: true } }),
+    ).toEqual({ idLabel: "User-1" });
+    expect(
+      extended.Posts.findFirst({
+        where: { id: 101 },
+        select: { idLabel: true },
+      }),
+    ).toEqual({ idLabel: "#101" });
+  });
+
+  test("別名なら $allModels とモデル固有の両方が付く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      result: {
+        $allModels: {
+          idLabel: {
+            needs: { id: true },
+            compute: (record: { id: number }) => `#${record.id}`,
+          },
+        },
+        Users: {
+          fullName: {
+            needs: { name: true },
+            compute: (user: { name: string }) => `Mr. ${user.name}`,
+          },
+        },
+      },
+    });
+    expect(extended.Users.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+      idLabel: "#1",
+      fullName: "Mr. Alice",
+    });
+    expect(extended.Posts.findFirst({ where: { id: 102 } })).toEqual({
+      id: 102,
+      authorId: 2,
+      title: "Post B",
+      idLabel: "#102",
+    });
+  });
+
+  test("モデル固有の算出フィールドは $allModels の算出フィールドに依存できる", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      result: {
+        Users: {
+          banner: {
+            needs: { idLabel: true },
+            compute: (user: { idLabel: string }) => `banner(${user.idLabel})`,
+          },
+        },
+        $allModels: {
+          idLabel: {
+            needs: { id: true },
+            compute: (record: { id: number }) => `#${record.id}`,
+          },
+        },
+      },
+    });
+    expect(
+      extended.Users.findFirst({ where: { id: 3 }, select: { banner: true } }),
+    ).toEqual({ banner: "banner(#3)" });
+  });
+
+  test("複数拡張のチェーンでは後の拡張の $allModels が前のモデル固有に勝つ", () => {
+    const client = buildTestClient();
+    const extended = client
+      .$extends({
+        result: {
+          Users: {
+            idLabel: {
+              needs: { id: true },
+              compute: (record: { id: number }) => `User-${record.id}`,
+            },
+          },
+        },
+      })
+      .$extends({
+        result: {
+          $allModels: {
+            idLabel: {
+              needs: { id: true },
+              compute: (record: { id: number }) => `#${record.id}`,
+            },
+          },
+        },
+      });
+    expect(
+      extended.Users.findFirst({ where: { id: 1 }, select: { idLabel: true } }),
+    ).toEqual({ idLabel: "#1" });
+  });
+});
+
+describe("$extends result: $allModels の select / omit 連携", () => {
+  test("select で $allModels の算出フィールドを指定すると needs は補完後に除去される", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(idLabelExtension);
+    expect(
+      extended.Posts.findMany({ select: { title: true, idLabel: true } }),
+    ).toEqual([
+      { title: "Post A", idLabel: "#101" },
+      { title: "Post B", idLabel: "#102" },
+    ]);
+  });
+
+  test("omit で $allModels の算出フィールドを除去できる", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(idLabelExtension);
+    expect(
+      extended.Users.findFirst({ where: { id: 1 }, omit: { idLabel: true } }),
+    ).toEqual({ id: 1, name: "Alice", age: 20 });
+  });
+});

--- a/src/__test__/util/extends/result/resultExtendsBasic.test.ts
+++ b/src/__test__/util/extends/result/resultExtendsBasic.test.ts
@@ -1,0 +1,159 @@
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "../extendsTestClient";
+
+afterAll(clearSpreadsheetApp);
+
+const fullNameExtension = {
+  result: {
+    Users: {
+      fullName: {
+        needs: { name: true },
+        compute: (user: { name: string }) => `Mr. ${user.name}`,
+      },
+    },
+  },
+};
+
+describe("$extends result: 基本動作", () => {
+  test("findMany の各レコードに算出フィールドが付く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(extended.Users.findMany({})).toEqual([
+      { id: 1, name: "Alice", age: 20, fullName: "Mr. Alice" },
+      { id: 2, name: "Bob", age: 30, fullName: "Mr. Bob" },
+      { id: 3, name: "Carol", age: 40, fullName: "Mr. Carol" },
+    ]);
+  });
+
+  test("findFirst / findFirstOrThrow の単体レコードに付く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(extended.Users.findFirst({ where: { id: 2 } })).toEqual({
+      id: 2,
+      name: "Bob",
+      age: 30,
+      fullName: "Mr. Bob",
+    });
+    expect(extended.Users.findFirstOrThrow({ where: { id: 3 } })).toEqual({
+      id: 3,
+      name: "Carol",
+      age: 40,
+      fullName: "Mr. Carol",
+    });
+  });
+
+  test("findFirst で該当なしなら null のまま", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(extended.Users.findFirst({ where: { id: 999 } })).toBeNull();
+  });
+
+  test("result 定義のないモデルは素通し", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(extended.Posts.findMany({})).toEqual([
+      { id: 101, authorId: 1, title: "Post A" },
+      { id: 102, authorId: 2, title: "Post B" },
+    ]);
+  });
+
+  test("書き込み系の返却レコードに付く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(
+      extended.Users.create({ data: { id: 4, name: "Dave", age: 1 } }),
+    ).toEqual({ id: 4, name: "Dave", age: 1, fullName: "Mr. Dave" });
+    expect(
+      extended.Users.createManyAndReturn({
+        data: [{ id: 5, name: "Eve", age: 2 }],
+      }),
+    ).toEqual([{ id: 5, name: "Eve", age: 2, fullName: "Mr. Eve" }]);
+    expect(
+      extended.Users.update({ where: { id: 1 }, data: { age: 21 } }),
+    ).toEqual({ id: 1, name: "Alice", age: 21, fullName: "Mr. Alice" });
+    expect(
+      extended.Users.updateManyAndReturn({
+        where: { id: 2 },
+        data: { age: 31 },
+      }),
+    ).toEqual([{ id: 2, name: "Bob", age: 31, fullName: "Mr. Bob" }]);
+    expect(
+      extended.Users.upsert({
+        where: { id: 6 },
+        create: { id: 6, name: "Frank", age: 3 },
+        update: { age: 99 },
+      }),
+    ).toEqual({ id: 6, name: "Frank", age: 3, fullName: "Mr. Frank" });
+    expect(extended.Users.delete({ where: { id: 6 } })).toEqual({
+      id: 6,
+      name: "Frank",
+      age: 3,
+      fullName: "Mr. Frank",
+    });
+  });
+
+  test("レコードを返さない操作には付かない", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(extended.Users.count({})).toBe(3);
+    expect(extended.Users.aggregate({ _count: { id: true } })).toEqual({
+      _count: { id: 3 },
+    });
+    const grouped = extended.Users.groupBy({ by: "age", _count: { id: true } });
+    grouped.forEach((group: Record<string, unknown>) => {
+      expect(group).not.toHaveProperty("fullName");
+    });
+    expect(
+      extended.Users.createMany({ data: [{ id: 7, name: "Gina", age: 4 }] }),
+    ).toEqual({ count: 1 });
+    expect(
+      extended.Users.updateMany({ where: { id: 7 }, data: { age: 5 } }),
+    ).toEqual({ count: 1 });
+    expect(extended.Users.deleteMany({ where: { id: 7 } })).toEqual({
+      count: 1,
+    });
+  });
+
+  test("算出フィールドは eager な通常プロパティ", () => {
+    const client = buildTestClient();
+    const compute = jest.fn((user: { name: string }) => `Mr. ${user.name}`);
+    const extended = client.$extends({
+      result: { Users: { fullName: { needs: { name: true }, compute } } },
+    });
+    const rows = extended.Users.findMany({});
+    expect(compute).toHaveBeenCalledTimes(3);
+    const descriptor = Object.getOwnPropertyDescriptor(rows[0], "fullName");
+    expect(descriptor).toMatchObject({
+      value: "Mr. Alice",
+      enumerable: true,
+      writable: true,
+    });
+    expect(descriptor?.get).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(rows[0])).fullName).toBe("Mr. Alice");
+    expect({ ...rows[0] }).toMatchObject({ fullName: "Mr. Alice" });
+    expect(rows[0]).toHaveProperty("fullName", "Mr. Alice");
+    expect(rows[0]).toHaveProperty("fullName", "Mr. Alice");
+    expect(compute).toHaveBeenCalledTimes(3);
+  });
+
+  test("元クライアントには影響しない", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    void extended;
+    expect(sheetOf(client, "Users").findMany({ where: { id: 1 } })).toEqual([
+      { id: 1, name: "Alice", age: 20 },
+    ]);
+  });
+
+  test("操作以外のメンバー（getColumnHeaders / fields）は透過する", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(extended.Users.getColumnHeaders()).toEqual(["id", "name", "age"]);
+    const ref = extended.Users.fields.age;
+    expect(ref.modelName).toBe("Users");
+    expect(ref.name).toBe("age");
+  });
+});

--- a/src/__test__/util/extends/result/resultExtendsComposition.test.ts
+++ b/src/__test__/util/extends/result/resultExtendsComposition.test.ts
@@ -1,0 +1,240 @@
+import { buildTestClient, clearSpreadsheetApp } from "../extendsTestClient";
+
+afterAll(clearSpreadsheetApp);
+
+describe("$extends result: 依存と上書き", () => {
+  test("算出フィールド同士の依存は宣言順によらず依存順に計算される", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      result: {
+        Users: {
+          greeting: {
+            needs: { fullName: true },
+            compute: (user: { fullName: string }) => `Hello, ${user.fullName}`,
+          },
+          fullName: {
+            needs: { name: true },
+            compute: (user: { name: string }) => `Mr. ${user.name}`,
+          },
+        },
+      },
+    });
+    expect(extended.Users.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+      fullName: "Mr. Alice",
+      greeting: "Hello, Mr. Alice",
+    });
+  });
+
+  test("3 段の依存連鎖も解決される", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      result: {
+        Users: {
+          c: {
+            needs: { b: true },
+            compute: (user: { b: string }) => `c(${user.b})`,
+          },
+          b: {
+            needs: { a: true },
+            compute: (user: { a: string }) => `b(${user.a})`,
+          },
+          a: {
+            needs: { name: true },
+            compute: (user: { name: string }) => `a(${user.name})`,
+          },
+        },
+      },
+    });
+    const row = extended.Users.findFirst({
+      where: { id: 2 },
+      select: { id: true, c: true },
+    });
+    expect(row).toEqual({ id: 2, c: "c(b(a(Bob)))" });
+  });
+
+  test("依存する算出フィールドを select しても依存先は出力されない", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      result: {
+        Users: {
+          greeting: {
+            needs: { fullName: true },
+            compute: (user: { fullName: string }) => `Hello, ${user.fullName}`,
+          },
+          fullName: {
+            needs: { name: true },
+            compute: (user: { name: string }) => `Mr. ${user.name}`,
+          },
+        },
+      },
+    });
+    expect(
+      extended.Users.findFirst({
+        where: { id: 1 },
+        select: { id: true, greeting: true },
+      }),
+    ).toEqual({ id: 1, greeting: "Hello, Mr. Alice" });
+  });
+
+  test("既存フィールドと同名の算出フィールドは値を置換し compute は元の値を受け取る", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      result: {
+        Users: {
+          name: {
+            needs: { name: true },
+            compute: (user: { name: string }) => user.name.toUpperCase(),
+          },
+        },
+      },
+    });
+    expect(extended.Users.findMany({})).toEqual([
+      { id: 1, name: "ALICE", age: 20 },
+      { id: 2, name: "BOB", age: 30 },
+      { id: 3, name: "CAROL", age: 40 },
+    ]);
+    expect(
+      extended.Users.findFirst({ where: { id: 1 }, select: { name: true } }),
+    ).toEqual({ name: "ALICE" });
+  });
+});
+
+describe("$extends result: query 併用とマージ", () => {
+  test("同一拡張オブジェクトの query と result が両方効く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      query: {
+        Users: {
+          findMany({ args, query }) {
+            return query({ ...args, where: { name: "Bob" } });
+          },
+        },
+      },
+      result: {
+        Users: {
+          fullName: {
+            needs: { name: true },
+            compute: (user: { name: string }) => `Mr. ${user.name}`,
+          },
+        },
+      },
+    });
+    expect(extended.Users.findMany({})).toEqual([
+      { id: 2, name: "Bob", age: 30, fullName: "Mr. Bob" },
+    ]);
+  });
+
+  test("チェーンした複数の result 拡張はマージされる", () => {
+    const client = buildTestClient();
+    const extended = client
+      .$extends({
+        result: {
+          Users: {
+            fullName: {
+              needs: { name: true },
+              compute: (user: { name: string }) => `Mr. ${user.name}`,
+            },
+          },
+        },
+      })
+      .$extends({
+        result: {
+          Users: {
+            ageLabel: {
+              needs: { age: true },
+              compute: (user: { age: number }) => `${user.age} 歳`,
+            },
+          },
+        },
+      });
+    expect(extended.Users.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+      fullName: "Mr. Alice",
+      ageLabel: "20 歳",
+    });
+  });
+
+  test("同名の算出フィールドは後から適用した拡張が勝つ", () => {
+    const client = buildTestClient();
+    const extended = client
+      .$extends({
+        result: {
+          Users: {
+            fullName: {
+              needs: { name: true },
+              compute: (user: { name: string }) => `Mr. ${user.name}`,
+            },
+          },
+        },
+      })
+      .$extends({
+        result: {
+          Users: {
+            fullName: {
+              needs: { name: true },
+              compute: (user: { name: string }) => `Dr. ${user.name}`,
+            },
+          },
+        },
+      });
+    expect(
+      extended.Users.findFirst({
+        where: { id: 1 },
+        select: { fullName: true },
+      }),
+    ).toEqual({ fullName: "Dr. Alice" });
+  });
+});
+
+describe("$extends result: Tier1 の境界", () => {
+  const fullNameExtension = {
+    result: {
+      Users: {
+        fullName: {
+          needs: { name: true },
+          compute: (user: { name: string }) => `Mr. ${user.name}`,
+        },
+      },
+    },
+  };
+
+  test("nested include の中の同モデルには付かない", () => {
+    const client = buildTestClient({ relations: true });
+    const extended = client.$extends(fullNameExtension);
+    expect(extended.Posts.findMany({ include: { author: true } })).toEqual([
+      {
+        id: 101,
+        authorId: 1,
+        title: "Post A",
+        author: { id: 1, name: "Alice", age: 20 },
+      },
+      {
+        id: 102,
+        authorId: 2,
+        title: "Post B",
+        author: { id: 2, name: "Bob", age: 30 },
+      },
+    ]);
+  });
+
+  test("include したトップレベルのレコードには付き include 先はそのまま", () => {
+    const client = buildTestClient({ relations: true });
+    const extended = client.$extends(fullNameExtension);
+    expect(
+      extended.Users.findMany({ where: { id: 1 }, include: { posts: true } }),
+    ).toEqual([
+      {
+        id: 1,
+        name: "Alice",
+        age: 20,
+        fullName: "Mr. Alice",
+        posts: [{ id: 101, authorId: 1, title: "Post A" }],
+      },
+    ]);
+  });
+});

--- a/src/__test__/util/extends/result/resultExtendsSelectOmit.test.ts
+++ b/src/__test__/util/extends/result/resultExtendsSelectOmit.test.ts
@@ -1,0 +1,124 @@
+import { buildTestClient, clearSpreadsheetApp } from "../extendsTestClient";
+
+afterAll(clearSpreadsheetApp);
+
+const fullNameExtension = {
+  result: {
+    Users: {
+      fullName: {
+        needs: { name: true },
+        compute: (user: { name: string }) => `Mr. ${user.name}`,
+      },
+    },
+  },
+};
+
+describe("$extends result: select 連携", () => {
+  test("select に算出フィールドを指定すると needs は自動補完され出力からは除去される", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(
+      extended.Users.findMany({ select: { id: true, fullName: true } }),
+    ).toEqual([
+      { id: 1, fullName: "Mr. Alice" },
+      { id: 2, fullName: "Mr. Bob" },
+      { id: 3, fullName: "Mr. Carol" },
+    ]);
+  });
+
+  test("select に算出フィールドが無ければ出力されず needs も補完されない", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(extended.Users.findMany({ select: { id: true } })).toEqual([
+      { id: 1 },
+      { id: 2 },
+      { id: 3 },
+    ]);
+  });
+
+  test("needs キーがユーザー select に元々ある場合は出力に残る", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(
+      extended.Users.findFirst({
+        where: { id: 1 },
+        select: { id: true, name: true, fullName: true },
+      }),
+    ).toEqual({ id: 1, name: "Alice", fullName: "Mr. Alice" });
+  });
+
+  test("select が算出フィールドのみでも動く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(
+      extended.Users.findFirst({
+        where: { id: 2 },
+        select: { fullName: true },
+      }),
+    ).toEqual({ fullName: "Mr. Bob" });
+  });
+
+  test("書き込み系の select でも算出フィールドを選択できる", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(
+      extended.Users.create({
+        data: { id: 4, name: "Dave", age: 1 },
+        select: { id: true, fullName: true },
+      }),
+    ).toEqual({ id: 4, fullName: "Mr. Dave" });
+    expect(
+      extended.Users.update({
+        where: { id: 4 },
+        data: { age: 2 },
+        select: { fullName: true },
+      }),
+    ).toEqual({ fullName: "Mr. Dave" });
+    expect(
+      extended.Users.delete({
+        where: { id: 4 },
+        select: { id: true, fullName: true },
+      }),
+    ).toEqual({ id: 4, fullName: "Mr. Dave" });
+  });
+});
+
+describe("$extends result: omit 連携", () => {
+  test("omit で算出フィールドを除去できる", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(
+      extended.Users.findMany({ where: { id: 1 }, omit: { fullName: true } }),
+    ).toEqual([{ id: 1, name: "Alice", age: 20 }]);
+  });
+
+  test("needs キーを omit しても compute は full record から計算される", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(
+      extended.Users.findMany({ where: { id: 1 }, omit: { name: true } }),
+    ).toEqual([{ id: 1, age: 20, fullName: "Mr. Alice" }]);
+  });
+
+  test("omit が false のキーは除去されない", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(
+      extended.Users.findFirst({
+        where: { id: 2 },
+        omit: { name: false, fullName: false },
+      }),
+    ).toEqual({ id: 2, name: "Bob", age: 30, fullName: "Mr. Bob" });
+  });
+
+  test("書き込み系の omit でも needs 除去と算出付与が両立する", () => {
+    const client = buildTestClient();
+    const extended = client.$extends(fullNameExtension);
+    expect(
+      extended.Users.create({
+        data: { id: 5, name: "Eve", age: 2 },
+        omit: { name: true },
+      }),
+    ).toEqual({ id: 5, age: 2, fullName: "Mr. Eve" });
+  });
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -26,8 +26,22 @@ declare namespace Gassma {
     [modelName: string]: QueryHookRecord;
   };
 
+  type ResultFieldDefinition = {
+    needs?: { [fieldName: string]: boolean };
+    compute: (record: any) => any;
+  };
+
+  type ResultFieldRecord = {
+    [fieldName: string]: ResultFieldDefinition;
+  };
+
+  type ResultExtensionConfig = {
+    [modelName: string]: ResultFieldRecord;
+  };
+
   type GassmaExtension = {
     query?: QueryExtensionConfig;
+    result?: ResultExtensionConfig;
   };
 
   type GassmaClient = {

--- a/src/types/extendsTypes.ts
+++ b/src/types/extendsTypes.ts
@@ -17,8 +17,22 @@ type QueryExtensionConfig = {
   [modelName: string]: QueryHookRecord;
 };
 
+type ResultFieldDefinition = {
+  needs?: { [fieldName: string]: boolean };
+  compute: (record: any) => any;
+};
+
+type ResultFieldRecord = {
+  [fieldName: string]: ResultFieldDefinition;
+};
+
+type ResultExtensionConfig = {
+  [modelName: string]: ResultFieldRecord;
+};
+
 type GassmaExtension = {
   query?: QueryExtensionConfig;
+  result?: ResultExtensionConfig;
 };
 
 type ExtendedClientCore = {
@@ -35,4 +49,7 @@ export type {
   QueryHook,
   QueryHookParams,
   QueryHookRecord,
+  ResultExtensionConfig,
+  ResultFieldDefinition,
+  ResultFieldRecord,
 };

--- a/src/util/extends/buildExtendedClient.ts
+++ b/src/util/extends/buildExtendedClient.ts
@@ -5,6 +5,8 @@ import type {
 } from "../../types/extendsTypes";
 import type { GassmaSheet } from "../../types/gassmaTypes";
 import { wrapControllerWithHooks } from "./query/wrapControllerWithHooks";
+import { resolveResultFields } from "./result/resolveResultFields";
+import { wrapControllerWithResult } from "./result/wrapControllerWithResult";
 
 const buildExtendedClient = (
   baseControllers: GassmaSheet,
@@ -12,10 +14,14 @@ const buildExtendedClient = (
 ): ExtendedGassmaClient => {
   const wrapped: GassmaSheet = {};
   Object.keys(baseControllers).forEach((model) => {
-    wrapped[model] = wrapControllerWithHooks(
+    const hooked = wrapControllerWithHooks(
       baseControllers[model],
       model,
       extensions,
+    );
+    wrapped[model] = wrapControllerWithResult(
+      hooked,
+      resolveResultFields(extensions, model),
     );
   });
   const core: ExtendedClientCore = {

--- a/src/util/extends/result/applyResultComputation.ts
+++ b/src/util/extends/result/applyResultComputation.ts
@@ -1,0 +1,28 @@
+import type { ResultFieldRecord } from "../../../types/extendsTypes";
+import { hasOwnKey } from "./hasOwnKey";
+
+const applyResultComputation = (
+  record: Record<string, unknown>,
+  fields: ResultFieldRecord,
+): Record<string, unknown> => {
+  const enriched: Record<string, unknown> = { ...record };
+  const done = new Set<string>();
+  const visiting = new Set<string>();
+  const computeField = (name: string) => {
+    if (done.has(name) || visiting.has(name)) return;
+    visiting.add(name);
+    const needs = fields[name].needs;
+    if (needs) {
+      Object.keys(needs).forEach((dep) => {
+        if (needs[dep] && hasOwnKey(fields, dep)) computeField(dep);
+      });
+    }
+    enriched[name] = fields[name].compute(enriched);
+    visiting.delete(name);
+    done.add(name);
+  };
+  Object.keys(fields).forEach(computeField);
+  return enriched;
+};
+
+export { applyResultComputation };

--- a/src/util/extends/result/collectResultKeys.ts
+++ b/src/util/extends/result/collectResultKeys.ts
@@ -1,0 +1,42 @@
+import type { ResultFieldRecord } from "../../../types/extendsTypes";
+import { hasOwnKey } from "./hasOwnKey";
+
+const collectRelevantFields = (
+  fields: ResultFieldRecord,
+  selected: string[],
+): string[] => {
+  const relevant: string[] = [];
+  const seen = new Set<string>();
+  const visit = (name: string) => {
+    if (seen.has(name) || !hasOwnKey(fields, name)) return;
+    seen.add(name);
+    relevant.push(name);
+    const needs = fields[name].needs;
+    if (!needs) return;
+    Object.keys(needs).forEach((dep) => {
+      if (needs[dep]) visit(dep);
+    });
+  };
+  selected.forEach(visit);
+  return relevant;
+};
+
+const collectNeededKeys = (
+  fields: ResultFieldRecord,
+  names: string[],
+): string[] => {
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  names.forEach((name) => {
+    const needs = fields[name].needs;
+    if (!needs) return;
+    Object.keys(needs).forEach((key) => {
+      if (!needs[key] || seen.has(key)) return;
+      seen.add(key);
+      keys.push(key);
+    });
+  });
+  return keys;
+};
+
+export { collectNeededKeys, collectRelevantFields };

--- a/src/util/extends/result/hasOwnKey.ts
+++ b/src/util/extends/result/hasOwnKey.ts
@@ -1,0 +1,4 @@
+const hasOwnKey = (target: Record<string, unknown>, key: string): boolean =>
+  Object.getOwnPropertyDescriptor(target, key) !== undefined;
+
+export { hasOwnKey };

--- a/src/util/extends/result/isRecordValue.ts
+++ b/src/util/extends/result/isRecordValue.ts
@@ -1,0 +1,4 @@
+const isRecordValue = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export { isRecordValue };

--- a/src/util/extends/result/prepareResultArgs.ts
+++ b/src/util/extends/result/prepareResultArgs.ts
@@ -1,0 +1,71 @@
+import type { ResultFieldRecord } from "../../../types/extendsTypes";
+import { collectNeededKeys, collectRelevantFields } from "./collectResultKeys";
+import { hasOwnKey } from "./hasOwnKey";
+import { isRecordValue } from "./isRecordValue";
+
+type ResultPlan =
+  | { kind: "all" }
+  | { kind: "select"; selectKeys: string[]; relevant: string[] }
+  | { kind: "omit"; dropKeys: string[] };
+
+type PreparedResultArgs = { args: any; plan: ResultPlan };
+
+const prepareSelect = (
+  args: any,
+  select: Record<string, unknown>,
+  fields: ResultFieldRecord,
+): PreparedResultArgs => {
+  const selected = Object.keys(fields).filter((name) =>
+    hasOwnKey(select, name),
+  );
+  const relevant = collectRelevantFields(fields, selected);
+  const needed = collectNeededKeys(fields, relevant);
+  const adjusted: Record<string, unknown> = { ...select };
+  selected.forEach((name) => {
+    delete adjusted[name];
+  });
+  needed.forEach((key) => {
+    if (!hasOwnKey(adjusted, key)) adjusted[key] = true;
+  });
+  return {
+    args: { ...args, select: adjusted },
+    plan: { kind: "select", selectKeys: Object.keys(select), relevant },
+  };
+};
+
+const prepareOmit = (
+  args: any,
+  omit: Record<string, unknown>,
+  fields: ResultFieldRecord,
+): PreparedResultArgs => {
+  const needed = collectNeededKeys(fields, Object.keys(fields));
+  const adjusted: Record<string, unknown> = { ...omit };
+  const dropKeys: string[] = [];
+  needed.forEach((key) => {
+    if (!hasOwnKey(adjusted, key) || !adjusted[key]) return;
+    delete adjusted[key];
+    dropKeys.push(key);
+  });
+  Object.keys(fields).forEach((name) => {
+    if (hasOwnKey(omit, name) && omit[name]) dropKeys.push(name);
+  });
+  return {
+    args: { ...args, omit: adjusted },
+    plan: { kind: "omit", dropKeys },
+  };
+};
+
+const prepareResultArgs = (
+  args: any,
+  fields: ResultFieldRecord,
+): PreparedResultArgs => {
+  const select = isRecordValue(args?.select) ? args.select : null;
+  const omit = isRecordValue(args?.omit) ? args.omit : null;
+  if (select && omit) return { args, plan: { kind: "all" } };
+  if (select) return prepareSelect(args, select, fields);
+  if (omit) return prepareOmit(args, omit, fields);
+  return { args, plan: { kind: "all" } };
+};
+
+export { prepareResultArgs };
+export type { PreparedResultArgs, ResultPlan };

--- a/src/util/extends/result/resolveResultFields.ts
+++ b/src/util/extends/result/resolveResultFields.ts
@@ -1,0 +1,21 @@
+import type {
+  GassmaExtension,
+  ResultFieldRecord,
+} from "../../../types/extendsTypes";
+
+const resolveResultFields = (
+  extensions: GassmaExtension[],
+  model: string,
+): ResultFieldRecord => {
+  const merged: ResultFieldRecord = {};
+  extensions.forEach((extension) => {
+    const config = extension.result;
+    if (!config || !config[model]) return;
+    Object.keys(config[model]).forEach((field) => {
+      merged[field] = config[model][field];
+    });
+  });
+  return merged;
+};
+
+export { resolveResultFields };

--- a/src/util/extends/result/resolveResultFields.ts
+++ b/src/util/extends/result/resolveResultFields.ts
@@ -8,12 +8,17 @@ const resolveResultFields = (
   model: string,
 ): ResultFieldRecord => {
   const merged: ResultFieldRecord = {};
+  const mergeFrom = (fields: ResultFieldRecord | undefined) => {
+    if (!fields) return;
+    Object.keys(fields).forEach((field) => {
+      merged[field] = fields[field];
+    });
+  };
   extensions.forEach((extension) => {
     const config = extension.result;
-    if (!config || !config[model]) return;
-    Object.keys(config[model]).forEach((field) => {
-      merged[field] = config[model][field];
-    });
+    if (!config) return;
+    mergeFrom(config.$allModels);
+    if (model !== "$allModels") mergeFrom(config[model]);
   });
   return merged;
 };

--- a/src/util/extends/result/resultOperations.ts
+++ b/src/util/extends/result/resultOperations.ts
@@ -1,0 +1,51 @@
+import type { GassmaController } from "../../../gassmaController";
+import type {
+  CreateData,
+  CreateManyAndReturnData,
+} from "../../../types/createTypes";
+import type { ResultFieldRecord } from "../../../types/extendsTypes";
+import type {
+  DeleteSingleData,
+  FindData,
+  FindFirstData,
+  UpdateData,
+  UpdateSingleData,
+  UpsertSingleData,
+} from "../../../types/findTypes";
+import { prepareResultArgs } from "./prepareResultArgs";
+import { transformResult } from "./transformResult";
+
+const buildResultOperations = (
+  controller: GassmaController,
+  fields: ResultFieldRecord,
+) => {
+  const wrapped =
+    <A, R>(execute: (args: A) => R) =>
+    (args: A): R => {
+      const prepared = prepareResultArgs(args, fields);
+      return transformResult(execute(prepared.args), fields, prepared.plan);
+    };
+
+  return {
+    findFirst: wrapped((a: FindFirstData) => controller.findFirst(a)),
+    findFirstOrThrow: wrapped((a: FindFirstData) =>
+      controller.findFirstOrThrow(a),
+    ),
+    findMany: wrapped((a: FindData) => controller.findMany(a)),
+    create: wrapped((a: CreateData) => controller.create(a)),
+    createManyAndReturn: wrapped((a: CreateManyAndReturnData) =>
+      controller.createManyAndReturn(a),
+    ),
+    update: wrapped((a: UpdateSingleData) => controller.update(a)),
+    updateManyAndReturn: wrapped((a: UpdateData) =>
+      controller.updateManyAndReturn(a),
+    ),
+    upsert: wrapped((a: UpsertSingleData) => controller.upsert(a)),
+    delete: wrapped((a: DeleteSingleData) => controller.delete(a)),
+  };
+};
+
+type ResultOperations = ReturnType<typeof buildResultOperations>;
+
+export { buildResultOperations };
+export type { ResultOperations };

--- a/src/util/extends/result/transformResult.ts
+++ b/src/util/extends/result/transformResult.ts
@@ -1,0 +1,56 @@
+import type { ResultFieldRecord } from "../../../types/extendsTypes";
+import { applyResultComputation } from "./applyResultComputation";
+import { isRecordValue } from "./isRecordValue";
+import type { ResultPlan } from "./prepareResultArgs";
+
+const pickFields = (
+  fields: ResultFieldRecord,
+  names: string[],
+): ResultFieldRecord => {
+  const picked: ResultFieldRecord = {};
+  names.forEach((name) => {
+    picked[name] = fields[name];
+  });
+  return picked;
+};
+
+const shapeRecord = (
+  record: Record<string, unknown>,
+  fields: ResultFieldRecord,
+  plan: ResultPlan,
+): Record<string, unknown> => {
+  if (plan.kind === "select") {
+    const enriched = applyResultComputation(
+      record,
+      pickFields(fields, plan.relevant),
+    );
+    const shaped: Record<string, unknown> = {};
+    plan.selectKeys.forEach((key) => {
+      shaped[key] = enriched[key];
+    });
+    return shaped;
+  }
+  const enriched = applyResultComputation(record, fields);
+  if (plan.kind === "omit") {
+    plan.dropKeys.forEach((key) => {
+      delete enriched[key];
+    });
+  }
+  return enriched;
+};
+
+const transformResult = (
+  raw: any,
+  fields: ResultFieldRecord,
+  plan: ResultPlan,
+): any => {
+  if (Array.isArray(raw)) {
+    return raw.map((record) => transformResult(record, fields, plan));
+  }
+  if (isRecordValue(raw)) {
+    return shapeRecord(raw, fields, plan);
+  }
+  return raw;
+};
+
+export { transformResult };

--- a/src/util/extends/result/wrapControllerWithResult.ts
+++ b/src/util/extends/result/wrapControllerWithResult.ts
@@ -1,0 +1,27 @@
+import type { GassmaController } from "../../../gassmaController";
+import type { ResultFieldRecord } from "../../../types/extendsTypes";
+import {
+  buildResultOperations,
+  type ResultOperations,
+} from "./resultOperations";
+
+const wrapControllerWithResult = (
+  controller: GassmaController,
+  fields: ResultFieldRecord,
+): GassmaController => {
+  if (Object.keys(fields).length === 0) return controller;
+  const operations = buildResultOperations(controller, fields);
+  const operationNames = new Set<string>(Object.keys(operations));
+  const isResultOperation = (
+    prop: string | symbol,
+  ): prop is keyof ResultOperations =>
+    typeof prop === "string" && operationNames.has(prop);
+  return new Proxy(controller, {
+    get: (target, prop, receiver) => {
+      if (isResultOperation(prop)) return operations[prop];
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+};
+
+export { wrapControllerWithResult };


### PR DESCRIPTION
## 概要

Prisma `$extends` の **`result` コンポーネント(computed fields)** を **Tier1(トップレベルのみ)** で実装します。既存の `$extends`(query)にラッパー層として相乗りします。

```ts
const extended = client.$extends({
  result: {
    User: {
      fullName: {
        needs: { name: true },
        compute: (u) => `Mr. ${u.name}`,
      },
    },
    $allModels: {
      _tag: { compute: () => "gassma" }, // 全モデルに付与
    },
  },
});
extended.User.findMany({}); // 各レコードに fullName / _tag が付く
```

## 仕様(Prisma 準拠・裏取り済み)

- `result.<model>.<field> = { needs, compute }`。`needs` は**スカラーのみ**、boolean フラグ
- `compute(record)` が算出値を返す。**eager(即時計算・通常プロパティ)**(getter でなく。GAS の Logger/JSON/スプレッド安定優先)
- **既存フィールド上書き可**、**他の算出フィールドに依存可**(needs 経由・依存順に計算)
- **`$allModels`** で全モデルに共通の算出フィールドを追加(同名はモデル固有が上書き)。query と対称
- 対象操作(レコードを返すもの): `findFirst`/`findFirstOrThrow`/`findMany`/`create`/`createManyAndReturn`/`update`/`updateManyAndReturn`/`upsert`/`delete`。**count/aggregate/groupBy/createMany/updateMany/deleteMany は対象外**
- query と同一 extension オブジェクトで併用可(`$extends({ query, result })`)、拡張適用済みの新クライアントを返し元は不変

## 実装(ラッパー層だけで完結・controller 内部やリレーション解決器は不変)

`src/util/extends/result/` に新設。read 返却系操作をラップし:
1. **needs 確保**: `args.select` があれば needs を補完(算出キーは下層 select から除去)/ `args.omit` に needs があれば解除(full row を読ませる)
2. 実操作実行(query フックがあればそれを通す)
3. **compute 適用**: 各レコードに依存順で算出フィールドを付与(循環は打ち切りガード)
4. **出力整形**: 自動補完した needs を除去、select 指定時は選択された算出フィールドのみ、omit 指定分を削除

`resolveResultFields` が `$allModels` → モデル固有の順でマージ(同名はモデル固有が勝つ)。`buildExtendedClient` が query(内側)→ result(外側)の合成ハブになります。

## 型

- core `src/index.d.ts` / `extendsTypes.ts` は緩い型(`compute: (record: any) => any`)。厳密な per-model/per-operation 結果型は cli 生成側の後続タスク(設計案は MEMORY に記録)
- `GassmaExtension` を `{ query?, result? }` に拡張。`ResultExtensionConfig` は index signature で `$allModels` を受理

## テスト

`src/__test__/util/extends/result/`(basic 9 / selectOmit 9 / composition 9 / allModels 9 = 36)。基本付与・対象操作網羅・select/omit 連携・上書き・依存順・元クライアント不変・query 併用・複数拡張マージ・**`$allModels`(複数モデル付与/同名上書き/併用/チェーン後勝ち)**・**nested include に付かないこと(Tier1 境界)**を検証。

- `npx jest`: **129 suites / 1523 tests 全 pass**(ベースライン 1487 → +36、既存全 green)
- `npx tsc --noEmit`: clean / `biome check`: clean / `npm run build`(webpack): 成功

## 既知の限界(合意事項・後続)

- **Tier2(nested include の結果にも算出フィールドを付与=Prisma 完全準拠)は後続で必ず実装予定**。今回は直接クエリしたモデルのトップレベルのみ
- `select: { <算出フィールド>: false }` はキー存在扱いで出力される(gassma 既存の select キー存在セマンティクスに意図的に一致)
- 循環 needs はエラーにせず打ち切り

🤖 Generated with [Claude Code](https://claude.com/claude-code)
