### PR TITLE
fix: changeSettings public type accepts column letters (number | string)

### DIFF
--- a/src/__test__/types/changeSettingsTypes.test.ts
+++ b/src/__test__/types/changeSettingsTypes.test.ts
@@ -1,0 +1,37 @@
+import type { GassmaController } from "../../gassmaController";
+import type { Gassma } from "../../index";
+
+type DtsParams = Parameters<Gassma.GassmaController["changeSettings"]>;
+type ImplParams = Parameters<GassmaController["changeSettings"]>;
+
+describe("changeSettings signature types", () => {
+  test("should accept column letters (string) in index.d.ts", () => {
+    const params: DtsParams = [2, "BA", "BC"];
+
+    expect(params).toBeDefined();
+  });
+
+  test("should accept column numbers in index.d.ts", () => {
+    const params: DtsParams = [2, 1, 3];
+
+    expect(params).toBeDefined();
+  });
+
+  test("should match the implementation signature", () => {
+    const dtsParams: DtsParams = [2, "A", 5];
+    const implParams: ImplParams = dtsParams;
+
+    expect(implParams).toBeDefined();
+  });
+
+  test("should reject boolean columns and string startRowNumber", () => {
+    // @ts-expect-error 列指定に boolean は指定できない
+    const boolColumn: DtsParams = [2, true, 3];
+
+    // @ts-expect-error startRowNumber は number のみ
+    const stringRow: DtsParams = ["2", 1, 3];
+
+    expect(boolColumn).toBeDefined();
+    expect(stringRow).toBeDefined();
+  });
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -59,8 +59,8 @@ declare namespace Gassma {
     getColumnHeaders(): string[];
     changeSettings(
       startRowNumber: number,
-      startColumnNumber: number,
-      endColumnNumber: number,
+      startColumnValue: number | string,
+      endColumnValue: number | string,
     ): void;
     createMany(createdData: CreateManyData): CreateManyReturn;
     createManyAndReturn(


### PR DESCRIPTION
## 概要

changeSettings のカラム指定は実装が `number | string` を受理("BA" 等の列文字。base-26 変換は #146 で修正済み・検証済み)なのに、公開型は number のみでした。型を実装の受理面に合わせます(ユーザー承認済み)。

## 変更

`index.d.ts` の changeSettings シグネチャ: 第2・第3引数を `number | string` に広げ、引数名も実装(gassmaController.ts:210-214)と一致する `startColumnValue` / `endColumnValue` へ。`startRowNumber` は number のみのまま(実装どおり)。

## テスト

新規型消費テスト4本(string "BA" 正例 / 数値正例 / 実装シグネチャ一致 / boolean・string 行番号の負例)。**Red 実測: 変更前は TS2322 で fail**。1556 テスト / tsc / lint / format / build / verify:bundle 全 green。

cli 追随 PR: akahoshi1421/gassma-cli#117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX