### PR TITLE
fix: Date keys compare by instant across grouping, referential actions, and relation lookups

### DIFF
--- a/src/__test__/util/find/findUtil/resolveRelationOrderBy.test.ts
+++ b/src/__test__/util/find/findUtil/resolveRelationOrderBy.test.ts
@@ -5,6 +5,7 @@ import {
 import { resolveRelationOrderBy } from "../../../../util/find/findUtil/resolveRelationOrderBy";
 import type { RelationContext } from "../../../../types/relationTypes";
 import type { OrderBy } from "../../../../types/coreTypes";
+import { createCrossRealmDate } from "../../../consts/crossRealm";
 
 const createRelationContext = (
   findManyOnSheet: RelationContext["findManyOnSheet"],
@@ -411,5 +412,88 @@ describe("resolveRelationOrderBy", () => {
     expect(() =>
       resolveRelationOrderBy([{ id: 1, authorId: 1 }], orderByArr, context),
     ).toThrow(RelationOrderByCountUnsupportedTypeError);
+  });
+});
+
+describe("resolveRelationOrderBy with Date keys", () => {
+  const dateContext = (
+    findManyOnSheet: RelationContext["findManyOnSheet"],
+  ): RelationContext => ({
+    relations: {
+      author: {
+        type: "manyToOne",
+        to: "Users",
+        field: "authorAt",
+        reference: "at",
+      },
+      posts: {
+        type: "oneToMany",
+        to: "Posts",
+        field: "key",
+        reference: "authorKey",
+      },
+    },
+    findManyOnSheet,
+  });
+
+  test("Date FK経由のmanyToOneフィールドソートが時刻一致で解決される", () => {
+    const records = [
+      { id: 1, authorAt: new Date("2026-07-18T09:30:00.000Z") },
+      { id: 2, authorAt: new Date("2026-07-18T09:30:00.001Z") },
+    ];
+
+    const findManyOnSheet = jest.fn(() => [
+      { at: new Date("2026-07-18T09:30:00.000Z"), name: "Zoe" },
+      { at: new Date("2026-07-18T09:30:00.001Z"), name: "Amy" },
+    ]);
+
+    const result = resolveRelationOrderBy(
+      records,
+      [{ author: { name: "asc" } }],
+      dateContext(findManyOnSheet),
+    );
+
+    expect(result.map((r) => r.id)).toEqual([2, 1]);
+  });
+
+  test("Dateキー経由の_countソートが時刻一致で解決される", () => {
+    const records = [
+      { id: 1, key: new Date("2026-07-18T09:30:00.000Z") },
+      { id: 2, key: new Date("2026-07-18T10:30:00.000Z") },
+    ];
+
+    const findManyOnSheet = jest.fn(() => [
+      { authorKey: new Date("2026-07-18T09:30:00.000Z") },
+      { authorKey: new Date("2026-07-18T10:30:00.000Z") },
+      { authorKey: new Date("2026-07-18T10:30:00.000Z") },
+    ]);
+
+    const result = resolveRelationOrderBy(
+      records,
+      [{ posts: { _count: "desc" } }],
+      dateContext(findManyOnSheet),
+    );
+
+    expect(result.map((r) => r.id)).toEqual([2, 1]);
+  });
+
+  test("クロスrealmのDate FKでもソートが解決される", () => {
+    const records = [
+      { id: 1, authorAt: createCrossRealmDate("2026-07-18T09:30:00.000Z") },
+      { id: 2, authorAt: new Date("2026-07-18T09:30:00.001Z") },
+    ];
+
+    const findManyOnSheet = jest.fn(() => [
+      { at: new Date("2026-07-18T09:30:00.000Z"), name: "Zoe" },
+      { at: new Date("2026-07-18T09:30:00.001Z"), name: "Amy" },
+    ]);
+
+    const result = resolveRelationOrderBy(
+      records,
+      [{ author: { name: "asc" } }],
+      dateContext(findManyOnSheet),
+    );
+
+    expect(result.map((r) => r.id)).toEqual([2, 1]);
   });
 });

--- a/src/__test__/util/groupby/groupbyUtil/by.test.ts
+++ b/src/__test__/util/groupby/groupbyUtil/by.test.ts
@@ -1,0 +1,71 @@
+import { byClassification } from "../../../../util/groupby/groubyUtil/by";
+import { createCrossRealmDate } from "../../../consts/crossRealm";
+
+describe("byClassification with Date values", () => {
+  test("同時刻・別インスタンスのDateは同一グループになる", () => {
+    const rows = [
+      { at: new Date("2026-07-18T09:30:00.000Z"), v: 1 },
+      { at: new Date("2026-07-18T09:30:00.000Z"), v: 2 },
+    ];
+
+    const result = byClassification(rows, ["at"]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(2);
+  });
+
+  test("ミリ秒差のDateは別グループになる", () => {
+    const rows = [
+      { at: new Date("2026-07-18T09:30:00.000Z"), v: 1 },
+      { at: new Date("2026-07-18T09:30:00.001Z"), v: 2 },
+    ];
+
+    const result = byClassification(rows, ["at"]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("DateとISO文字列は別グループになる", () => {
+    const rows = [
+      { at: new Date("2026-07-18T09:30:00.000Z"), v: 1 },
+      { at: "2026-07-18T09:30:00.000Z", v: 2 },
+    ];
+
+    const result = byClassification(rows, ["at"]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("複数キーでもDateキーは時刻一致でグループ化される", () => {
+    const rows = [
+      { at: new Date("2026-07-18T09:30:00.000Z"), city: "Tokyo" },
+      { at: new Date("2026-07-18T09:30:00.000Z"), city: "Tokyo" },
+      { at: new Date("2026-07-18T09:30:00.000Z"), city: "Osaka" },
+    ];
+
+    const result = byClassification(rows, ["at", "city"]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("非Date値のグループ化は従来どおり", () => {
+    const rows = [{ city: "Tokyo" }, { city: "Osaka" }, { city: "Tokyo" }];
+
+    const result = byClassification(rows, ["city"]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toHaveLength(2);
+  });
+
+  test("クロスrealmのDateも同時刻なら同一グループになる", () => {
+    const rows = [
+      { at: new Date("2026-07-18T09:30:00.000Z"), v: 1 },
+      { at: createCrossRealmDate("2026-07-18T09:30:00.000Z"), v: 2 },
+    ];
+
+    const result = byClassification(rows, ["at"]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(2);
+  });
+});

--- a/src/__test__/util/other/toLookupKey.test.ts
+++ b/src/__test__/util/other/toLookupKey.test.ts
@@ -1,0 +1,47 @@
+import { createCrossRealmDate } from "../../consts/crossRealm";
+import { toLookupKey } from "../../../util/other/toLookupKey";
+
+describe("toLookupKey", () => {
+  test("should return the same key for Dates with the same time but different instances", () => {
+    expect(toLookupKey(new Date("2026-07-18T09:30:00.000Z"))).toBe(
+      toLookupKey(new Date("2026-07-18T09:30:00.000Z")),
+    );
+  });
+
+  test("should return different keys for Dates with different times", () => {
+    expect(toLookupKey(new Date("2026-07-18T09:30:00.000Z"))).not.toBe(
+      toLookupKey(new Date("2026-07-18T09:30:00.001Z")),
+    );
+  });
+
+  test("should not collide between a Date and any string", () => {
+    const date = new Date("2026-07-18T09:30:00.000Z");
+    const dateKey = toLookupKey(date);
+    expect(dateKey).not.toBe(toLookupKey("2026-07-18T09:30:00.000Z"));
+    expect(dateKey).not.toBe(toLookupKey(String(dateKey)));
+  });
+
+  test("should keep identity semantics for non-Date primitives", () => {
+    expect(toLookupKey("a")).toBe(toLookupKey("a"));
+    expect(toLookupKey(1)).toBe(1);
+    expect(toLookupKey(true)).toBe(true);
+    expect(toLookupKey(null)).toBe(null);
+    expect(toLookupKey(1)).not.toBe(toLookupKey("1"));
+  });
+});
+
+describe("toLookupKey with cross-realm Dates", () => {
+  test("should return the same key for a cross-realm Date with the same time", () => {
+    const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
+    expect(crossDate instanceof Date).toBe(false);
+    expect(toLookupKey(crossDate)).toBe(
+      toLookupKey(new Date("2026-07-18T09:30:00.000Z")),
+    );
+  });
+
+  test("should return different keys for cross-realm Dates with different times", () => {
+    expect(
+      toLookupKey(createCrossRealmDate("2026-07-18T09:30:00.000Z")),
+    ).not.toBe(toLookupKey(createCrossRealmDate("2026-07-18T09:30:00.001Z")));
+  });
+});

--- a/src/__test__/util/relation/onUpdate/resolveOnUpdate.test.ts
+++ b/src/__test__/util/relation/onUpdate/resolveOnUpdate.test.ts
@@ -4,6 +4,7 @@ import type {
   RelationDefinition,
   RelationContext,
 } from "../../../../types/relationTypes";
+import { createCrossRealmDate } from "../../../consts/crossRealm";
 
 describe("resolveOnUpdate", () => {
   const mockFindMany = jest.fn();
@@ -273,6 +274,141 @@ describe("resolveOnUpdate", () => {
     expect(() =>
       resolveOnUpdate([{ id: 1 }], [{ id: 10 }], baseContext(relations)),
     ).toThrow("comments");
+
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveOnUpdate with Date keys", () => {
+  const mockFindMany = jest.fn();
+  const mockDeleteMany = jest.fn();
+  const mockUpdateMany = jest.fn();
+
+  const context = (
+    relations: Record<string, RelationDefinition>,
+  ): RelationContext => ({
+    relations,
+    findManyOnSheet: mockFindMany,
+    deleteManyOnSheet: mockDeleteMany,
+    updateManyOnSheet: mockUpdateMany,
+  });
+
+  const dateRelations = (
+    onUpdate: RelationDefinition["onUpdate"],
+  ): Record<string, RelationDefinition> => ({
+    posts: {
+      type: "oneToMany",
+      to: "Posts",
+      field: "key",
+      reference: "authorKey",
+      onUpdate,
+    },
+  });
+
+  beforeEach(() => {
+    mockFindMany.mockReset();
+    mockDeleteMany.mockReset();
+    mockUpdateMany.mockReset();
+  });
+
+  it("同時刻・別インスタンスのDateへの更新ではRestrictが発火しない", () => {
+    expect(() =>
+      resolveOnUpdate(
+        [{ key: new Date("2026-07-18T09:30:00.000Z") }],
+        [{ key: new Date("2026-07-18T09:30:00.000Z") }],
+        context(dateRelations("Restrict")),
+      ),
+    ).not.toThrow();
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it("同時刻・別インスタンスのDateへの更新ではCascadeが発火しない", () => {
+    resolveOnUpdate(
+      [{ key: new Date("2026-07-18T09:30:00.000Z") }],
+      [{ key: new Date("2026-07-18T09:30:00.000Z") }],
+      context(dateRelations("Cascade")),
+    );
+
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("同時刻・別インスタンスのDateへの更新ではSetNullが発火しない", () => {
+    resolveOnUpdate(
+      [{ key: new Date("2026-07-18T09:30:00.000Z") }],
+      [{ key: new Date("2026-07-18T09:30:00.000Z") }],
+      context(dateRelations("SetNull")),
+    );
+
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("ミリ秒差のDateへの更新ではCascadeが発火する", () => {
+    const oldKey = new Date("2026-07-18T09:30:00.000Z");
+    const newKey = new Date("2026-07-18T09:30:00.001Z");
+
+    resolveOnUpdate(
+      [{ key: oldKey }],
+      [{ key: newKey }],
+      context(dateRelations("Cascade")),
+    );
+
+    expect(mockUpdateMany).toHaveBeenCalledWith("Posts", {
+      where: { authorKey: oldKey },
+      data: { authorKey: newKey },
+    });
+  });
+
+  it("ミリ秒差のDateへの更新ではRestrictが発火する", () => {
+    mockFindMany.mockReturnValue([{ id: 101 }]);
+
+    expect(() =>
+      resolveOnUpdate(
+        [{ key: new Date("2026-07-18T09:30:00.000Z") }],
+        [{ key: new Date("2026-07-18T09:30:00.001Z") }],
+        context(dateRelations("Restrict")),
+      ),
+    ).toThrow(RelationOnUpdateRestrictError);
+  });
+
+  it("SetNullは同時刻の行を除外し変更行のみ対象にする", () => {
+    const changedOld = new Date("2026-07-18T10:00:00.000Z");
+
+    resolveOnUpdate(
+      [{ key: new Date("2026-07-18T09:30:00.000Z") }, { key: changedOld }],
+      [
+        { key: new Date("2026-07-18T09:30:00.000Z") },
+        { key: new Date("2026-07-18T11:00:00.000Z") },
+      ],
+      context(dateRelations("SetNull")),
+    );
+
+    expect(mockUpdateMany).toHaveBeenCalledWith("Posts", {
+      where: { authorKey: { in: [changedOld] } },
+      data: { authorKey: null },
+    });
+  });
+
+  it("DateからISO文字列への変更は変更として扱いCascadeが発火する", () => {
+    const oldKey = new Date("2026-07-18T09:30:00.000Z");
+
+    resolveOnUpdate(
+      [{ key: oldKey }],
+      [{ key: "2026-07-18T09:30:00.000Z" }],
+      context(dateRelations("Cascade")),
+    );
+
+    expect(mockUpdateMany).toHaveBeenCalledWith("Posts", {
+      where: { authorKey: oldKey },
+      data: { authorKey: "2026-07-18T09:30:00.000Z" },
+    });
+  });
+
+  it("クロスrealmの同時刻Dateへの更新では発火しない", () => {
+    resolveOnUpdate(
+      [{ key: createCrossRealmDate("2026-07-18T09:30:00.000Z") }],
+      [{ key: new Date("2026-07-18T09:30:00.000Z") }],
+      context(dateRelations("Cascade")),
+    );
 
     expect(mockUpdateMany).not.toHaveBeenCalled();
   });

--- a/src/__test__/util/relation/resolveCount.test.ts
+++ b/src/__test__/util/relation/resolveCount.test.ts
@@ -3,6 +3,7 @@ import type {
   RelationContext,
   RelationDefinition,
 } from "../../../types/relationTypes";
+import { createCrossRealmDate } from "../../consts/crossRealm";
 
 describe("resolveCount", () => {
   const mockFindMany = jest.fn();
@@ -308,5 +309,200 @@ describe("resolveCount", () => {
 
     expect(result).toEqual([]);
     expect(mockFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveCount with Date keys", () => {
+  const mockFindMany = jest.fn();
+
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  test("oneToMany: 同時刻・別インスタンスのDateキーでカウントされる", () => {
+    const context: RelationContext = {
+      relations: {
+        posts: {
+          type: "oneToMany",
+          to: "Posts",
+          field: "key",
+          reference: "authorKey",
+        },
+      },
+      findManyOnSheet: mockFindMany,
+    };
+
+    const parents = [
+      { key: new Date("2026-07-18T09:30:00.000Z") },
+      { key: new Date("2026-07-18T10:30:00.000Z") },
+    ];
+
+    mockFindMany.mockReturnValue([
+      { authorKey: new Date("2026-07-18T09:30:00.000Z") },
+      { authorKey: new Date("2026-07-18T09:30:00.000Z") },
+      { authorKey: new Date("2026-07-18T10:30:00.000Z") },
+    ]);
+
+    const result = resolveCount(parents, { select: { posts: true } }, context);
+
+    expect(result[0]._count).toEqual({ posts: 2 });
+    expect(result[1]._count).toEqual({ posts: 1 });
+  });
+
+  test("oneToMany: ミリ秒差のDateキーはカウントされない", () => {
+    const context: RelationContext = {
+      relations: {
+        posts: {
+          type: "oneToMany",
+          to: "Posts",
+          field: "key",
+          reference: "authorKey",
+        },
+      },
+      findManyOnSheet: mockFindMany,
+    };
+
+    const parents = [{ key: new Date("2026-07-18T09:30:00.000Z") }];
+
+    mockFindMany.mockReturnValue([
+      { authorKey: new Date("2026-07-18T09:30:00.000Z") },
+      { authorKey: new Date("2026-07-18T09:30:00.001Z") },
+    ]);
+
+    const result = resolveCount(parents, { select: { posts: true } }, context);
+
+    expect(result[0]._count).toEqual({ posts: 1 });
+  });
+
+  test("manyToOne: Date FKの存在カウントが時刻一致で1になる", () => {
+    const context: RelationContext = {
+      relations: {
+        author: {
+          type: "manyToOne",
+          to: "Users",
+          field: "authorAt",
+          reference: "at",
+        },
+      },
+      findManyOnSheet: mockFindMany,
+    };
+
+    const parents = [{ authorAt: new Date("2026-07-18T09:30:00.000Z") }];
+
+    mockFindMany.mockReturnValue([
+      { at: new Date("2026-07-18T09:30:00.000Z") },
+    ]);
+
+    const result = resolveCount(parents, { select: { author: true } }, context);
+
+    expect(result[0]._count).toEqual({ author: 1 });
+  });
+
+  test("manyToMany: Dateキーの中間テーブルでカウントされる", () => {
+    const context: RelationContext = {
+      relations: {
+        categories: {
+          type: "manyToMany",
+          to: "Categories",
+          field: "at",
+          reference: "at",
+          through: {
+            sheet: "PostCategories",
+            field: "postAt",
+            reference: "categoryAt",
+          },
+        },
+      },
+      findManyOnSheet: mockFindMany,
+    };
+
+    const parents = [{ at: new Date("2026-07-18T09:30:00.000Z") }];
+
+    mockFindMany.mockReturnValue([
+      {
+        postAt: new Date("2026-07-18T09:30:00.000Z"),
+        categoryAt: new Date("2026-07-18T10:30:00.000Z"),
+      },
+      {
+        postAt: new Date("2026-07-18T09:30:00.000Z"),
+        categoryAt: new Date("2026-07-18T11:30:00.000Z"),
+      },
+    ]);
+
+    const result = resolveCount(
+      parents,
+      { select: { categories: true } },
+      context,
+    );
+
+    expect(result[0]._count).toEqual({ categories: 2 });
+  });
+
+  test("manyToMany: filter付きでもDateキーが突合される", () => {
+    const context: RelationContext = {
+      relations: {
+        categories: {
+          type: "manyToMany",
+          to: "Categories",
+          field: "at",
+          reference: "at",
+          through: {
+            sheet: "PostCategories",
+            field: "postAt",
+            reference: "categoryAt",
+          },
+        },
+      },
+      findManyOnSheet: mockFindMany,
+    };
+
+    const parents = [{ at: new Date("2026-07-18T09:30:00.000Z") }];
+
+    mockFindMany.mockReturnValueOnce([
+      {
+        postAt: new Date("2026-07-18T09:30:00.000Z"),
+        categoryAt: new Date("2026-07-18T10:30:00.000Z"),
+      },
+      {
+        postAt: new Date("2026-07-18T09:30:00.000Z"),
+        categoryAt: new Date("2026-07-18T10:30:00.001Z"),
+      },
+    ]);
+    mockFindMany.mockReturnValueOnce([
+      { at: new Date("2026-07-18T10:30:00.000Z"), active: true },
+    ]);
+
+    const result = resolveCount(
+      parents,
+      { select: { categories: { where: { active: true } } } },
+      context,
+    );
+
+    expect(result[0]._count).toEqual({ categories: 1 });
+  });
+
+  test("oneToMany: クロスrealmのDateキーでもカウントされる", () => {
+    const context: RelationContext = {
+      relations: {
+        posts: {
+          type: "oneToMany",
+          to: "Posts",
+          field: "key",
+          reference: "authorKey",
+        },
+      },
+      findManyOnSheet: mockFindMany,
+    };
+
+    const parents = [{ key: createCrossRealmDate("2026-07-18T09:30:00.000Z") }];
+
+    mockFindMany.mockReturnValue([
+      { authorKey: new Date("2026-07-18T09:30:00.000Z") },
+      { authorKey: new Date("2026-07-18T09:30:00.000Z") },
+    ]);
+
+    const result = resolveCount(parents, { select: { posts: true } }, context);
+
+    expect(result[0]._count).toEqual({ posts: 2 });
   });
 });

--- a/src/__test__/util/relation/resolvers/manyToMany.test.ts
+++ b/src/__test__/util/relation/resolvers/manyToMany.test.ts
@@ -1,5 +1,6 @@
 import { resolveManyToMany } from "../../../../util/relation/resolvers/manyToMany";
 import type { RelationDefinition } from "../../../../types/relationTypes";
+import { createCrossRealmDate } from "../../../consts/crossRealm";
 
 describe("resolveManyToMany", () => {
   const relation: RelationDefinition = {
@@ -373,5 +374,102 @@ describe("resolveManyToMany", () => {
     expect(result[0].categories).toEqual([
       { name: "Tech", posts: [{ id: 1, title: "Post A" }] },
     ]);
+  });
+});
+
+describe("resolveManyToMany with Date keys", () => {
+  const dateRelation: RelationDefinition = {
+    type: "manyToMany",
+    to: "Categories",
+    field: "at",
+    reference: "at",
+    through: {
+      sheet: "PostCategories",
+      field: "postAt",
+      reference: "categoryAt",
+    },
+  };
+
+  const mockFindMany = jest.fn();
+
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  it("Dateキーの中間テーブル経由で関連が解決される", () => {
+    const parents = [
+      { at: new Date("2026-07-18T09:30:00.000Z"), title: "Post A" },
+    ];
+
+    mockFindMany.mockReturnValueOnce([
+      {
+        postAt: new Date("2026-07-18T09:30:00.000Z"),
+        categoryAt: new Date("2026-07-18T10:30:00.000Z"),
+      },
+    ]);
+    mockFindMany.mockReturnValueOnce([
+      { at: new Date("2026-07-18T10:30:00.000Z"), name: "Tech" },
+    ]);
+
+    const result = resolveManyToMany(
+      parents,
+      dateRelation,
+      "categories",
+      mockFindMany,
+    );
+
+    expect(result[0].categories).toEqual([
+      { at: new Date("2026-07-18T10:30:00.000Z"), name: "Tech" },
+    ]);
+  });
+
+  it("ミリ秒差のターゲットはマッチしない", () => {
+    const parents = [
+      { at: new Date("2026-07-18T09:30:00.000Z"), title: "Post A" },
+    ];
+
+    mockFindMany.mockReturnValueOnce([
+      {
+        postAt: new Date("2026-07-18T09:30:00.000Z"),
+        categoryAt: new Date("2026-07-18T10:30:00.000Z"),
+      },
+    ]);
+    mockFindMany.mockReturnValueOnce([
+      { at: new Date("2026-07-18T10:30:00.001Z"), name: "Tech" },
+    ]);
+
+    const result = resolveManyToMany(
+      parents,
+      dateRelation,
+      "categories",
+      mockFindMany,
+    );
+
+    expect(result[0].categories).toEqual([]);
+  });
+
+  it("クロスrealmのDateキーでも関連が解決される", () => {
+    const parents = [
+      { at: new Date("2026-07-18T09:30:00.000Z"), title: "Post A" },
+    ];
+
+    mockFindMany.mockReturnValueOnce([
+      {
+        postAt: createCrossRealmDate("2026-07-18T09:30:00.000Z"),
+        categoryAt: createCrossRealmDate("2026-07-18T10:30:00.000Z"),
+      },
+    ]);
+    mockFindMany.mockReturnValueOnce([
+      { at: new Date("2026-07-18T10:30:00.000Z"), name: "Tech" },
+    ]);
+
+    const result = resolveManyToMany(
+      parents,
+      dateRelation,
+      "categories",
+      mockFindMany,
+    );
+
+    expect(result[0].categories).toHaveLength(1);
   });
 });

--- a/src/__test__/util/relation/resolvers/manyToOne.test.ts
+++ b/src/__test__/util/relation/resolvers/manyToOne.test.ts
@@ -1,5 +1,7 @@
 import { resolveManyToOne } from "../../../../util/relation/resolvers/manyToOne";
 import type { RelationDefinition } from "../../../../types/relationTypes";
+import { GassmaRelationDuplicateError } from "../../../../errors/relation/relationError";
+import { createCrossRealmDate } from "../../../consts/crossRealm";
 
 describe("resolveManyToOne", () => {
   const relation: RelationDefinition = {
@@ -219,5 +221,114 @@ describe("resolveManyToOne", () => {
       name: "Alice",
       posts: [{ id: 101, authorId: 1, title: "Post A" }],
     });
+  });
+});
+
+describe("resolveManyToOne with Date keys", () => {
+  const dateRelation: RelationDefinition = {
+    type: "manyToOne",
+    to: "Users",
+    field: "joinedAt",
+    reference: "createdAt",
+  };
+
+  const mockFindMany = jest.fn();
+
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  it("同時刻・別インスタンスのDate FKで参照先が解決される", () => {
+    const parents = [
+      { id: 101, joinedAt: new Date("2026-07-18T09:30:00.000Z") },
+    ];
+
+    mockFindMany.mockReturnValue([
+      { createdAt: new Date("2026-07-18T09:30:00.000Z"), name: "Alice" },
+    ]);
+
+    const result = resolveManyToOne(
+      parents,
+      dateRelation,
+      "author",
+      mockFindMany,
+    );
+
+    expect(result[0].author).toEqual({
+      createdAt: new Date("2026-07-18T09:30:00.000Z"),
+      name: "Alice",
+    });
+  });
+
+  it("ミリ秒差のDate FKはマッチせずnullになる", () => {
+    const parents = [
+      { id: 101, joinedAt: new Date("2026-07-18T09:30:00.001Z") },
+    ];
+
+    mockFindMany.mockReturnValue([
+      { createdAt: new Date("2026-07-18T09:30:00.000Z"), name: "Alice" },
+    ]);
+
+    const result = resolveManyToOne(
+      parents,
+      dateRelation,
+      "author",
+      mockFindMany,
+    );
+
+    expect(result[0].author).toBeNull();
+  });
+
+  it("Date FKとISO文字列の参照はマッチしない", () => {
+    const parents = [
+      { id: 101, joinedAt: new Date("2026-07-18T09:30:00.000Z") },
+    ];
+
+    mockFindMany.mockReturnValue([
+      { createdAt: "2026-07-18T09:30:00.000Z", name: "Alice" },
+    ]);
+
+    const result = resolveManyToOne(
+      parents,
+      dateRelation,
+      "author",
+      mockFindMany,
+    );
+
+    expect(result[0].author).toBeNull();
+  });
+
+  it("同時刻・別インスタンスの参照の重複はエラーになる", () => {
+    const parents = [
+      { id: 101, joinedAt: new Date("2026-07-18T09:30:00.000Z") },
+    ];
+
+    mockFindMany.mockReturnValue([
+      { createdAt: new Date("2026-07-18T09:30:00.000Z"), name: "Alice" },
+      { createdAt: new Date("2026-07-18T09:30:00.000Z"), name: "Alice2" },
+    ]);
+
+    expect(() =>
+      resolveManyToOne(parents, dateRelation, "author", mockFindMany),
+    ).toThrow(GassmaRelationDuplicateError);
+  });
+
+  it("クロスrealmのDate FKでも参照先が解決される", () => {
+    const parents = [
+      { id: 101, joinedAt: createCrossRealmDate("2026-07-18T09:30:00.000Z") },
+    ];
+
+    mockFindMany.mockReturnValue([
+      { createdAt: new Date("2026-07-18T09:30:00.000Z"), name: "Alice" },
+    ]);
+
+    const result = resolveManyToOne(
+      parents,
+      dateRelation,
+      "author",
+      mockFindMany,
+    );
+
+    expect(result[0].author).not.toBeNull();
   });
 });

--- a/src/__test__/util/relation/resolvers/oneToMany.test.ts
+++ b/src/__test__/util/relation/resolvers/oneToMany.test.ts
@@ -1,5 +1,6 @@
 import { resolveOneToMany } from "../../../../util/relation/resolvers/oneToMany";
 import type { RelationDefinition } from "../../../../types/relationTypes";
+import { createCrossRealmDate } from "../../../consts/crossRealm";
 
 describe("resolveOneToMany", () => {
   const relation: RelationDefinition = {
@@ -392,5 +393,76 @@ describe("resolveOneToMany", () => {
       where: { authorId: { in: [1] } },
       include: { comments: true },
     });
+  });
+});
+
+describe("resolveOneToMany with Date keys", () => {
+  const dateRelation: RelationDefinition = {
+    type: "oneToMany",
+    to: "Posts",
+    field: "key",
+    reference: "authorKey",
+  };
+
+  const mockFindMany = jest.fn();
+
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  it("同時刻・別インスタンスのDateキーで子が同じ親に集約される", () => {
+    const parents = [{ id: 1, key: new Date("2026-07-18T09:30:00.000Z") }];
+
+    mockFindMany.mockReturnValue([
+      { id: 101, authorKey: new Date("2026-07-18T09:30:00.000Z") },
+      { id: 102, authorKey: new Date("2026-07-18T09:30:00.000Z") },
+    ]);
+
+    const result = resolveOneToMany(
+      parents,
+      dateRelation,
+      "posts",
+      mockFindMany,
+    );
+
+    expect(result[0].posts).toHaveLength(2);
+  });
+
+  it("ミリ秒差のDateキーの子は集約されない", () => {
+    const parents = [{ id: 1, key: new Date("2026-07-18T09:30:00.000Z") }];
+
+    mockFindMany.mockReturnValue([
+      { id: 101, authorKey: new Date("2026-07-18T09:30:00.000Z") },
+      { id: 102, authorKey: new Date("2026-07-18T09:30:00.001Z") },
+    ]);
+
+    const result = resolveOneToMany(
+      parents,
+      dateRelation,
+      "posts",
+      mockFindMany,
+    );
+
+    expect(result[0].posts).toHaveLength(1);
+  });
+
+  it("クロスrealmのDateキーでも子が集約される", () => {
+    const parents = [
+      { id: 1, key: createCrossRealmDate("2026-07-18T09:30:00.000Z") },
+    ];
+
+    mockFindMany.mockReturnValue([
+      { id: 101, authorKey: new Date("2026-07-18T09:30:00.000Z") },
+      { id: 102, authorKey: new Date("2026-07-18T09:30:00.000Z") },
+    ]);
+
+    const result = resolveOneToMany(
+      parents,
+      dateRelation,
+      "posts",
+      mockFindMany,
+    );
+
+    expect(result[0].posts).toHaveLength(2);
   });
 });

--- a/src/__test__/util/relation/resolvers/oneToOne.test.ts
+++ b/src/__test__/util/relation/resolvers/oneToOne.test.ts
@@ -1,5 +1,6 @@
 import { resolveOneToOne } from "../../../../util/relation/resolvers/oneToOne";
 import type { RelationDefinition } from "../../../../types/relationTypes";
+import { createCrossRealmDate } from "../../../consts/crossRealm";
 
 describe("resolveOneToOne", () => {
   const relation: RelationDefinition = {
@@ -194,5 +195,89 @@ describe("resolveOneToOne", () => {
       bio: "Hello",
       user: { id: 1, name: "Alice" },
     });
+  });
+});
+
+describe("resolveOneToOne with Date keys", () => {
+  const dateRelation: RelationDefinition = {
+    type: "oneToOne",
+    to: "Profiles",
+    field: "registeredAt",
+    reference: "userRegisteredAt",
+  };
+
+  const mockFindMany = jest.fn();
+
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  it("同時刻・別インスタンスのDateキーで子が解決される", () => {
+    const parents = [
+      { id: 1, registeredAt: new Date("2026-07-18T09:30:00.000Z") },
+    ];
+
+    mockFindMany.mockReturnValue([
+      {
+        userRegisteredAt: new Date("2026-07-18T09:30:00.000Z"),
+        bio: "Hello",
+      },
+    ]);
+
+    const result = resolveOneToOne(
+      parents,
+      dateRelation,
+      "profile",
+      mockFindMany,
+    );
+
+    expect(result[0].profile).toEqual({
+      userRegisteredAt: new Date("2026-07-18T09:30:00.000Z"),
+      bio: "Hello",
+    });
+  });
+
+  it("ミリ秒差のDateキーはマッチせずnullになる", () => {
+    const parents = [
+      { id: 1, registeredAt: new Date("2026-07-18T09:30:00.001Z") },
+    ];
+
+    mockFindMany.mockReturnValue([
+      {
+        userRegisteredAt: new Date("2026-07-18T09:30:00.000Z"),
+        bio: "Hello",
+      },
+    ]);
+
+    const result = resolveOneToOne(
+      parents,
+      dateRelation,
+      "profile",
+      mockFindMany,
+    );
+
+    expect(result[0].profile).toBeNull();
+  });
+
+  it("クロスrealmのDateキーでも子が解決される", () => {
+    const parents = [
+      { id: 1, registeredAt: createCrossRealmDate("2026-07-18T09:30:00.000Z") },
+    ];
+
+    mockFindMany.mockReturnValue([
+      {
+        userRegisteredAt: new Date("2026-07-18T09:30:00.000Z"),
+        bio: "Hello",
+      },
+    ]);
+
+    const result = resolveOneToOne(
+      parents,
+      dateRelation,
+      "profile",
+      mockFindMany,
+    );
+
+    expect(result[0].profile).not.toBeNull();
   });
 });

--- a/src/__test__/util/relation/whereRelation/filters/everyFilter.test.ts
+++ b/src/__test__/util/relation/whereRelation/filters/everyFilter.test.ts
@@ -1,6 +1,7 @@
 import { applyEveryFilter } from "../../../../../util/relation/whereRelation/filters/everyFilter";
 import type { RelationDefinition } from "../../../../../types/relationTypes";
 import type { WhereUse } from "../../../../../types/coreTypes";
+import { createCrossRealmDate } from "../../../../consts/crossRealm";
 
 describe("applyEveryFilter", () => {
   const mockFindMany = jest.fn();
@@ -176,5 +177,150 @@ describe("applyEveryFilter", () => {
       // post2: tag10(合致) → 全数1, 合致数1 → 成功
       expect(result).toEqual({ id: { notIn: [1] } });
     });
+  });
+});
+
+describe("applyEveryFilter with Date keys", () => {
+  const mockFindMany = jest.fn();
+
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  const dateRelation: RelationDefinition = {
+    type: "oneToMany",
+    to: "Posts",
+    field: "key",
+    reference: "authorKey",
+  };
+
+  it("全子が合致する親はDateキーでもnotInに含まれない", () => {
+    mockFindMany.mockImplementation(
+      (_sheet: string, findData: { where?: WhereUse }) => {
+        if (!findData.where || Object.keys(findData.where).length === 0) {
+          return [
+            {
+              authorKey: new Date("2026-07-18T09:30:00.000Z"),
+              published: true,
+            },
+          ];
+        }
+        return [
+          { authorKey: new Date("2026-07-18T09:30:00.000Z"), published: true },
+        ];
+      },
+    );
+
+    const result = applyEveryFilter(
+      dateRelation,
+      "posts",
+      { published: true },
+      mockFindMany,
+    );
+
+    expect(result).toEqual({ key: { notIn: [] } });
+  });
+
+  it("合致しない子を持つ親のDateキーは元の値でnotInに含まれる", () => {
+    mockFindMany.mockImplementation(
+      (_sheet: string, findData: { where?: WhereUse }) => {
+        if (!findData.where || Object.keys(findData.where).length === 0) {
+          return [
+            {
+              authorKey: new Date("2026-07-18T09:30:00.000Z"),
+              published: true,
+            },
+            {
+              authorKey: new Date("2026-07-18T10:30:00.000Z"),
+              published: false,
+            },
+          ];
+        }
+        return [
+          { authorKey: new Date("2026-07-18T09:30:00.000Z"), published: true },
+        ];
+      },
+    );
+
+    const result = applyEveryFilter(
+      dateRelation,
+      "posts",
+      { published: true },
+      mockFindMany,
+    );
+
+    expect(result).toEqual({
+      key: { notIn: [new Date("2026-07-18T10:30:00.000Z")] },
+    });
+  });
+
+  it("manyToMany: ミリ秒差のターゲットは合致扱いされない", () => {
+    const m2mRelation: RelationDefinition = {
+      type: "manyToMany",
+      to: "Categories",
+      field: "at",
+      reference: "at",
+      through: {
+        sheet: "PostCategories",
+        field: "postAt",
+        reference: "categoryAt",
+      },
+    };
+
+    mockFindMany.mockImplementation(
+      (sheet: string, _findData: { where?: WhereUse }) => {
+        if (sheet === "PostCategories") {
+          return [
+            {
+              postAt: new Date("2026-07-01T00:00:00.000Z"),
+              categoryAt: new Date("2026-07-18T09:30:00.000Z"),
+            },
+            {
+              postAt: new Date("2026-07-02T00:00:00.000Z"),
+              categoryAt: new Date("2026-07-18T09:30:00.001Z"),
+            },
+          ];
+        }
+        return [{ at: new Date("2026-07-18T09:30:00.000Z"), active: true }];
+      },
+    );
+
+    const result = applyEveryFilter(
+      m2mRelation,
+      "categories",
+      { active: true },
+      mockFindMany,
+    );
+
+    expect(result).toEqual({
+      at: { notIn: [new Date("2026-07-02T00:00:00.000Z")] },
+    });
+  });
+
+  it("クロスrealmのDateキーでも突合される", () => {
+    mockFindMany.mockImplementation(
+      (_sheet: string, findData: { where?: WhereUse }) => {
+        if (!findData.where || Object.keys(findData.where).length === 0) {
+          return [
+            {
+              authorKey: createCrossRealmDate("2026-07-18T09:30:00.000Z"),
+              published: true,
+            },
+          ];
+        }
+        return [
+          { authorKey: new Date("2026-07-18T09:30:00.000Z"), published: true },
+        ];
+      },
+    );
+
+    const result = applyEveryFilter(
+      dateRelation,
+      "posts",
+      { published: true },
+      mockFindMany,
+    );
+
+    expect(result).toEqual({ key: { notIn: [] } });
   });
 });

--- a/src/util/find/findUtil/resolveRelationOrderBy.ts
+++ b/src/util/find/findUtil/resolveRelationOrderBy.ts
@@ -4,6 +4,7 @@ import {
   RelationOrderByUnsupportedTypeError,
   RelationOrderByCountUnsupportedTypeError,
 } from "../../../errors/find/findError";
+import { toLookupKey } from "../../other/toLookupKey";
 import { collectKeys } from "../../relation/collectKeys";
 import { countByRelation } from "../../relation/resolveCount";
 import { isRelationOrderByValue } from "./separateRelationOrderBy";
@@ -40,7 +41,7 @@ const resolveCountOrderBy = (
   );
 
   records.forEach((r) => {
-    const key = r[relationDef.field];
+    const key = toLookupKey(r[relationDef.field]);
     r[tempKey] = countMap.get(key) ?? 0;
   });
 
@@ -79,13 +80,15 @@ const resolveFieldOrderBy = (
 
   const lookup = new Map<unknown, unknown>();
   relatedRecords.forEach((r) => {
-    lookup.set(r[relationDef.reference], r[sortField]);
+    lookup.set(toLookupKey(r[relationDef.reference]), r[sortField]);
   });
 
   records.forEach((r) => {
     const fk = r[relationDef.field];
     r[tempKey] =
-      fk === null || fk === undefined ? null : (lookup.get(fk) ?? null);
+      fk === null || fk === undefined
+        ? null
+        : (lookup.get(toLookupKey(fk)) ?? null);
   });
 
   return tempKey;

--- a/src/util/groupby/groubyUtil/by.ts
+++ b/src/util/groupby/groubyUtil/by.ts
@@ -1,4 +1,5 @@
 import type { GassmaAny } from "../../../types/coreTypes";
+import { containsValue, isValueEqual } from "../../other/isValueEqual";
 
 const bySearch = (
   rows: Record<string, any>[],
@@ -12,7 +13,7 @@ const bySearch = (
   rows.forEach((row) => {
     const data: GassmaAny = row[byData[depth]];
 
-    if (matches.includes(data)) return;
+    if (containsValue(matches, data)) return;
 
     matches.push(data);
   });
@@ -21,7 +22,7 @@ const bySearch = (
     rows.filter((row) => {
       const data = row[byData[depth]];
 
-      return data === match;
+      return isValueEqual(data, match);
     }),
   );
 

--- a/src/util/other/toLookupKey.ts
+++ b/src/util/other/toLookupKey.ts
@@ -1,0 +1,9 @@
+import { isDateValue } from "./isDateValue";
+
+const toLookupKey = (value: unknown): unknown => {
+  if (isDateValue(value)) return `date:${value.getTime()}`;
+  if (typeof value === "string") return `str:${value}`;
+  return value;
+};
+
+export { toLookupKey };

--- a/src/util/relation/onUpdate/resolveOnUpdate.ts
+++ b/src/util/relation/onUpdate/resolveOnUpdate.ts
@@ -1,6 +1,7 @@
 import type { GassmaAny } from "../../../types/coreTypes";
 import type { RelationContext } from "../../../types/relationTypes";
 import { RelationOnUpdateRestrictError } from "../../../errors/relation/relationError";
+import { isValueEqual } from "../../other/isValueEqual";
 import { collectKeys, isGassmaAny } from "../collectKeys";
 
 type ChangedPair = {
@@ -19,7 +20,7 @@ const extractChangedPairs = (
     if (!after) return;
     const oldValue = before[field];
     const newValue = after[field];
-    if (oldValue === newValue) return;
+    if (isValueEqual(oldValue, newValue)) return;
     if (!isGassmaAny(oldValue) || !isGassmaAny(newValue)) return;
     pairs.push({ oldValue, newValue });
   });
@@ -105,7 +106,10 @@ const resolveOnUpdate = (
       const oldValues = collectKeys(
         beforeRecords.filter((before, i) => {
           const after = afterRecords[i];
-          return after && before[relation.field] !== after[relation.field];
+          return (
+            after &&
+            !isValueEqual(before[relation.field], after[relation.field])
+          );
         }),
         relation.field,
       );

--- a/src/util/relation/resolveCount.ts
+++ b/src/util/relation/resolveCount.ts
@@ -5,6 +5,7 @@ import type {
   RelationDefinition,
 } from "../../types/relationTypes";
 import { GassmaThroughRequiredError } from "../../errors/relation/relationError";
+import { toLookupKey } from "../other/toLookupKey";
 import { collectKeys } from "./collectKeys";
 
 type FindManyOnSheet = (
@@ -52,7 +53,7 @@ const countOneToManyOrOne = (
 
   const countMap = new Map<unknown, number>();
   children.forEach((child) => {
-    const key = child[relation.reference];
+    const key = toLookupKey(child[relation.reference]);
     countMap.set(key, (countMap.get(key) ?? 0) + 1);
   });
 
@@ -77,12 +78,13 @@ const countManyToOne = (
 
   const existsSet = new Set<unknown>();
   targets.forEach((t) => {
-    existsSet.add(t[relation.reference]);
+    existsSet.add(toLookupKey(t[relation.reference]));
   });
 
   const countMap = new Map<unknown, number>();
   fkValues.forEach((fk) => {
-    countMap.set(fk, existsSet.has(fk) ? 1 : 0);
+    const key = toLookupKey(fk);
+    countMap.set(key, existsSet.has(key) ? 1 : 0);
   });
 
   return countMap;
@@ -110,7 +112,7 @@ const countManyToMany = (
   if (!filterWhere) {
     const countMap = new Map<unknown, number>();
     junctionRows.forEach((jRow) => {
-      const parentKey = jRow[through.field];
+      const parentKey = toLookupKey(jRow[through.field]);
       countMap.set(parentKey, (countMap.get(parentKey) ?? 0) + 1);
     });
     return countMap;
@@ -123,13 +125,13 @@ const countManyToMany = (
 
   const validTargetKeys = new Set<unknown>();
   targets.forEach((t) => {
-    validTargetKeys.add(t[relation.reference]);
+    validTargetKeys.add(toLookupKey(t[relation.reference]));
   });
 
   const countMap = new Map<unknown, number>();
   junctionRows.forEach((jRow) => {
-    if (!validTargetKeys.has(jRow[through.reference])) return;
-    const parentKey = jRow[through.field];
+    if (!validTargetKeys.has(toLookupKey(jRow[through.reference]))) return;
+    const parentKey = toLookupKey(jRow[through.field]);
     countMap.set(parentKey, (countMap.get(parentKey) ?? 0) + 1);
   });
 
@@ -179,7 +181,7 @@ const resolveCount = (
     );
 
     parents.forEach((parent, index) => {
-      const key = parent[relation.field];
+      const key = toLookupKey(parent[relation.field]);
       countResults[index][relationName] = countMap.get(key) ?? 0;
     });
   });

--- a/src/util/relation/resolvers/manyToMany.ts
+++ b/src/util/relation/resolvers/manyToMany.ts
@@ -9,6 +9,7 @@ import { GassmaThroughRequiredError } from "../../../errors/relation/relationErr
 import { orderByFunc } from "../../find/findUtil/orderBy";
 import { applySelectOmit } from "../../find/findUtil/applySelectOmit";
 import { applySelectRelations } from "../../find/findUtil/applySelectRelations";
+import { toLookupKey } from "../../other/toLookupKey";
 import { collectKeys } from "../collectKeys";
 import { pickOmitFalse } from "../pickOmitFalse";
 import { processSelectForInclude } from "../processSelectForInclude";
@@ -69,14 +70,14 @@ const resolveManyToMany = (
   // Step 3: ターゲットをルックアップマップに
   const targetLookup = new Map<unknown, Record<string, unknown>>();
   targets.forEach((t) => {
-    targetLookup.set(t[relation.reference], t);
+    targetLookup.set(toLookupKey(t[relation.reference]), t);
   });
 
   // Step 4: 親→中間テーブル→ターゲットのマッピング
   const parentToTargets = new Map<unknown, Record<string, unknown>[]>();
   junctionRows.forEach((jRow) => {
-    const parentKey = jRow[through.field];
-    const target = targetLookup.get(jRow[through.reference]);
+    const parentKey = toLookupKey(jRow[through.field]);
+    const target = targetLookup.get(toLookupKey(jRow[through.reference]));
     if (!target) return;
 
     const list = parentToTargets.get(parentKey) ?? [];
@@ -85,7 +86,7 @@ const resolveManyToMany = (
   });
 
   return parents.map((parent) => {
-    let items = parentToTargets.get(parent[relation.field]) ?? [];
+    let items = parentToTargets.get(toLookupKey(parent[relation.field])) ?? [];
 
     if (options?.orderBy) {
       const orderByArr = Array.isArray(options.orderBy)

--- a/src/util/relation/resolvers/manyToOne.ts
+++ b/src/util/relation/resolvers/manyToOne.ts
@@ -7,6 +7,7 @@ import type { QueryOmit, WhereUse } from "../../../types/coreTypes";
 import { GassmaRelationDuplicateError } from "../../../errors/relation/relationError";
 import { applySelectOmit } from "../../find/findUtil/applySelectOmit";
 import { applySelectRelations } from "../../find/findUtil/applySelectRelations";
+import { toLookupKey } from "../../other/toLookupKey";
 import { collectKeys } from "../collectKeys";
 import { pickOmitFalse } from "../pickOmitFalse";
 import { processSelectForInclude } from "../processSelectForInclude";
@@ -49,20 +50,23 @@ const resolveManyToOne = (
   const lookup = new Map<unknown, Record<string, unknown>>();
   targets.forEach((target) => {
     const key = target[relation.reference];
-    if (lookup.has(key)) {
+    const lookupKey = toLookupKey(key);
+    if (lookup.has(lookupKey)) {
       throw new GassmaRelationDuplicateError(
         relation.to,
         relation.reference,
         key,
       );
     }
-    lookup.set(key, target);
+    lookup.set(lookupKey, target);
   });
 
   return parents.map((parent) => {
     const fk = parent[relation.field];
     const raw =
-      fk !== null && fk !== undefined ? (lookup.get(fk) ?? null) : null;
+      fk !== null && fk !== undefined
+        ? (lookup.get(toLookupKey(fk)) ?? null)
+        : null;
     if (!raw) return { ...parent, [relationName]: null };
 
     if (processed?.nestedInclude) {

--- a/src/util/relation/resolvers/oneToMany.ts
+++ b/src/util/relation/resolvers/oneToMany.ts
@@ -8,6 +8,7 @@ import { GassmaSkipNegativeError } from "../../../errors/find/findError";
 import { orderByFunc } from "../../find/findUtil/orderBy";
 import { applySelectOmit } from "../../find/findUtil/applySelectOmit";
 import { applySelectRelations } from "../../find/findUtil/applySelectRelations";
+import { toLookupKey } from "../../other/toLookupKey";
 import { collectKeys } from "../collectKeys";
 import { pickOmitFalse } from "../pickOmitFalse";
 import { processSelectForInclude } from "../processSelectForInclude";
@@ -49,14 +50,14 @@ const resolveOneToMany = (
 
   const grouped = new Map<unknown, Record<string, unknown>[]>();
   children.forEach((child) => {
-    const key = child[relation.reference];
+    const key = toLookupKey(child[relation.reference]);
     const list = grouped.get(key) ?? [];
     list.push(child);
     grouped.set(key, list);
   });
 
   return parents.map((parent) => {
-    let items = grouped.get(parent[relation.field]) ?? [];
+    let items = grouped.get(toLookupKey(parent[relation.field])) ?? [];
 
     if (options?.orderBy) {
       const orderByArr = Array.isArray(options.orderBy)

--- a/src/util/relation/resolvers/oneToOne.ts
+++ b/src/util/relation/resolvers/oneToOne.ts
@@ -7,6 +7,7 @@ import type { QueryOmit, WhereUse } from "../../../types/coreTypes";
 import { GassmaRelationDuplicateError } from "../../../errors/relation/relationError";
 import { applySelectOmit } from "../../find/findUtil/applySelectOmit";
 import { applySelectRelations } from "../../find/findUtil/applySelectRelations";
+import { toLookupKey } from "../../other/toLookupKey";
 import { collectKeys } from "../collectKeys";
 import { pickOmitFalse } from "../pickOmitFalse";
 import { processSelectForInclude } from "../processSelectForInclude";
@@ -49,18 +50,19 @@ const resolveOneToOne = (
   const lookup = new Map<unknown, Record<string, unknown>>();
   children.forEach((child) => {
     const key = child[relation.reference];
-    if (lookup.has(key)) {
+    const lookupKey = toLookupKey(key);
+    if (lookup.has(lookupKey)) {
       throw new GassmaRelationDuplicateError(
         relation.to,
         relation.reference,
         key,
       );
     }
-    lookup.set(key, child);
+    lookup.set(lookupKey, child);
   });
 
   return parents.map((parent) => {
-    const child = lookup.get(parent[relation.field]) ?? null;
+    const child = lookup.get(toLookupKey(parent[relation.field])) ?? null;
     if (!child) return { ...parent, [relationName]: null };
 
     if (processed?.nestedInclude) {

--- a/src/util/relation/whereRelation/filters/everyFilter.ts
+++ b/src/util/relation/whereRelation/filters/everyFilter.ts
@@ -1,5 +1,6 @@
 import type { RelationDefinition } from "../../../../types/relationTypes";
 import type { GassmaAny, WhereUse } from "../../../../types/coreTypes";
+import { toLookupKey } from "../../../other/toLookupKey";
 import { collectKeys } from "../../collectKeys";
 import { isGassmaAny } from "../../collectKeys";
 
@@ -8,28 +9,36 @@ type FindManyOnSheet = (
   findData: { where?: WhereUse },
 ) => Record<string, unknown>[];
 
+type KeyCount = { value: GassmaAny; count: number };
+
 const countByKey = (
   records: Record<string, unknown>[],
   keyField: string,
-): Map<unknown, number> => {
-  const counts = new Map<unknown, number>();
+): Map<unknown, KeyCount> => {
+  const counts = new Map<unknown, KeyCount>();
   records.forEach((r) => {
     const key = r[keyField];
     if (!isGassmaAny(key)) return;
-    counts.set(key, (counts.get(key) ?? 0) + 1);
+    const lookupKey = toLookupKey(key);
+    const entry = counts.get(lookupKey);
+    if (entry) {
+      entry.count += 1;
+      return;
+    }
+    counts.set(lookupKey, { value: key, count: 1 });
   });
   return counts;
 };
 
 const findFailingKeys = (
-  allCounts: Map<unknown, number>,
-  matchCounts: Map<unknown, number>,
+  allCounts: Map<unknown, KeyCount>,
+  matchCounts: Map<unknown, KeyCount>,
 ): GassmaAny[] => {
   const failing: GassmaAny[] = [];
-  allCounts.forEach((total, key) => {
-    const matched = matchCounts.get(key) ?? 0;
-    if (matched < total && isGassmaAny(key)) {
-      failing.push(key);
+  allCounts.forEach((entry, key) => {
+    const matched = matchCounts.get(key)?.count ?? 0;
+    if (matched < entry.count) {
+      failing.push(entry.value);
     }
   });
   return failing;
@@ -70,12 +79,12 @@ const applyEveryFilterManyToMany = (
 
   const matchTargets = findManyOnSheet(relation.to, { where: filterWhere });
   const matchTargetKeys = new Set(
-    collectKeys(matchTargets, relation.reference).map(String),
+    collectKeys(matchTargets, relation.reference).map(toLookupKey),
   );
 
   const matchJunctions = allJunctions.filter((j) => {
     const ref = j[through.reference];
-    return isGassmaAny(ref) && matchTargetKeys.has(String(ref));
+    return isGassmaAny(ref) && matchTargetKeys.has(toLookupKey(ref));
   });
   const matchCounts = countByKey(matchJunctions, through.field);
 


### PR DESCRIPTION
## 概要

#139(Date 等価の時刻一致化)のスコープ外として記録されていた**参照比較の残存**を、Prisma 実測で確証してから修正します(ユーザー承認済み・実測必須指示)。

## Prisma 実測(7.4.1、SQLite。schema 組み替え含め実測後に md5 一致で完全復元)

| 項目 | 結果 |
|---|---|
| groupBy + DateTime の by | 同時刻(別インスタンス・TZ 表現差含む)は**同一グループ**、+1ms は別グループ |
| onUpdate + DateTime キー | 同時刻の新インスタンスで update → **Restrict/SetNull/Cascade 全て不発火**(+1ms の対照実験では全て発火 = SQL の実質 IS DISTINCT FROM) |
| DateTime FK の解決 | include / _count / relation filter(is/some/every)/ relation orderBy **全て時刻一致でマッチ** |
| 端数 | ms 精度で完全保存・丸めなし |

## 修正(当初3箇所 + 走査で発見した同型6ファイル)

- **既知3箇所**: groupBy `byClassification`(includes/`===` → containsValue/isValueEqual)、`resolveOnUpdate` の変更検知2箇所、リレーション resolver 4種(manyToOne/oneToOne/oneToMany/manyToMany)の Map キー
- **追加発見**: `resolveCount` の全4経路、`resolveRelationOrderBy` の lookup 2種、`everyFilter` の countByKey — every は Date キーで常時誤判定に加え、**manyToMany 経路が `String()` キー化で ms を落とし別時刻を合致扱いする逆方向バグ**も併発していたため両方修正
- キー化は新ヘルパー **`toLookupKey`**(`date:<epoch>` / `str:` プレフィックスで衝突なし、isDateValue ベースで realm 安全)に統一
- 監査済みクリーン: distinct(JSON.stringify で既に正常)・onDelete・having・orderBy 比較・where 系
- Date と ISO 文字列の混在は暗黙変換なし(#139 と一貫)

## テスト

1552 → **1599(+47)**。逆検証: 修正前実装で **31 件 fail** を実測。**クロス realm テストを修正箇所ごとに最低1本(計10本、vm helper 使用)**。tsc / lint / format / build / verify:bundle 全 green。

## gassma-test 追随(マージ後・要判断1点)

- groupBy の Date by は既存の createdAt 列で追随可能(同時刻シードの有無は次ラウンドで確認)
- **DateTime FK / DateTime キーの onUpdate 構成は既存シートに存在せず**、統合テストには新モデルのシート3点セット(CSV + consts + reset)が必要 → 別途ご判断ください

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX