### PR TITLE
feat: declare and expose the 14 remaining runtime error classes

### DIFF
--- a/src/__test__/errors/errorPrototypeChain.test.ts
+++ b/src/__test__/errors/errorPrototypeChain.test.ts
@@ -1,15 +1,27 @@
 import {
+  GassmaAggregateAvgError,
+  GassmaAggregateAvgTypeError,
   GassmaAggregateMaxError,
   GassmaAggregateMinError,
+  GassmaAggregateSumError,
+  GassmaAggregateSumTypeError,
+  GassmaAggregateTypeError,
 } from "../../errors/aggregate/aggregateError";
 import { GassmaInValidColumnValueError } from "../../errors/changeSettings/changeSettingsError";
 import {
   GassmaFindFirstTakeError,
+  GassmaFindSelectOmitConflictError,
   NotFoundError,
 } from "../../errors/find/findError";
 import { GassmaGroupByHavingDontWriteByError } from "../../errors/groupBy/groupByError";
 import { NestedWriteTargetNotFoundError } from "../../errors/relation/nestedWriteError";
-import { RelationOnDeleteRestrictError } from "../../errors/relation/relationError";
+import {
+  GassmaIncludeSelectConflictError,
+  GassmaRelationDuplicateError,
+  GassmaRelationNotFoundError,
+  GassmaThroughRequiredError,
+  RelationOnDeleteRestrictError,
+} from "../../errors/relation/relationError";
 import { GassmaUndefinedValueError } from "../../errors/skip/skipError";
 
 type ErrorCase = {
@@ -58,9 +70,65 @@ const cases: ErrorCase[] = [
     create: () => new GassmaGroupByHavingDontWriteByError(),
   },
   {
+    className: "GassmaFindSelectOmitConflictError",
+    ctor: GassmaFindSelectOmitConflictError,
+    create: () => new GassmaFindSelectOmitConflictError(),
+  },
+  {
+    className: "GassmaIncludeSelectConflictError",
+    ctor: GassmaIncludeSelectConflictError,
+    create: () => new GassmaIncludeSelectConflictError(),
+  },
+  {
+    className: "GassmaRelationNotFoundError",
+    ctor: GassmaRelationNotFoundError,
+    create: () => new GassmaRelationNotFoundError("posts", "Users"),
+  },
+  {
+    className: "GassmaThroughRequiredError",
+    ctor: GassmaThroughRequiredError,
+    create: () => new GassmaThroughRequiredError("tags"),
+  },
+  {
+    className: "GassmaRelationDuplicateError",
+    ctor: GassmaRelationDuplicateError,
+    create: () =>
+      new GassmaRelationDuplicateError("Users", "email", "a@example.com"),
+  },
+  {
+    className: "GassmaAggregateMaxError",
+    ctor: GassmaAggregateMaxError,
+    create: () => new GassmaAggregateMaxError(),
+  },
+  {
     className: "GassmaAggregateMinError",
     ctor: GassmaAggregateMinError,
     create: () => new GassmaAggregateMinError(),
+  },
+  {
+    className: "GassmaAggregateSumError",
+    ctor: GassmaAggregateSumError,
+    create: () => new GassmaAggregateSumError(),
+  },
+  {
+    className: "GassmaAggregateAvgError",
+    ctor: GassmaAggregateAvgError,
+    create: () => new GassmaAggregateAvgError(),
+  },
+  {
+    className: "GassmaAggregateTypeError",
+    ctor: GassmaAggregateTypeError,
+    create: () => new GassmaAggregateTypeError(),
+  },
+  {
+    className: "GassmaAggregateSumTypeError",
+    ctor: GassmaAggregateSumTypeError,
+    create: () => new GassmaAggregateSumTypeError(),
+  },
+  {
+    className: "GassmaAggregateAvgTypeError",
+    ctor: GassmaAggregateAvgTypeError,
+    create: () => new GassmaAggregateAvgTypeError(),
   },
 ];
 
@@ -87,5 +155,82 @@ describe("エラークラスの prototype チェーン", () => {
     const err = new GassmaAggregateMinError();
 
     expect(err instanceof GassmaAggregateMaxError).toBe(true);
+  });
+
+  it("GassmaAggregateSumError / GassmaAggregateAvgError も GassmaAggregateMaxError の instanceof が成立する", () => {
+    const sum = new GassmaAggregateSumError();
+    const avg = new GassmaAggregateAvgError();
+
+    expect(sum instanceof GassmaAggregateMaxError).toBe(true);
+    expect(avg instanceof GassmaAggregateMaxError).toBe(true);
+  });
+
+  it("GassmaAggregateAvgTypeError は親クラス GassmaAggregateSumTypeError としても instanceof が成立する", () => {
+    const err = new GassmaAggregateAvgTypeError();
+
+    expect(err instanceof GassmaAggregateSumTypeError).toBe(true);
+  });
+});
+
+describe("追加エラークラスのメッセージ", () => {
+  const messageCases: {
+    className: string;
+    create: () => Error;
+    message: string;
+  }[] = [
+    {
+      className: "GassmaFindSelectOmitConflictError",
+      create: () => new GassmaFindSelectOmitConflictError(),
+      message: "Cannot use both select and omit in the same query",
+    },
+    {
+      className: "GassmaIncludeSelectConflictError",
+      create: () => new GassmaIncludeSelectConflictError(),
+      message: "Cannot use both include and select in the same query",
+    },
+    {
+      className: "GassmaAggregateMaxError",
+      create: () => new GassmaAggregateMaxError(),
+      message: "Cannot produce a maximum value of more than one type.",
+    },
+    {
+      className: "GassmaAggregateMinError(親のメッセージを継承)",
+      create: () => new GassmaAggregateMinError(),
+      message: "Cannot produce a maximum value of more than one type.",
+    },
+    {
+      className: "GassmaAggregateTypeError",
+      create: () => new GassmaAggregateTypeError(),
+      message:
+        'Only "number", "string", "boolean", and "Date" types are supported.',
+    },
+    {
+      className: "GassmaAggregateAvgTypeError(親のメッセージを継承)",
+      create: () => new GassmaAggregateAvgTypeError(),
+      message: 'Only "number" type is supported.',
+    },
+    {
+      className: "GassmaRelationNotFoundError",
+      create: () => new GassmaRelationNotFoundError("posts", "Users"),
+      message: 'Relation "posts" is not defined for sheet "Users"',
+    },
+    {
+      className: "GassmaThroughRequiredError",
+      create: () => new GassmaThroughRequiredError("tags"),
+      message: 'Relation "tags" is manyToMany but "through" is not defined',
+    },
+    {
+      className: "GassmaRelationDuplicateError",
+      create: () =>
+        new GassmaRelationDuplicateError("Users", "email", "a@example.com"),
+      message:
+        'Duplicate value "a@example.com" found in "Users.email" for a unique relation',
+    },
+  ];
+
+  messageCases.forEach(({ className, create, message }) => {
+    it(`${className} のメッセージがピン留めされている`, () => {
+      expect(create().message).toBe(message);
+    });
   });
 });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -560,6 +560,48 @@ declare namespace Gassma {
   class GassmaUpdateWhereMissingError extends Error {
     constructor();
   }
+  class GassmaFindSelectOmitConflictError extends Error {
+    constructor();
+  }
+  class GassmaInValidColumnValueError extends Error {
+    constructor();
+  }
+  class GassmaGroupByHavingDontWriteByError extends Error {
+    constructor();
+  }
+  class GassmaAggregateMaxError extends Error {
+    constructor();
+  }
+  class GassmaAggregateMinError extends GassmaAggregateMaxError {
+    constructor();
+  }
+  class GassmaAggregateSumError extends GassmaAggregateMaxError {
+    constructor();
+  }
+  class GassmaAggregateAvgError extends GassmaAggregateMaxError {
+    constructor();
+  }
+  class GassmaAggregateTypeError extends Error {
+    constructor();
+  }
+  class GassmaAggregateSumTypeError extends Error {
+    constructor();
+  }
+  class GassmaAggregateAvgTypeError extends GassmaAggregateSumTypeError {
+    constructor();
+  }
+  class GassmaRelationNotFoundError extends Error {
+    constructor(relationName: string, sheetName: string);
+  }
+  class GassmaThroughRequiredError extends Error {
+    constructor(relationName: string);
+  }
+  class GassmaIncludeSelectConflictError extends Error {
+    constructor();
+  }
+  class GassmaRelationDuplicateError extends Error {
+    constructor(sheetName: string, field: string, value: unknown);
+  }
 }
 
 export { Gassma };

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -1,4 +1,7 @@
+import * as aggregateErrors from "./errors/aggregate/aggregateError";
+import * as changeSettingsErrors from "./errors/changeSettings/changeSettingsError";
 import * as findErrors from "./errors/find/findError";
+import * as groupByErrors from "./errors/groupBy/groupByError";
 import * as nestedWriteErrors from "./errors/relation/nestedWriteError";
 import * as relationErrors from "./errors/relation/relationError";
 import * as relationValidationErrors from "./errors/relation/relationValidationError";
@@ -76,3 +79,32 @@ export const GassmaSkipInArrayError = skipErrors.GassmaSkipInArrayError;
 
 export const GassmaUpdateWhereMissingError =
   updateErrors.GassmaUpdateWhereMissingError;
+
+export const GassmaFindSelectOmitConflictError =
+  findErrors.GassmaFindSelectOmitConflictError;
+
+export const GassmaInValidColumnValueError =
+  changeSettingsErrors.GassmaInValidColumnValueError;
+
+export const GassmaGroupByHavingDontWriteByError =
+  groupByErrors.GassmaGroupByHavingDontWriteByError;
+
+export const GassmaAggregateMaxError = aggregateErrors.GassmaAggregateMaxError;
+export const GassmaAggregateMinError = aggregateErrors.GassmaAggregateMinError;
+export const GassmaAggregateSumError = aggregateErrors.GassmaAggregateSumError;
+export const GassmaAggregateAvgError = aggregateErrors.GassmaAggregateAvgError;
+export const GassmaAggregateTypeError =
+  aggregateErrors.GassmaAggregateTypeError;
+export const GassmaAggregateSumTypeError =
+  aggregateErrors.GassmaAggregateSumTypeError;
+export const GassmaAggregateAvgTypeError =
+  aggregateErrors.GassmaAggregateAvgTypeError;
+
+export const GassmaRelationNotFoundError =
+  relationErrors.GassmaRelationNotFoundError;
+export const GassmaThroughRequiredError =
+  relationErrors.GassmaThroughRequiredError;
+export const GassmaIncludeSelectConflictError =
+  relationErrors.GassmaIncludeSelectConflictError;
+export const GassmaRelationDuplicateError =
+  relationErrors.GassmaRelationDuplicateError;


### PR DESCRIPTION
## 概要

#156 で判明した「**ランタイムで throw されるのに index.d.ts に宣言が無く、利用者が instanceof で捕捉できないエラー15個**」の公開です(ユーザー承認済み)。棚卸しの結果 **14個を公開・1個を除外**しました。

## 公開した14個

- **aggregate 系 7**: GassmaAggregateMax/Min/Sum/AvgError + GassmaAggregateType/SumType/AvgTypeError(**実装の継承チェーン — Min/Sum/Avg→Max、AvgType→SumType — を宣言にも忠実に反映**。実行時 prototype と一致)
- **relation 系 4**: GassmaRelationNotFoundError(relationName, sheetName)/ GassmaThroughRequiredError(relationName)/ GassmaRelationDuplicateError(sheetName, field, value)/ GassmaIncludeSelectConflictError
- **その他 3**: GassmaFindSelectOmitConflictError / GassmaInValidColumnValueError(changeSettings 列指定不正)/ GassmaGroupByHavingDontWriteByError

constructor シグネチャは全て実装と突合済み。throw 箇所と利用者到達経路も全数確認しています(PR 内テーブルは省略、コミットメッセージ参照)。

## 除外した1個: GassmaTargetSheetNotFoundError

定義と export 列挙以外に **throw も new も一切存在しない完全な dead code**(relation 機能導入以来一度も投げられていない)。利用者に到達し得ないため公開対象外としました(実装は未変更 — 削除は別判断)。

## verify:bundle の Red→Green(#156 ガードの実証)

- 宣言のみ追加 → **Red: 失敗14件**(`公開シンボルが bundle に存在しません`)
- publicApi.ts に export 追加 → **Green: 公開シンボル 33 → 47 件**

興味深い前例: この作業は過去に一度実施され revert されています(`05af158` → `a892bfd`)。**当時は宣言のみで export が欠けており、まさに今の verify:bundle が検出する形**でした。

## テスト

1606 → **1650(+44)**: 新規11クラス × toThrow/instanceof/prototype + 継承チェーン2 + メッセージピン9(errorPrototypeChain.test.ts に集約)。tsc / lint / format / build / verify:bundle 全 green。

## 備考

並列 PR(必須引数ガード)と index.d.ts / publicApi.ts が衝突します。**本 PR を先にマージ**いただければ、もう1本を私が rebase します。マージ後の gassma-test 追随(testLibrarySurface へ14列挙追加・ambient 再同期)はガード側とまとめて1ラウンドで実施します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX