### PR TITLE
refactor: remove dead GassmaTargetSheetNotFoundError and applyCursor take parameter

### DIFF
--- a/src/__test__/util/find/findUtil/applyCursor.test.ts
+++ b/src/__test__/util/find/findUtil/applyCursor.test.ts
@@ -9,42 +9,13 @@ const data = [
 ];
 
 describe("applyCursor", () => {
-  test("should return records from cursor to end with positive take", () => {
-    const result = applyCursor(data, { id: 2 }, 3);
-    expect(result).toEqual([
-      { id: 2, name: "Bob" },
-      { id: 3, name: "Charlie" },
-      { id: 4, name: "David" },
-      { id: 5, name: "Eve" },
-    ]);
-  });
-
-  test("should return records from start to cursor with negative take", () => {
-    const result = applyCursor(data, { id: 4 }, -3);
-    expect(result).toEqual([
-      { id: 1, name: "Alice" },
-      { id: 2, name: "Bob" },
-      { id: 3, name: "Charlie" },
-      { id: 4, name: "David" },
-    ]);
-  });
-
   test("should return empty array when cursor not found", () => {
-    const result = applyCursor(data, { id: 99 }, 3);
+    const result = applyCursor(data, { id: 99 });
     expect(result).toEqual([]);
   });
 
   test("should return records from cursor to end when take is null", () => {
-    const result = applyCursor(data, { id: 3 }, null);
-    expect(result).toEqual([
-      { id: 3, name: "Charlie" },
-      { id: 4, name: "David" },
-      { id: 5, name: "Eve" },
-    ]);
-  });
-
-  test("should return records from cursor to end when take is undefined", () => {
-    const result = applyCursor(data, { id: 3 }, undefined);
+    const result = applyCursor(data, { id: 3 });
     expect(result).toEqual([
       { id: 3, name: "Charlie" },
       { id: 4, name: "David" },
@@ -53,7 +24,7 @@ describe("applyCursor", () => {
   });
 
   test("should match cursor with multiple keys", () => {
-    const result = applyCursor(data, { id: 3, name: "Charlie" }, 2);
+    const result = applyCursor(data, { id: 3, name: "Charlie" });
     expect(result).toEqual([
       { id: 3, name: "Charlie" },
       { id: 4, name: "David" },
@@ -62,7 +33,7 @@ describe("applyCursor", () => {
   });
 
   test("should return empty array when cursor keys partially match", () => {
-    const result = applyCursor(data, { id: 3, name: "Alice" }, 2);
+    const result = applyCursor(data, { id: 3, name: "Alice" });
     expect(result).toEqual([]);
   });
 
@@ -72,11 +43,9 @@ describe("applyCursor", () => {
       { id: 2, createdAt: new Date("2026-07-19T12:00:00.000Z") },
       { id: 3, createdAt: new Date("2026-07-20T15:45:00.000Z") },
     ];
-    const result = applyCursor(
-      dateData,
-      { createdAt: new Date("2026-07-19T12:00:00.000Z") },
-      null,
-    );
+    const result = applyCursor(dateData, {
+      createdAt: new Date("2026-07-19T12:00:00.000Z"),
+    });
     expect(result).toEqual([dateData[1], dateData[2]]);
   });
 
@@ -84,11 +53,9 @@ describe("applyCursor", () => {
     const dateData = [
       { id: 1, createdAt: new Date("2026-07-18T09:30:00.000Z") },
     ];
-    const result = applyCursor(
-      dateData,
-      { createdAt: new Date("2026-07-18T09:30:00.001Z") },
-      null,
-    );
+    const result = applyCursor(dateData, {
+      createdAt: new Date("2026-07-18T09:30:00.001Z"),
+    });
     expect(result).toEqual([]);
   });
 });

--- a/src/errors/relation/relationError.ts
+++ b/src/errors/relation/relationError.ts
@@ -4,12 +4,6 @@ class GassmaRelationNotFoundError extends Error {
   }
 }
 
-class GassmaTargetSheetNotFoundError extends Error {
-  constructor(targetSheetName: string) {
-    super(`Target sheet "${targetSheetName}" is not accessible`);
-  }
-}
-
 class GassmaThroughRequiredError extends Error {
   constructor(relationName: string) {
     super(
@@ -52,7 +46,6 @@ class RelationOnUpdateRestrictError extends Error {
 
 export {
   GassmaRelationNotFoundError,
-  GassmaTargetSheetNotFoundError,
   GassmaThroughRequiredError,
   GassmaIncludeSelectConflictError,
   GassmaRelationDuplicateError,

--- a/src/util/find/findFirst.ts
+++ b/src/util/find/findFirst.ts
@@ -49,7 +49,7 @@ const findFirstFunc = (
 
   const cursor = "cursor" in findData ? findData.cursor : null;
   if (cursor) {
-    findDataDictArray = applyCursor(findDataDictArray, cursor, null);
+    findDataDictArray = applyCursor(findDataDictArray, cursor);
   }
 
   if (distinct) {

--- a/src/util/find/findFirstWithRelationOrderBy.ts
+++ b/src/util/find/findFirstWithRelationOrderBy.ts
@@ -38,7 +38,7 @@ const findFirstWithRelationOrderBy = (
   const directed = applyFindFirstTake(sorted, take);
 
   const cursor = "cursor" in findData ? findData.cursor : null;
-  const cursored = cursor ? applyCursor(directed, cursor, null) : directed;
+  const cursored = cursor ? applyCursor(directed, cursor) : directed;
 
   const distincted = distinct ? applyDistinct(cursored, distinct) : cursored;
 

--- a/src/util/find/findUtil/applyCursor.ts
+++ b/src/util/find/findUtil/applyCursor.ts
@@ -3,7 +3,6 @@ import { isValueEqual } from "../../other/isValueEqual";
 const applyCursor = (
   records: Record<string, unknown>[],
   cursor: Record<string, unknown>,
-  take: number | null | undefined,
 ): Record<string, unknown>[] => {
   const cursorEntries = Object.entries(cursor);
   const index = records.findIndex((record) =>
@@ -11,9 +10,6 @@ const applyCursor = (
   );
   if (index === -1) return [];
 
-  if (take !== null && take !== undefined && take < 0) {
-    return records.slice(0, index + 1);
-  }
   return records.slice(index);
 };
 

--- a/src/util/find/findUtil/applyCursorDistinctSkipTake.ts
+++ b/src/util/find/findUtil/applyCursorDistinctSkipTake.ts
@@ -14,7 +14,7 @@ const applyCursorDistinctSkipTake = (
 
   let result = backward ? [...records].reverse() : records;
 
-  if (cursor) result = applyCursor(result, cursor, null);
+  if (cursor) result = applyCursor(result, cursor);
   if (distinct) result = applyDistinct(result, distinct);
 
   result = applySkipTake(result, skip, backward ? -take : take);


### PR DESCRIPTION
## 概要

dead code 2件の掃除です(ユーザー承認済み。「実装漏れで到達不能」ではなく「後続実装に置き換えられた双子」であることを事前調査で確認済み)。

## 件1: GassmaTargetSheetNotFoundError 削除

リレーション初回実装(c3c9326)以来 **throw も new もゼロ**(repo 全体 grep で自ファイルの定義+export 列挙の2ヒットのみ)。想定していた「リレーション先シート不在」は検証時の `RelationSheetNotFoundError` が全経路(relations キー / to / through.sheet)をガード済み。#160 でも dead code として公開対象から除外済みのため、verify:bundle への影響なし(公開47件不変)。

## 件2: applyCursor の take 引数削除

#151 で take 負数の反転が `applyCursorDistinctSkipTake`(cursor 適用**前**に配列反転)へ移行して以来、全3呼び出し元が null 渡し = 内部の take 分岐は production 到達不能。引数・分岐・専用テスト3件を削除。**反転セマンティクスは Prisma 実測ピンの上位スイート(findFirstTakeSkipDistinct / findManyDistinctOrder 等)が無変更のまま全 green** で担保。

## テスト

1679 → **1676**(-3 = 削除した take 分岐テストのみ)。tsc / lint / format / build / verify:bundle 全 green。-57 行 / +13 行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX