### PR TITLE
fix: throw a clear error when update is called without where

### DIFF
--- a/src/__test__/util/update/updateWhereMissing.test.ts
+++ b/src/__test__/util/update/updateWhereMissing.test.ts
@@ -1,0 +1,42 @@
+import { GassmaUpdateWhereMissingError } from "../../../errors/update/updateError";
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "../extends/extendsTestClient";
+
+afterEach(() => {
+  clearSpreadsheetApp();
+});
+
+describe("update の where 必須バリデーション", () => {
+  test("where 未指定は GassmaUpdateWhereMissingError", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    const rawUpdate: (updateData: {
+      data: Record<string, unknown>;
+    }) => unknown = users.update.bind(users);
+
+    expect(() => rawUpdate({ data: { age: 99 } })).toThrow(
+      GassmaUpdateWhereMissingError,
+    );
+    expect(() => rawUpdate({ data: { age: 99 } })).toThrow(
+      "Argument `where` is missing.",
+    );
+  });
+
+  test("where: undefined も GassmaUpdateWhereMissingError", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    expect(() => users.update({ where: undefined, data: { age: 99 } })).toThrow(
+      GassmaUpdateWhereMissingError,
+    );
+  });
+
+  test("where: {} は従来どおり先頭行を更新する", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    const result = users.update({ where: {}, data: { age: 99 } });
+
+    expect(result).toEqual({ id: 1, name: "Alice", age: 99 });
+  });
+});

--- a/src/errors/update/updateError.ts
+++ b/src/errors/update/updateError.ts
@@ -1,0 +1,8 @@
+class GassmaUpdateWhereMissingError extends Error {
+  constructor() {
+    super("Argument `where` is missing.");
+    this.name = "GassmaUpdateWhereMissingError";
+  }
+}
+
+export { GassmaUpdateWhereMissingError };

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -16,6 +16,7 @@ import { omitFunc } from "./util/find/findUtil/omit";
 import { resolveGlobalOmit } from "./util/omit/resolveGlobalOmit";
 import { GassmaIncludeSelectConflictError } from "./errors/relation/relationError";
 import { IncludeWithoutRelationsError } from "./errors/relation/relationValidationError";
+import { GassmaUpdateWhereMissingError } from "./errors/update/updateError";
 import type { AggregateData } from "./types/aggregateType";
 import type {
   AnyUse,
@@ -763,6 +764,9 @@ class GassmaController {
 
   public update(updateData: UpdateSingleData) {
     updateData = this.normalizeInput(updateData);
+    if (updateData.where === undefined) {
+      throw new GassmaUpdateWhereMissingError();
+    }
     if (updateData.include && updateData.select) {
       throw new GassmaIncludeSelectConflictError();
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -557,6 +557,9 @@ declare namespace Gassma {
   class GassmaSkipInArrayError extends Error {
     constructor(path: string);
   }
+  class GassmaUpdateWhereMissingError extends Error {
+    constructor();
+  }
 }
 
 export { Gassma };

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -3,6 +3,7 @@ import * as nestedWriteErrors from "./errors/relation/nestedWriteError";
 import * as relationErrors from "./errors/relation/relationError";
 import * as relationValidationErrors from "./errors/relation/relationValidationError";
 import * as skipErrors from "./errors/skip/skipError";
+import * as updateErrors from "./errors/update/updateError";
 import * as whereRelationErrors from "./errors/relation/whereRelationError";
 import { GassmaClient as GassmaClientClass } from "./gassma";
 import { GassmaController as GassmaControllerClass } from "./gassmaController";
@@ -72,3 +73,6 @@ export const NestedWriteTargetNotFoundError =
 
 export const GassmaUndefinedValueError = skipErrors.GassmaUndefinedValueError;
 export const GassmaSkipInArrayError = skipErrors.GassmaSkipInArrayError;
+
+export const GassmaUpdateWhereMissingError =
+  updateErrors.GassmaUpdateWhereMissingError;


### PR DESCRIPTION
## 概要

型なし利用者(素の JS / 生クライアント)が `update({ data })` と書くと、本体が `whereFilter(undefined)` の `Object.keys(undefined)` で**素の TypeError** になっていました。Prisma 準拠の明確なバリデーションエラーに変えます(ユーザー承認済み。reference は既に「where 必須」に修正済みで整合)。

## 変更

- 新エラークラス **`GassmaUpdateWhereMissingError`**(メッセージ: `Argument \`where\` is missing.` = prisma-test 既測の Prisma 形)
- ガードは controller の `update()` 入口・normalizeInput 直後(strict モードの `where: Gassma.skip` もキー除去後に捕捉)
- `where: {}` は従来どおり先頭行更新(既存仕様、ピンテストで固定)
- #156 体制に準拠: index.d.ts 宣言 + **publicApi.ts export** — export を意図的に抜いた状態で verify:bundle が `公開シンボルが bundle に存在しません` で fail することを実測(#156 のガードが効いている実証)

## テスト

新規3本(where 未指定 / where: undefined / `where: {}` ピン)。Red 実測: 修正前は素の TypeError(スタックトレース記録済み)。1555 テスト / tsc / lint / format / build / verify:bundle(公開33件)全 green。

## 報告事項(調査のみ・未修正)

同種の必須引数省略を全メソッドで実測しました。upsert(where/create/update なし)・update/create/createMany/updateMany(data なし)は素の TypeError。**特筆: `delete` の where なしは throw せず先頭行を暗黙削除して返します**(全件マッチ扱いに流れる。Prisma ならバリデーションエラー)。`groupBy` の by なしは `[{}]` を返します。これらを同様にエラー化するかは別判断としてください(特に delete は破壊的なので推奨)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX