### PR TITLE
fix: expose the declared Gassma library surface (errors, skip, FieldRef) as working globals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,6 @@ jobs:
 
     - name: Build project
       run: npm run build
+
+    - name: Verify bundle globals
+      run: node scripts/verifyBundleGlobals.js

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "types": "src/index.d.ts",
   "scripts": {
     "build": "webpack",
+    "verify:bundle": "npm run build && node scripts/verifyBundleGlobals.js",
     "push": "npm run build && clasp push",
     "test": "jest",
     "format": "biome format --write src",

--- a/scripts/verifyBundleGlobals.js
+++ b/scripts/verifyBundleGlobals.js
@@ -1,0 +1,249 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const rootDir = path.join(__dirname, "..");
+const dtsPath = path.join(rootDir, "src", "index.d.ts");
+const bundlePath = path.join(rootDir, "dist", "bundle.js");
+
+const parsePublicDeclarations = (dtsSource) => {
+  const decls = new Map();
+  dtsSource.split("\n").forEach((line) => {
+    const matched = line.match(
+      /^ {2}(class|const|function) ([A-Za-z_$][A-Za-z0-9_$]*)(.*)$/,
+    );
+    if (!matched) return;
+    const keyword = matched[1];
+    const name = matched[2];
+    const rest = matched[3];
+    if (decls.has(name)) return;
+    if (keyword === "class") {
+      decls.set(name, rest.includes("extends Error") ? "errorClass" : "class");
+      return;
+    }
+    if (keyword === "function") {
+      decls.set(name, "function");
+      return;
+    }
+    if (rest.includes("unique symbol")) {
+      decls.set(name, "symbol");
+      return;
+    }
+    decls.set(name, /:\s*new\b/.test(rest) ? "class" : "value");
+  });
+  return decls;
+};
+
+const fakeGasSetupCode = `
+globalThis.SpreadsheetApp = (() => {
+  const makeSheet = (name, initial) => {
+    const data = initial.map((row) => row.slice());
+    return {
+      getName: () => name,
+      getLastRow: () => data.length,
+      getLastColumn: () => data[0].length,
+      getDataRange: () => ({ getValues: () => data.map((row) => row.slice()) }),
+      getRange: (row, col, numRows, numCols) => ({
+        getValues: () =>
+          data
+            .slice(row - 1, row - 1 + numRows)
+            .map((r) => r.slice(col - 1, col - 1 + numCols)),
+        setValues: (values) => {
+          values.forEach((rowValues, i) => {
+            while (data.length < row + i)
+              data.push(new Array(data[0].length).fill(""));
+            rowValues.forEach((value, j) => {
+              data[row - 1 + i][col - 1 + j] = value;
+            });
+          });
+        },
+      }),
+      deleteRow: (rowIndex) => {
+        data.splice(rowIndex - 1, 1);
+      },
+    };
+  };
+  const sheets = [
+    makeSheet("Users", [
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+    ]),
+  ];
+  const spreadsheet = {
+    getId: () => "verify-bundle",
+    getSheets: () => sheets,
+    getSheetByName: (name) =>
+      sheets.find((sheet) => sheet.getName() === name) ?? null,
+  };
+  return { getActiveSpreadsheet: () => spreadsheet };
+})();
+`;
+
+const scenarioCode = `
+JSON.stringify((() => {
+  const results = {};
+  const client = new GassmaClient();
+  results.clientInstanceOk = client instanceof GassmaClient;
+  results.controllerInstanceOk = client.Users instanceof GassmaController;
+  results.findAllCount = client.Users.findMany({}).length;
+  results.createdName = client.Users.create({
+    data: { id: 3, name: "Carol", age: 40 },
+  }).name;
+  results.afterCreateCount = client.Users.count({});
+  results.skipFilteredCount = client.Users.findMany({
+    where: { name: skip },
+  }).length;
+  const strictClient = new GassmaClient({ strictUndefinedChecks: true });
+  results.strictSkipCount = strictClient.Users.findMany({
+    where: { name: skip },
+  }).length;
+  try {
+    strictClient.Users.findMany({ where: { name: undefined } });
+    results.strictUndefined = "no-throw";
+  } catch (e) {
+    results.strictUndefined =
+      e instanceof GassmaUndefinedValueError
+        ? "GassmaUndefinedValueError"
+        : "other: " + e.name;
+  }
+  try {
+    client.Users.findFirstOrThrow({ where: { id: 999 } });
+    results.notFound = "no-throw";
+  } catch (e) {
+    results.notFound =
+      e instanceof NotFoundError ? "NotFoundError" : "other: " + e.name;
+  }
+  results.updatedAge = client.Users.update({
+    where: { id: 1 },
+    data: { age: 21 },
+  }).age;
+  results.deletedName = client.Users.delete({ where: { id: 2 } }).name;
+  results.finalCount = client.Users.count({});
+  return results;
+})())
+`;
+
+const instantiationCode = (names) => `
+JSON.stringify(${JSON.stringify(names)}.map((name) => {
+  const Ctor = globalThis[name];
+  const report = { name };
+  try {
+    const instance = new Ctor("arg1", "arg2", "arg3", "arg4");
+    report.instanceOk = instance instanceof Ctor;
+    report.errorChainOk = Error.prototype.isPrototypeOf(instance);
+  } catch (e) {
+    report.thrown = String(e);
+  }
+  return report;
+}))
+`;
+
+const typeOfKind = { class: "function", errorClass: "function", function: "function", symbol: "symbol" };
+
+const main = () => {
+  if (!fs.existsSync(bundlePath)) {
+    console.error("dist/bundle.js がありません。先に npm run build を実行してください。");
+    process.exit(1);
+  }
+  const expected = parsePublicDeclarations(fs.readFileSync(dtsPath, "utf8"));
+  if (expected.size === 0) {
+    console.error("src/index.d.ts から公開宣言を抽出できませんでした。");
+    process.exit(1);
+  }
+
+  const failures = [];
+  const sandbox = {};
+  vm.createContext(sandbox);
+  vm.runInContext(fakeGasSetupCode, sandbox, { filename: "fakeGas.js" });
+  const preBundleNames = new Set(Object.getOwnPropertyNames(sandbox));
+  vm.runInContext(fs.readFileSync(bundlePath, "utf8"), sandbox, {
+    filename: "bundle.js",
+  });
+
+  const introduced = Object.getOwnPropertyNames(sandbox).filter(
+    (name) => !preBundleNames.has(name),
+  );
+  introduced.forEach((name) => {
+    if (!expected.has(name))
+      failures.push(`公開対象外のシンボルが露出しています: ${name}`);
+  });
+  expected.forEach((kind, name) => {
+    if (!introduced.includes(name)) {
+      failures.push(`公開シンボルが bundle に存在しません: ${name}`);
+      return;
+    }
+    const expectedType = typeOfKind[kind];
+    const actualType = typeof sandbox[name];
+    if (expectedType && actualType !== expectedType)
+      failures.push(
+        `型不一致: ${name} は ${expectedType} のはずですが ${actualType} でした`,
+      );
+    if (!expectedType && sandbox[name] === undefined)
+      failures.push(`公開シンボルが undefined です: ${name}`);
+  });
+
+  const errorClassNames = [];
+  expected.forEach((kind, name) => {
+    if (kind === "errorClass") errorClassNames.push(name);
+  });
+  if (failures.length === 0) {
+    const reports = JSON.parse(
+      vm.runInContext(instantiationCode(errorClassNames), sandbox),
+    );
+    reports.forEach((report) => {
+      if (report.thrown)
+        failures.push(`${report.name} の new に失敗: ${report.thrown}`);
+      else if (!report.instanceOk)
+        failures.push(`${report.name}: instanceof が成立しません`);
+      else if (!report.errorChainOk)
+        failures.push(`${report.name}: Error の prototype チェーンにありません`);
+    });
+
+    const fieldRef = JSON.parse(
+      vm.runInContext(
+        'JSON.stringify({ ok: new FieldRef("m", "f") instanceof FieldRef, chain: Error.prototype.isPrototypeOf(new FieldRef("m", "f")), modelName: new FieldRef("m", "f").modelName })',
+        sandbox,
+      ),
+    );
+    if (!fieldRef.ok || fieldRef.chain || fieldRef.modelName !== "m")
+      failures.push("FieldRef の instanceof / プロパティ検証に失敗しました");
+
+    const scenario = JSON.parse(vm.runInContext(scenarioCode, sandbox));
+    const expectations = {
+      clientInstanceOk: true,
+      controllerInstanceOk: true,
+      findAllCount: 2,
+      createdName: "Carol",
+      afterCreateCount: 3,
+      skipFilteredCount: 3,
+      strictSkipCount: 3,
+      strictUndefined: "GassmaUndefinedValueError",
+      notFound: "NotFoundError",
+      updatedAge: 21,
+      deletedName: "Bob",
+      finalCount: 2,
+    };
+    Object.keys(expectations).forEach((key) => {
+      if (scenario[key] !== expectations[key])
+        failures.push(
+          `シナリオ検証に失敗: ${key} の期待値 ${expectations[key]} に対し実際は ${scenario[key]}`,
+        );
+    });
+  }
+
+  if (failures.length > 0) {
+    failures.forEach((failure) => console.error(`NG: ${failure}`));
+    console.error(
+      `\nbundle 検証に失敗しました (失敗 ${failures.length} 件 / 公開シンボル ${expected.size} 件 / トップレベル ${introduced.length} 件)`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `bundle 検証 OK: 公開シンボル ${expected.size} 件 (トップレベル宣言 ${introduced.length} 件、エラークラス ${errorClassNames.length} 件)、サイズ ${fs.statSync(bundlePath).size} bytes`,
+  );
+};
+
+main();

--- a/src/__test__/publicApi.test.ts
+++ b/src/__test__/publicApi.test.ts
@@ -1,0 +1,46 @@
+import { NotFoundError } from "../errors/find/findError";
+import { GassmaClient } from "../gassma";
+import { GassmaController } from "../gassmaController";
+import * as publicApi from "../publicApi";
+import { FieldRef } from "../util/filterConditions/fieldRef";
+import { skip } from "../util/skip/skip";
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "./util/extends/extendsTestClient";
+
+afterEach(() => {
+  clearSpreadsheetApp();
+});
+
+describe("publicApi", () => {
+  test("skip は本体の Symbol と同一", () => {
+    expect(typeof publicApi.skip).toBe("symbol");
+    expect(publicApi.skip).toBe(skip);
+  });
+
+  test("クラス実体は本体のクラスと同一", () => {
+    expect(publicApi.GassmaClient).toBe(GassmaClient);
+    expect(publicApi.GassmaController).toBe(GassmaController);
+    expect(publicApi.FieldRef).toBe(FieldRef);
+    expect(publicApi.NotFoundError).toBe(NotFoundError);
+  });
+
+  test("全 export が実体を持つ(skip 以外は function)", () => {
+    const entries = Object.entries(publicApi);
+    expect(entries.length).toBeGreaterThan(0);
+    entries.forEach(([name, value]) => {
+      if (name === "skip") return;
+      expect(typeof value).toBe("function");
+    });
+  });
+
+  test("ライブラリ内部から投げられたエラーは公開クラスの instanceof を満たす", () => {
+    const client = buildTestClient();
+    const users = sheetOf(client, "Users");
+    expect(() => users.findFirstOrThrow({ where: { id: 999 } })).toThrow(
+      publicApi.NotFoundError,
+    );
+  });
+});

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -1,0 +1,74 @@
+import * as findErrors from "./errors/find/findError";
+import * as nestedWriteErrors from "./errors/relation/nestedWriteError";
+import * as relationErrors from "./errors/relation/relationError";
+import * as relationValidationErrors from "./errors/relation/relationValidationError";
+import * as skipErrors from "./errors/skip/skipError";
+import * as whereRelationErrors from "./errors/relation/whereRelationError";
+import { GassmaClient as GassmaClientClass } from "./gassma";
+import { GassmaController as GassmaControllerClass } from "./gassmaController";
+import { FieldRef as FieldRefClass } from "./util/filterConditions/fieldRef";
+import { skip as skipSymbol } from "./util/skip/skip";
+
+// GAS ライブラリとして公開する実体。src/index.d.ts の namespace Gassma と 1:1 に保つ。
+// gas-webpack-plugin が検出できるのは `exports.X = ...` 代入式のみのため、
+// re-export 構文ではなく `export const X = 実体` の形にしている。
+export const GassmaClient = GassmaClientClass;
+export const GassmaController = GassmaControllerClass;
+export const FieldRef = FieldRefClass;
+export const skip = skipSymbol;
+
+export const GassmaSkipNegativeError = findErrors.GassmaSkipNegativeError;
+export const GassmaFindFirstTakeError = findErrors.GassmaFindFirstTakeError;
+export const GassmaLimitNegativeError = findErrors.GassmaLimitNegativeError;
+export const NotFoundError = findErrors.NotFoundError;
+export const RelationOrderByUnsupportedTypeError =
+  findErrors.RelationOrderByUnsupportedTypeError;
+export const RelationOrderByCountUnsupportedTypeError =
+  findErrors.RelationOrderByCountUnsupportedTypeError;
+
+export const RelationSheetNotFoundError =
+  relationValidationErrors.RelationSheetNotFoundError;
+export const RelationMissingPropertyError =
+  relationValidationErrors.RelationMissingPropertyError;
+export const RelationInvalidPropertyTypeError =
+  relationValidationErrors.RelationInvalidPropertyTypeError;
+export const RelationInvalidTypeError =
+  relationValidationErrors.RelationInvalidTypeError;
+export const RelationColumnNotFoundError =
+  relationValidationErrors.RelationColumnNotFoundError;
+export const IncludeWithoutRelationsError =
+  relationValidationErrors.IncludeWithoutRelationsError;
+export const IncludeInvalidOptionTypeError =
+  relationValidationErrors.IncludeInvalidOptionTypeError;
+export const IncludeSelectOmitConflictError =
+  relationValidationErrors.IncludeSelectOmitConflictError;
+export const IncludeSelectIncludeConflictError =
+  relationValidationErrors.IncludeSelectIncludeConflictError;
+export const RelationInvalidOnDeleteError =
+  relationValidationErrors.RelationInvalidOnDeleteError;
+export const RelationInvalidOnUpdateError =
+  relationValidationErrors.RelationInvalidOnUpdateError;
+
+export const WhereRelationInvalidFilterError =
+  whereRelationErrors.WhereRelationInvalidFilterError;
+export const WhereRelationWithoutContextError =
+  whereRelationErrors.WhereRelationWithoutContextError;
+
+export const RelationOnDeleteRestrictError =
+  relationErrors.RelationOnDeleteRestrictError;
+export const RelationOnUpdateRestrictError =
+  relationErrors.RelationOnUpdateRestrictError;
+
+export const NestedWriteConnectNotFoundError =
+  nestedWriteErrors.NestedWriteConnectNotFoundError;
+export const NestedWriteRelationNotFoundError =
+  nestedWriteErrors.NestedWriteRelationNotFoundError;
+export const NestedWriteInvalidOperationError =
+  nestedWriteErrors.NestedWriteInvalidOperationError;
+export const NestedWriteWithoutRelationsError =
+  nestedWriteErrors.NestedWriteWithoutRelationsError;
+export const NestedWriteTargetNotFoundError =
+  nestedWriteErrors.NestedWriteTargetNotFoundError;
+
+export const GassmaUndefinedValueError = skipErrors.GassmaUndefinedValueError;
+export const GassmaSkipInArrayError = skipErrors.GassmaSkipInArrayError;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 const GasPlugin = require("gas-webpack-plugin");
 
 module.exports = {
-  entry: "./src/gassma.ts",
+  entry: "./src/publicApi.ts",
   mode: "development",
   devtool: false,
 
@@ -28,7 +28,7 @@ module.exports = {
 
   plugins: [
     new GasPlugin({
-      autoGlobalExportsFiles: ["**/*.ts"],
+      autoGlobalExportsFiles: [path.resolve(__dirname, "src/publicApi.ts")],
     }),
   ],
 };


### PR DESCRIPTION
## 概要

#154 検証で発見した「**GassmaClient 以外の 181 中 180 グローバルが実行時 undefined**」問題の修正です(承認済み)。

**根本原因**: gas-webpack-plugin の `autoGlobalExportsFiles` が挿入する代入 `__webpack_require__.g.X = __webpack_exports__.X` は、webpack 5 の非エントリモジュール内では `__webpack_exports__` がクロージャ経由で**エントリ用の空オブジェクト**を指すため全て undefined になる(plugin の `exportsIdentifierName` が全モジュール一律 `RuntimeGlobals.exports` 固定)。エントリだけ `var exports = __webpack_exports__` でインライン実行されるため GassmaClient のみ動いていた。

## 実害バグ: Gassma.skip も undefined だった

型乖離に留まらず、**strictUndefinedChecks 利用者が `Gassma.skip` を渡すと undefined として渡り、`GassmaUndefinedValueError` が throw** — skip の目的と真逆の実行時エラーになる状態でした(非 strict でもキー除去 semantics が不発)。修正後は同一 Symbol が global 経由で渡り `===` 判定が成立します(E2E で strict/非 strict 両方を実証)。

## 修正

- 新エントリ **`src/publicApi.ts`** から index.d.ts 宣言と正確に一致する **32 実体**(エラークラス 28 / GassmaClient / GassmaController / FieldRef / skip)を `exports.X = 実体` 形式で公開(generator が検出できる唯一の形・GassmaClient の実績経路)
- `autoGlobalExportsFiles` を publicApi.ts 1ファイルに縮小 → **壊れた内部シンボル漏れ 149 個を全廃**(バンドル -11KB: 320,842 → 309,830 bytes)

## 再発防止: verify:bundle を常設 + CI 組込

`scripts/verifyBundleGlobals.js`(`npm run verify:bundle`、CI の Build 直後に実行)が**実 dist/bundle.js を vm ロード**して検証:
- 公開リストは **index.d.ts をパースして導出**(手書き二重管理なし — d.ts に幻宣言を足すと不足検出で fail、export を消すと build が fail する双方向ドリフト検出を変異テストで実証)
- 32 シンボルの存在と typeof(class→function / skip→symbol)、内部漏れゼロ、28 エラークラスの instanceof チェーン、E2E 12 検証(read/write、strict skip round-trip、throw された NotFoundError の instanceof)
- **修正前に Red = 180 failures を実測** → 修正後 Green

## テスト

1512 → **1516(+4)**。npm test / tsc / lint / format / build / verify:bundle 全 green。

## 報告事項(未対応・要判断)

**index.d.ts に宣言されていないランタイムエラーが 15 個**あります(GassmaAggregate 系 7、GassmaRelationNotFoundError 等 relation 系 5、GassmaFindSelectOmitConflictError、GassmaInValidColumnValueError、GassmaGroupByHavingDontWriteByError)。現状これらは throw されても利用者が instanceof で捕捉できません。公開するには index.d.ts への宣言追加(=公開 API 拡張)が必要なため、仕様判断として保留しています。

## マージ後

デプロイ + gassma-test に実機テスト追加を予定: ①`e instanceof Gassma.NotFoundError` 等 ②**strict クライアントで `Gassma.skip` が throw しない**(今回の実害バグの回帰)③`typeof Gassma.skip === "symbol"` — 特に「非関数値(symbol)がライブラリメンバーとして実機参照できるか」はモックで検証不能な唯一の残項目です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX