### PR TITLE
docs: drop the hand-written version sections from the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,3 @@ function myFunction(){
 ## Official Reference
 
 https://akahoshi1421.github.io/gassma-reference/en
-
-## version
-
-7

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -84,7 +84,3 @@ function myFunction(){
 ## 公式リファレンス
 
 https://akahoshi1421.github.io/gassma-reference/
-
-## バージョン
-
-7


### PR DESCRIPTION
## 概要

README.md の `## version` 節と docs/README.ja.md の `## バージョン` 節を削除し、**バージョンの正を package.json の1箇所に集約**します。

## 背景

GAS ライブラリのバージョンが3箇所(package.json / README 英 / README 日)に手書きされており、bump 漏れでドリフトするリスクがありました。当初は3点一致を CI でチェックする案でしたが、**重複そのものを消す方がシンプル**という判断です。

## 影響がないことの確認

- `gassma bootstrap` のバージョン実行時解決(GitHub raw 経路)は **package.json を読む**ので無関係
- bootstrap のオフライン時案内文言も既に package.json を指しており README 非依存
- 人間向けにも、GAS の「ライブラリを追加」ダイアログが選択可能バージョンを表示するため README の数字は必須ではない
- gassma-reference 側に README のバージョン節への言及なし(確認済み)

## 残る運用

「GAS ライブラリの新バージョン作成時に package.json の `version` を bump する」は引き続き必要です(bootstrap の GitHub raw フォールバックの生命線)。bump 箇所が 3→1 になったぶん忘れにくくなります。リリース手順に明記します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja