### PR TITLE
chore: drop Tier2 labels from result extension test names

### DIFF
--- a/src/__test__/util/extends/result/resultExtendsComposition.test.ts
+++ b/src/__test__/util/extends/result/resultExtendsComposition.test.ts
@@ -191,7 +191,7 @@ describe("$extends result: query 併用とマージ", () => {
   });
 });
 
-describe("$extends result: nested への伝播（Tier2）", () => {
+describe("$extends result: nested への伝播", () => {
   const fullNameExtension = {
     result: {
       Users: {

--- a/src/__test__/util/extends/result/resultExtendsNested.test.ts
+++ b/src/__test__/util/extends/result/resultExtendsNested.test.ts
@@ -25,7 +25,7 @@ const nestedExtension = {
   },
 };
 
-describe("$extends result: nested include (Tier2)", () => {
+describe("$extends result: nested include", () => {
   test("oneToMany include の各 nested レコードに算出フィールドが付く", () => {
     const client = buildTestClient({ relations: true });
     const extended = client.$extends(nestedExtension);


### PR DESCRIPTION
## 概要

result 拡張のテスト describe から `Tier2` ラベルを除去します。Tier1/Tier2 は**実装をどう段階分けして進めたかという戦略ラベルで、コード上の意味を持たない**ため、振る舞いを直接説明する文言にします。

## 変更

- `resultExtendsComposition.test.ts`: `"$extends result: nested への伝播（Tier2）"` → `"$extends result: nested への伝播"`
- `resultExtendsNested.test.ts`: `"$extends result: nested include (Tier2)"` → `"$extends result: nested include"`

コメント/describe のみの変更。`npx jest src/__test__/util/extends/result` 44 tests 全 pass、挙動不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)