### PR TITLE
feat: apply result computed fields to nested include results (Tier2)

### DIFF
--- a/src/__test__/util/extends/extendsTestClient.ts
+++ b/src/__test__/util/extends/extendsTestClient.ts
@@ -62,6 +62,12 @@ const buildTestClient = (options?: { relations?: boolean }): GassmaClient => {
       [101, 1, "Post A"],
       [102, 2, "Post B"],
     ]),
+    makeSheet("Comments", [
+      ["id", "postId", "body"],
+      [1001, 101, "Hello world"],
+      [1002, 101, "Nice post"],
+      [1003, 102, "Great read"],
+    ]),
   ];
   const mockSpreadsheet = {
     getId: () => "test-spreadsheet",
@@ -88,6 +94,20 @@ const buildTestClient = (options?: { relations?: boolean }): GassmaClient => {
           type: "manyToOne",
           to: "Users",
           field: "authorId",
+          reference: "id",
+        },
+        comments: {
+          type: "oneToMany",
+          to: "Comments",
+          field: "id",
+          reference: "postId",
+        },
+      },
+      Comments: {
+        post: {
+          type: "manyToOne",
+          to: "Posts",
+          field: "postId",
           reference: "id",
         },
       },

--- a/src/__test__/util/extends/result/resultExtendsComposition.test.ts
+++ b/src/__test__/util/extends/result/resultExtendsComposition.test.ts
@@ -191,7 +191,7 @@ describe("$extends result: query 併用とマージ", () => {
   });
 });
 
-describe("$extends result: Tier1 の境界", () => {
+describe("$extends result: nested への伝播（Tier2）", () => {
   const fullNameExtension = {
     result: {
       Users: {
@@ -203,7 +203,7 @@ describe("$extends result: Tier1 の境界", () => {
     },
   };
 
-  test("nested include の中の同モデルには付かない", () => {
+  test("nested include の中の同モデルにも付く", () => {
     const client = buildTestClient({ relations: true });
     const extended = client.$extends(fullNameExtension);
     expect(extended.Posts.findMany({ include: { author: true } })).toEqual([
@@ -211,18 +211,18 @@ describe("$extends result: Tier1 の境界", () => {
         id: 101,
         authorId: 1,
         title: "Post A",
-        author: { id: 1, name: "Alice", age: 20 },
+        author: { id: 1, name: "Alice", age: 20, fullName: "Mr. Alice" },
       },
       {
         id: 102,
         authorId: 2,
         title: "Post B",
-        author: { id: 2, name: "Bob", age: 30 },
+        author: { id: 2, name: "Bob", age: 30, fullName: "Mr. Bob" },
       },
     ]);
   });
 
-  test("include したトップレベルのレコードには付き include 先はそのまま", () => {
+  test("result 定義のないモデルの include 先はそのまま", () => {
     const client = buildTestClient({ relations: true });
     const extended = client.$extends(fullNameExtension);
     expect(

--- a/src/__test__/util/extends/result/resultExtendsNested.test.ts
+++ b/src/__test__/util/extends/result/resultExtendsNested.test.ts
@@ -1,0 +1,182 @@
+import { buildTestClient, clearSpreadsheetApp } from "../extendsTestClient";
+
+afterAll(clearSpreadsheetApp);
+
+const nestedExtension = {
+  result: {
+    Users: {
+      fullName: {
+        needs: { name: true },
+        compute: (user: { name: string }) => `Mr. ${user.name}`,
+      },
+    },
+    Posts: {
+      titleUpper: {
+        needs: { title: true },
+        compute: (post: { title: string }) => post.title.toUpperCase(),
+      },
+    },
+    Comments: {
+      excerpt: {
+        needs: { body: true },
+        compute: (comment: { body: string }) => comment.body.slice(0, 5),
+      },
+    },
+  },
+};
+
+describe("$extends result: nested include (Tier2)", () => {
+  test("oneToMany include の各 nested レコードに算出フィールドが付く", () => {
+    const client = buildTestClient({ relations: true });
+    const extended = client.$extends(nestedExtension);
+    expect(extended.Users.findMany({ include: { posts: true } })).toEqual([
+      {
+        id: 1,
+        name: "Alice",
+        age: 20,
+        fullName: "Mr. Alice",
+        posts: [
+          { id: 101, authorId: 1, title: "Post A", titleUpper: "POST A" },
+        ],
+      },
+      {
+        id: 2,
+        name: "Bob",
+        age: 30,
+        fullName: "Mr. Bob",
+        posts: [
+          { id: 102, authorId: 2, title: "Post B", titleUpper: "POST B" },
+        ],
+      },
+      { id: 3, name: "Carol", age: 40, fullName: "Mr. Carol", posts: [] },
+    ]);
+  });
+
+  test("manyToOne include の nested レコードに付く", () => {
+    const client = buildTestClient({ relations: true });
+    const extended = client.$extends(nestedExtension);
+    expect(
+      extended.Posts.findFirst({
+        where: { id: 101 },
+        include: { author: true },
+      }),
+    ).toEqual({
+      id: 101,
+      authorId: 1,
+      title: "Post A",
+      titleUpper: "POST A",
+      author: { id: 1, name: "Alice", age: 20, fullName: "Mr. Alice" },
+    });
+  });
+
+  test("深いネスト（include の中の include）でも付く", () => {
+    const client = buildTestClient({ relations: true });
+    const extended = client.$extends(nestedExtension);
+    expect(
+      extended.Users.findFirst({
+        where: { id: 1 },
+        include: { posts: { include: { comments: true } } },
+      }),
+    ).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+      fullName: "Mr. Alice",
+      posts: [
+        {
+          id: 101,
+          authorId: 1,
+          title: "Post A",
+          titleUpper: "POST A",
+          comments: [
+            { id: 1001, postId: 101, body: "Hello world", excerpt: "Hello" },
+            { id: 1002, postId: 101, body: "Nice post", excerpt: "Nice " },
+          ],
+        },
+      ],
+    });
+  });
+
+  test("nested select は needs を確保したうえで整形される", () => {
+    const client = buildTestClient({ relations: true });
+    const extended = client.$extends(nestedExtension);
+    expect(
+      extended.Users.findFirst({
+        where: { id: 1 },
+        include: { posts: { select: { id: true, titleUpper: true } } },
+      }),
+    ).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+      fullName: "Mr. Alice",
+      posts: [{ id: 101, titleUpper: "POST A" }],
+    });
+  });
+
+  test("nested omit は needs を読んで計算しつつ結果から落とす", () => {
+    const client = buildTestClient({ relations: true });
+    const extended = client.$extends(nestedExtension);
+    expect(
+      extended.Posts.findFirst({
+        where: { id: 101 },
+        include: { author: { omit: { name: true } } },
+      }),
+    ).toEqual({
+      id: 101,
+      authorId: 1,
+      title: "Post A",
+      titleUpper: "POST A",
+      author: { id: 1, age: 20, fullName: "Mr. Alice" },
+    });
+  });
+
+  test("select 内のリレーションの nested レコードにも付く", () => {
+    const client = buildTestClient({ relations: true });
+    const extended = client.$extends(nestedExtension);
+    expect(
+      extended.Users.findFirst({
+        where: { id: 2 },
+        select: { name: true, posts: { select: { titleUpper: true } } },
+      }),
+    ).toEqual({
+      name: "Bob",
+      posts: [{ titleUpper: "POST B" }],
+    });
+  });
+
+  test("$allModels の算出フィールドは nested にも付く", () => {
+    const client = buildTestClient({ relations: true });
+    const extended = client.$extends({
+      result: { $allModels: { tagged: { compute: () => true } } },
+    });
+    const users = extended.Users.findMany({ include: { posts: true } });
+    expect(users.length).toBe(3);
+    users.forEach((user: Record<string, unknown>) => {
+      expect(user.tagged).toBe(true);
+      const posts: unknown = user.posts;
+      if (!Array.isArray(posts)) throw new Error("posts が配列でない");
+      posts.forEach((post: Record<string, unknown>) => {
+        expect(post.tagged).toBe(true);
+      });
+    });
+  });
+
+  test("書き込み系の include にも nested の算出フィールドが付く", () => {
+    const client = buildTestClient({ relations: true });
+    const extended = client.$extends(nestedExtension);
+    expect(
+      extended.Posts.update({
+        where: { id: 102 },
+        data: { title: "Post B2" },
+        include: { author: true },
+      }),
+    ).toEqual({
+      id: 102,
+      authorId: 2,
+      title: "Post B2",
+      titleUpper: "POST B2",
+      author: { id: 2, name: "Bob", age: 30, fullName: "Mr. Bob" },
+    });
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -107,6 +107,16 @@ class GassmaController {
     this.relationContext = context;
   }
 
+  public _getRelationTargets(): { [relationName: string]: string } {
+    const targets: { [relationName: string]: string } = {};
+    const relations = this.relationContext?.relations;
+    if (!relations) return targets;
+    Object.keys(relations).forEach((name) => {
+      targets[name] = relations[name].to;
+    });
+    return targets;
+  }
+
   public _setGlobalOmit(omit: Omit) {
     this.globalOmit = omit;
   }

--- a/src/util/extends/buildExtendedClient.ts
+++ b/src/util/extends/buildExtendedClient.ts
@@ -5,7 +5,6 @@ import type {
 } from "../../types/extendsTypes";
 import type { GassmaSheet } from "../../types/gassmaTypes";
 import { wrapControllerWithHooks } from "./query/wrapControllerWithHooks";
-import { resolveResultFields } from "./result/resolveResultFields";
 import { wrapControllerWithResult } from "./result/wrapControllerWithResult";
 
 const buildExtendedClient = (
@@ -13,6 +12,10 @@ const buildExtendedClient = (
   extensions: GassmaExtension[],
 ): ExtendedGassmaClient => {
   const wrapped: GassmaSheet = {};
+  const relationTargets = (model: string): { [name: string]: string } => {
+    const target = baseControllers[model];
+    return target ? target._getRelationTargets() : {};
+  };
   Object.keys(baseControllers).forEach((model) => {
     const hooked = wrapControllerWithHooks(
       baseControllers[model],
@@ -21,7 +24,9 @@ const buildExtendedClient = (
     );
     wrapped[model] = wrapControllerWithResult(
       hooked,
-      resolveResultFields(extensions, model),
+      model,
+      extensions,
+      relationTargets,
     );
   });
   const core: ExtendedClientCore = {

--- a/src/util/extends/result/prepareResultTree.ts
+++ b/src/util/extends/result/prepareResultTree.ts
@@ -1,0 +1,64 @@
+import type { ResultFieldRecord } from "../../../types/extendsTypes";
+import { isRecordValue } from "./isRecordValue";
+import { prepareResultArgs, type ResultPlan } from "./prepareResultArgs";
+
+type ResultTreeContext = {
+  fieldsFor: (model: string) => ResultFieldRecord;
+  relationTargets: (model: string) => { [relationName: string]: string };
+};
+
+type ResultTreeNode = {
+  fields: ResultFieldRecord;
+  plan: ResultPlan;
+  children: { [key: string]: ResultTreeNode };
+};
+
+type PreparedResultTree = { args: any; node: ResultTreeNode };
+
+const isTrivialNode = (node: ResultTreeNode): boolean =>
+  node.plan.kind === "all" &&
+  Object.keys(node.fields).length === 0 &&
+  Object.keys(node.children).length === 0;
+
+const prepareResultTree = (
+  model: string,
+  args: any,
+  ctx: ResultTreeContext,
+): PreparedResultTree => {
+  const fields = ctx.fieldsFor(model);
+  const prepared = prepareResultArgs(args, fields);
+  const targets = ctx.relationTargets(model);
+  const children: { [key: string]: ResultTreeNode } = {};
+  let nextArgs = prepared.args;
+
+  const visitEntry = (
+    adjusted: Record<string, unknown>,
+    key: string,
+    value: unknown,
+  ) => {
+    const target = targets[key];
+    if (!target) return;
+    if (value !== true && !isRecordValue(value)) return;
+    const sub = prepareResultTree(target, value === true ? {} : value, ctx);
+    if (value !== true) adjusted[key] = sub.args;
+    if (!isTrivialNode(sub.node)) children[key] = sub.node;
+  };
+
+  const adjustContainer = (container: "include" | "select") => {
+    const source: unknown = nextArgs?.[container];
+    if (!isRecordValue(source)) return;
+    const adjusted: Record<string, unknown> = { ...source };
+    Object.keys(source).forEach((key) => {
+      visitEntry(adjusted, key, source[key]);
+    });
+    nextArgs = { ...nextArgs, [container]: adjusted };
+  };
+
+  adjustContainer("include");
+  adjustContainer("select");
+
+  return { args: nextArgs, node: { fields, plan: prepared.plan, children } };
+};
+
+export { prepareResultTree };
+export type { PreparedResultTree, ResultTreeContext, ResultTreeNode };

--- a/src/util/extends/result/resultOperations.ts
+++ b/src/util/extends/result/resultOperations.ts
@@ -3,7 +3,6 @@ import type {
   CreateData,
   CreateManyAndReturnData,
 } from "../../../types/createTypes";
-import type { ResultFieldRecord } from "../../../types/extendsTypes";
 import type {
   DeleteSingleData,
   FindData,
@@ -12,18 +11,19 @@ import type {
   UpdateSingleData,
   UpsertSingleData,
 } from "../../../types/findTypes";
-import { prepareResultArgs } from "./prepareResultArgs";
-import { transformResult } from "./transformResult";
+import { prepareResultTree, type ResultTreeContext } from "./prepareResultTree";
+import { transformResultTree } from "./transformResultTree";
 
 const buildResultOperations = (
   controller: GassmaController,
-  fields: ResultFieldRecord,
+  model: string,
+  ctx: ResultTreeContext,
 ) => {
   const wrapped =
     <A, R>(execute: (args: A) => R) =>
     (args: A): R => {
-      const prepared = prepareResultArgs(args, fields);
-      return transformResult(execute(prepared.args), fields, prepared.plan);
+      const prepared = prepareResultTree(model, args, ctx);
+      return transformResultTree(execute(prepared.args), prepared.node);
     };
 
   return {

--- a/src/util/extends/result/transformResult.ts
+++ b/src/util/extends/result/transformResult.ts
@@ -53,4 +53,4 @@ const transformResult = (
   return raw;
 };
 
-export { transformResult };
+export { shapeRecord, transformResult };

--- a/src/util/extends/result/transformResultTree.ts
+++ b/src/util/extends/result/transformResultTree.ts
@@ -1,0 +1,19 @@
+import { hasOwnKey } from "./hasOwnKey";
+import { isRecordValue } from "./isRecordValue";
+import type { ResultTreeNode } from "./prepareResultTree";
+import { shapeRecord } from "./transformResult";
+
+const transformResultTree = (raw: any, node: ResultTreeNode): any => {
+  if (Array.isArray(raw)) {
+    return raw.map((record) => transformResultTree(record, node));
+  }
+  if (!isRecordValue(raw)) return raw;
+  const shaped = shapeRecord(raw, node.fields, node.plan);
+  Object.keys(node.children).forEach((key) => {
+    if (!hasOwnKey(shaped, key)) return;
+    shaped[key] = transformResultTree(shaped[key], node.children[key]);
+  });
+  return shaped;
+};
+
+export { transformResultTree };

--- a/src/util/extends/result/wrapControllerWithResult.ts
+++ b/src/util/extends/result/wrapControllerWithResult.ts
@@ -1,16 +1,47 @@
 import type { GassmaController } from "../../../gassmaController";
-import type { ResultFieldRecord } from "../../../types/extendsTypes";
+import type {
+  GassmaExtension,
+  ResultFieldRecord,
+} from "../../../types/extendsTypes";
+import type { ResultTreeContext } from "./prepareResultTree";
+import { resolveResultFields } from "./resolveResultFields";
 import {
   buildResultOperations,
   type ResultOperations,
 } from "./resultOperations";
 
+const hasResultConfig = (extensions: GassmaExtension[]): boolean =>
+  extensions.some(
+    (extension) =>
+      extension.result !== undefined &&
+      Object.keys(extension.result).length > 0,
+  );
+
+const buildFieldsResolver = (
+  extensions: GassmaExtension[],
+): ResultTreeContext["fieldsFor"] => {
+  const cache = new Map<string, ResultFieldRecord>();
+  return (model) => {
+    const cached = cache.get(model);
+    if (cached) return cached;
+    const resolved = resolveResultFields(extensions, model);
+    cache.set(model, resolved);
+    return resolved;
+  };
+};
+
 const wrapControllerWithResult = (
   controller: GassmaController,
-  fields: ResultFieldRecord,
+  model: string,
+  extensions: GassmaExtension[],
+  relationTargets: ResultTreeContext["relationTargets"],
 ): GassmaController => {
-  if (Object.keys(fields).length === 0) return controller;
-  const operations = buildResultOperations(controller, fields);
+  if (!hasResultConfig(extensions)) return controller;
+  const ctx: ResultTreeContext = {
+    fieldsFor: buildFieldsResolver(extensions),
+    relationTargets,
+  };
+  const operations = buildResultOperations(controller, model, ctx);
   const operationNames = new Set<string>(Object.keys(operations));
   const isResultOperation = (
     prop: string | symbol,


### PR DESCRIPTION
## 概要

`$extends({ result })` の算出フィールドを、**結果ツリーの全階層(nested include の結果)にも付与**します(Tier2 = Prisma 完全準拠)。Tier1 はトップレベルのみでしたが、include した関連・深いネストにもそのモデルの算出フィールドが乗ります。

## 実装(ラッパー層のみ・リレーション解決経路は不変)

案A(ラッパー層でのツリー後処理)を採用。core の resolveInclude/resolvers は一切触りません。

- **`prepareResultTree`**: args の include/select 構造を再帰的に辿り、各リレーションキーを対象モデルに解決 → 各階層で `prepareResultArgs`(needs 注入)を適用し、`{fields, plan, children}` ツリーを構築。trivial ノードは枝刈り
- **`transformResultTree`**: 各階層で `shapeRecord`(compute 適用 + select/omit 整形)→ children キーへ再帰
- **`_getRelationTargets`**(GassmaController 内部アクセサ・realm 安全): `relationContext.relations` から `{relationName: to}` を返す。`buildExtendedClient` が baseControllers を閉包した `relationTargets(model)` を作り全階層から到達

Tier1 helper(`prepareResultArgs`/`applyResultComputation`/`shapeRecord`/`resolveResultFields`)を各階層でそのまま再利用しています。

## 適用範囲

- include した oneToMany / manyToOne / oneToOne / manyToMany の nested レコード、**深いネスト(include の中の include)**、select 内リレーションにも付与
- 各階層で **needs 確保・select/omit 連携・`$allModels`** が効く
- 対象操作は Tier1 と同じ9つ(find*/create/createManyAndReturn/update/updateManyAndReturn/upsert/delete)。count/aggregate/groupBy 等は不変
- **トップレベルの Tier1 挙動・既存全テストは不変**

## テスト

`src/__test__/util/extends/result/resultExtendsNested.test.ts`(8件: oneToMany/manyToOne include、深いネスト、nested select+needs、nested omit+needs、select 内リレーション、`$allModels` nested、update+include 書き込み系)。Tier1 の「nested に付かない」境界テストは Tier2 仕様(付く)へ反転。テスト用に Comments シート + Posts.comments/Comments.post リレーションを追加。

- `npx jest`: **136 suites / 1679 tests 全 pass**
- `npx tsc --noEmit`: clean / `biome check`: clean / `npm run build`(webpack): 成功

## cli 追随(後続・Opus 4.8 max-effort で実装予定)

型生成は結果型再帰(FindResult/IncludeMap)に result 拡張 R を1本通し、**各 include 階層で `ComputedOf<その階層のモデル, R>` を交差**する必要があります(モデル解決は `Relations[M][K]["to"]`、select/omit/`$allModels`/チェーンの扱いは本 PR のランタイム contract に一致)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)