### PR TITLE
refactor: route all sheet writes through an injectable SheetWriter

### DIFF
--- a/src/__test__/util/write/sheetWriter.test.ts
+++ b/src/__test__/util/write/sheetWriter.test.ts
@@ -1,0 +1,205 @@
+import {
+  immediateSheetWriter,
+  resolveWriter,
+} from "../../../util/write/sheetWriter";
+import type { SheetWriter } from "../../../util/write/sheetWriter";
+import { createFunc } from "../../../util/create/create";
+import { createManyFunc } from "../../../util/create/createManyFunc";
+import { updateManyFunc } from "../../../util/update/updateMany";
+import { deleteManyFunc } from "../../../util/delete/deleteMany";
+import { resolveNestedUpdate } from "../../../util/update/nestedWrite/resolveNestedUpdate";
+import { getMutableMockControllerUtil } from "../../consts/mockControllerUtil";
+
+type WriterCall = { method: string; args: unknown[] };
+
+const createFakeWriter = (): { writer: SheetWriter; calls: WriterCall[] } => {
+  const calls: WriterCall[] = [];
+  const writer: SheetWriter = {
+    appendRows: (sheet, startColumnNumber, columnLength, rows) => {
+      calls.push({
+        method: "appendRows",
+        args: [sheet, startColumnNumber, columnLength, rows],
+      });
+    },
+    updateRow: (sheet, rowNumber, startColumnNumber, columnLength, row) => {
+      calls.push({
+        method: "updateRow",
+        args: [sheet, rowNumber, startColumnNumber, columnLength, row],
+      });
+    },
+    deleteRow: (sheet, rowNumber) => {
+      calls.push({ method: "deleteRow", args: [sheet, rowNumber] });
+    },
+  };
+  return { writer, calls };
+};
+
+const createSpySheet = () => {
+  const setValues = jest.fn();
+  const getRange = jest.fn(() => ({ setValues }));
+  const sheet = {
+    getLastRow: jest.fn(() => 9),
+    getRange,
+    deleteRow: jest.fn(),
+  } as any;
+  return { sheet, getRange, setValues };
+};
+
+describe("immediateSheetWriter", () => {
+  test("appendRows は getLastRow()+1 の位置に setValues する", () => {
+    const { sheet, getRange, setValues } = createSpySheet();
+    const rows = [
+      ["a", 1],
+      ["b", 2],
+    ];
+
+    immediateSheetWriter.appendRows(sheet, 3, 2, rows);
+
+    expect(sheet.getLastRow).toHaveBeenCalledTimes(1);
+    expect(getRange).toHaveBeenCalledWith(10, 3, 2, 2);
+    expect(setValues).toHaveBeenCalledWith(rows);
+  });
+
+  test("updateRow は指定行の範囲に setValues する", () => {
+    const { sheet, getRange, setValues } = createSpySheet();
+    const row = ["a", 1, "x"];
+
+    immediateSheetWriter.updateRow(sheet, 5, 2, 3, row);
+
+    expect(getRange).toHaveBeenCalledWith(5, 2, 1, 3);
+    expect(setValues).toHaveBeenCalledWith([row]);
+    expect(sheet.getLastRow).not.toHaveBeenCalled();
+  });
+
+  test("deleteRow は sheet.deleteRow を呼ぶ", () => {
+    const { sheet, getRange } = createSpySheet();
+
+    immediateSheetWriter.deleteRow(sheet, 7);
+
+    expect(sheet.deleteRow).toHaveBeenCalledWith(7);
+    expect(getRange).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveWriter", () => {
+  test("未指定なら immediateSheetWriter を返す", () => {
+    expect(resolveWriter(undefined)).toBe(immediateSheetWriter);
+  });
+
+  test("指定されたライタをそのまま返す", () => {
+    const { writer } = createFakeWriter();
+    expect(resolveWriter(writer)).toBe(writer);
+  });
+});
+
+describe("ライタ差し替え時はシートへ直接書き込まれない", () => {
+  test("createFunc の書き込みは注入ライタに届く", () => {
+    const util = getMutableMockControllerUtil();
+    const { writer, calls } = createFakeWriter();
+    util.writer = writer;
+    const before = util.sheet._getMockData();
+
+    createFunc(util, { data: { 名前: "Ivy", 年齢: 20 } });
+
+    expect(calls).toEqual([
+      {
+        method: "appendRows",
+        args: [util.sheet, 1, 5, [["Ivy", 20, "", "", ""]]],
+      },
+    ]);
+    expect(util.sheet._getMockData()).toEqual(before);
+  });
+
+  test("createManyFunc の書き込みは注入ライタに届く", () => {
+    const util = getMutableMockControllerUtil();
+    const { writer, calls } = createFakeWriter();
+    util.writer = writer;
+    const before = util.sheet._getMockData();
+
+    createManyFunc(util, {
+      data: [{ 名前: "Ivy" }, { 名前: "Jack" }],
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "appendRows",
+        args: [
+          util.sheet,
+          1,
+          5,
+          [
+            ["Ivy", "", "", "", ""],
+            ["Jack", "", "", "", ""],
+          ],
+        ],
+      },
+    ]);
+    expect(util.sheet._getMockData()).toEqual(before);
+  });
+
+  test("updateManyFunc の書き込みは注入ライタに届く", () => {
+    const util = getMutableMockControllerUtil();
+    const { writer, calls } = createFakeWriter();
+    util.writer = writer;
+    const before = util.sheet._getMockData();
+
+    updateManyFunc(util, { where: { 名前: "Alice" }, data: { 年齢: 29 } });
+
+    expect(calls).toEqual([
+      {
+        method: "updateRow",
+        args: [
+          util.sheet,
+          2,
+          1,
+          5,
+          ["Alice", 29, "Tokyo", "100-0001", "Engineer"],
+        ],
+      },
+    ]);
+    expect(util.sheet._getMockData()).toEqual(before);
+  });
+
+  test("resolveNestedUpdate の書き込みは注入ライタに届く", () => {
+    const util = getMutableMockControllerUtil();
+    const { writer, calls } = createFakeWriter();
+    util.writer = writer;
+    const before = util.sheet._getMockData();
+
+    resolveNestedUpdate(
+      util,
+      { where: { 名前: "Bob" }, data: { 住所: "Nagoya" } },
+      undefined,
+    );
+
+    expect(calls).toEqual([
+      {
+        method: "updateRow",
+        args: [
+          util.sheet,
+          3,
+          1,
+          5,
+          ["Bob", 35, "Nagoya", "550-0001", "Designer"],
+        ],
+      },
+    ]);
+    expect(util.sheet._getMockData()).toEqual(before);
+  });
+
+  test("deleteManyFunc の削除は注入ライタに届く", () => {
+    const util = getMutableMockControllerUtil();
+    const { writer, calls } = createFakeWriter();
+    util.writer = writer;
+    const before = util.sheet._getMockData();
+
+    deleteManyFunc(util, { where: { 住所: "Kyoto" } });
+
+    expect(calls).toEqual([
+      { method: "deleteRow", args: [util.sheet, 9] },
+      { method: "deleteRow", args: [util.sheet, 5] },
+    ]);
+    expect(util.sheet._getMockData()).toEqual(before);
+    expect(util.sheet.deleteRow).not.toHaveBeenCalled();
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -71,6 +71,8 @@ import { upsertFunc } from "./util/upsert/upsert";
 import { separateRelationOrderBy } from "./util/find/findUtil/separateRelationOrderBy";
 import { findManyWithRelationOrderBy } from "./util/find/findManyWithRelationOrderBy";
 import { findFirstWithRelationOrderBy } from "./util/find/findFirstWithRelationOrderBy";
+import type { SheetWriter } from "./util/write/sheetWriter";
+import { immediateSheetWriter } from "./util/write/sheetWriter";
 
 class GassmaController {
   private readonly sheet: GoogleAppsScript.Spreadsheet.Sheet;
@@ -87,6 +89,7 @@ class GassmaController {
   private fieldMapping: FieldMapping | null = null;
   private codeName: string | null = null;
   private strictUndefinedChecks: boolean = false;
+  private writer: SheetWriter = immediateSheetWriter;
 
   constructor(sheetName: string, id?: string) {
     const spreadSheet = id
@@ -238,6 +241,7 @@ class GassmaController {
       startRowNumber: this.startRowNumber,
       startColumnNumber: this.startColumnNumber,
       endColumnNumber: this.endColumnNumber,
+      writer: this.writer,
     };
     if (this.fieldMapping) {
       util.fieldMapping = this.fieldMapping;

--- a/src/types/gassmaControllerUtilType.ts
+++ b/src/types/gassmaControllerUtilType.ts
@@ -1,4 +1,5 @@
 import type { FieldMapping } from "../util/map/mapFields";
+import type { SheetWriter } from "../util/write/sheetWriter";
 
 type GassmaControllerUtil = {
   sheet: GoogleAppsScript.Spreadsheet.Sheet;
@@ -6,6 +7,7 @@ type GassmaControllerUtil = {
   startColumnNumber: number;
   endColumnNumber: number;
   fieldMapping?: FieldMapping;
+  writer?: SheetWriter;
 };
 
 export type { GassmaControllerUtil };

--- a/src/util/create/create.ts
+++ b/src/util/create/create.ts
@@ -4,6 +4,7 @@ import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType"
 import { getTitle } from "../core/getTitle";
 import { getWantUpdateIndex } from "../core/getWantUpdateIndex";
 import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
+import { resolveWriter } from "../write/sheetWriter";
 
 const createFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
@@ -28,12 +29,14 @@ const createFunc = (
     return data[titles[index]];
   });
 
-  const rowNumber = sheet.getLastRow() + 1;
   const ColumnLength = endColumnNumber - startColumnNumber + 1;
 
-  sheet
-    .getRange(rowNumber, startColumnNumber, 1, ColumnLength)
-    .setValues([escapeFormulaInjectionRow(newData)]);
+  resolveWriter(gassmaControllerUtil.writer).appendRows(
+    sheet,
+    startColumnNumber,
+    ColumnLength,
+    [escapeFormulaInjectionRow(newData)],
+  );
 
   return createReturn;
 };

--- a/src/util/create/createManyFunc.ts
+++ b/src/util/create/createManyFunc.ts
@@ -7,6 +7,7 @@ import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType"
 import { getTitle } from "../core/getTitle";
 import { getWantUpdateIndex } from "../core/getWantUpdateIndex";
 import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
+import { resolveWriter } from "../write/sheetWriter";
 
 function createManyFunc(
   gassmaControllerUtil: GassmaControllerUtil,
@@ -45,13 +46,14 @@ function createManyFunc(
     });
   });
 
-  const rowNumber = sheet.getLastRow() + 1;
   const ColumnLength = endColumnNumber - startColumnNumber + 1;
-  const rowLength = newData.length;
 
-  sheet
-    .getRange(rowNumber, startColumnNumber, rowLength, ColumnLength)
-    .setValues(newData.map(escapeFormulaInjectionRow));
+  resolveWriter(gassmaControllerUtil.writer).appendRows(
+    sheet,
+    startColumnNumber,
+    ColumnLength,
+    newData.map(escapeFormulaInjectionRow),
+  );
 
   if (withReturn) {
     return data.map((row) =>

--- a/src/util/delete/deleteMany.ts
+++ b/src/util/delete/deleteMany.ts
@@ -2,6 +2,7 @@ import type { DeleteData, DeleteManyReturn } from "../../types/findTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import { GassmaLimitNegativeError } from "../../errors/find/findError";
 import { whereFilter } from "../core/whereFilter";
+import { resolveWriter } from "../write/sheetWriter";
 
 const deleteManyFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
@@ -25,9 +26,10 @@ const deleteManyFunc = (
   // sortDescendingを使って降順にソート
   const sortedData = findedData.sort((a, b) => b.rowNumber - a.rowNumber);
 
+  const writer = resolveWriter(gassmaControllerUtil.writer);
   sortedData.forEach((row) => {
     const actualRowNumber = row.rowNumber + startRowNumber;
-    sheet.deleteRow(actualRowNumber);
+    writer.deleteRow(sheet, actualRowNumber);
   });
 
   return { count: findedDataLength };

--- a/src/util/update/nestedWrite/resolveNestedUpdate.ts
+++ b/src/util/update/nestedWrite/resolveNestedUpdate.ts
@@ -22,6 +22,7 @@ import {
   resolveNumberOperation,
 } from "../resolveNumberOperation";
 import { escapeFormulaInjectionRow } from "../../core/escapeFormulaInjection";
+import { resolveWriter } from "../../write/sheetWriter";
 
 type UpdateInput = {
   where: WhereUse;
@@ -82,13 +83,13 @@ const resolveNestedUpdate = (
     });
 
     const rowNumber = firstRow.rowNumber + startRowNumber;
-    const updateRange = sheet.getRange(
+    resolveWriter(util.writer).updateRow(
+      sheet,
       rowNumber,
       startColumnNumber,
-      1,
       columnLength,
+      escapeFormulaInjectionRow(updatedRow),
     );
-    updateRange.setValues([escapeFormulaInjectionRow(updatedRow)]);
 
     return titles.reduce<Record<string, unknown>>((record, title, index) => {
       record[title] = updatedRow[index];
@@ -127,13 +128,13 @@ const resolveNestedUpdate = (
   });
 
   const rowNumber = firstRow.rowNumber + startRowNumber;
-  const updateRange = sheet.getRange(
+  resolveWriter(util.writer).updateRow(
+    sheet,
     rowNumber,
     startColumnNumber,
-    1,
     columnLength,
+    escapeFormulaInjectionRow(updatedRow),
   );
-  updateRange.setValues([escapeFormulaInjectionRow(updatedRow)]);
 
   const updatedRecord = titles.reduce<Record<string, unknown>>(
     (record, title, index) => {

--- a/src/util/update/updateMany.ts
+++ b/src/util/update/updateMany.ts
@@ -9,6 +9,7 @@ import {
   resolveNumberOperation,
 } from "./resolveNumberOperation";
 import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
+import { resolveWriter } from "../write/sheetWriter";
 
 function updateManyFunc(
   gassmaControllerUtil: GassmaControllerUtil,
@@ -59,13 +60,13 @@ function updateManyFunc(
 
     if (updatedRow.length > 0) {
       const rowNumber = row.rowNumber + startRowNumber;
-      const updateRange = sheet.getRange(
+      resolveWriter(gassmaControllerUtil.writer).updateRow(
+        sheet,
         rowNumber,
         startColumnNumber,
-        1,
         ColumnLength,
+        escapeFormulaInjectionRow(updatedRow),
       );
-      updateRange.setValues([escapeFormulaInjectionRow(updatedRow)]);
     }
 
     return titles.reduce<Record<string, unknown>>((record, title, index) => {

--- a/src/util/write/sheetWriter.ts
+++ b/src/util/write/sheetWriter.ts
@@ -1,0 +1,39 @@
+type SheetWriter = {
+  appendRows(
+    sheet: GoogleAppsScript.Spreadsheet.Sheet,
+    startColumnNumber: number,
+    columnLength: number,
+    rows: unknown[][],
+  ): void;
+  updateRow(
+    sheet: GoogleAppsScript.Spreadsheet.Sheet,
+    rowNumber: number,
+    startColumnNumber: number,
+    columnLength: number,
+    row: unknown[],
+  ): void;
+  deleteRow(sheet: GoogleAppsScript.Spreadsheet.Sheet, rowNumber: number): void;
+};
+
+const immediateSheetWriter: SheetWriter = {
+  appendRows: (sheet, startColumnNumber, columnLength, rows) => {
+    const rowNumber = sheet.getLastRow() + 1;
+    sheet
+      .getRange(rowNumber, startColumnNumber, rows.length, columnLength)
+      .setValues(rows);
+  },
+  updateRow: (sheet, rowNumber, startColumnNumber, columnLength, row) => {
+    sheet
+      .getRange(rowNumber, startColumnNumber, 1, columnLength)
+      .setValues([row]);
+  },
+  deleteRow: (sheet, rowNumber) => {
+    sheet.deleteRow(rowNumber);
+  },
+};
+
+const resolveWriter = (writer: SheetWriter | undefined): SheetWriter =>
+  writer ?? immediateSheetWriter;
+
+export { immediateSheetWriter, resolveWriter };
+export type { SheetWriter };


### PR DESCRIPTION
## 概要

**$transaction 実装(3フェーズ計画)の Phase 1** です(仕様承認済み: rollback 既定 true / maxWait 20s / timeout 60s)。全書き込み経路を差し替え可能な `SheetWriter` interface 経由に寄せる、**挙動完全不変**のリファクタです。

## 全数調査の結果

シート実書き込みは **6箇所・5ファイル**が全数と確定(setValues/appendRow/deleteRow/insertRow/clearContents/setValue/copyTo/getRange で再調査): create / createManyFunc / updateMany / resolveNestedUpdate(2経路)/ deleteMany。**過去の見積もりにあった gassmaController.ts / gassma.ts は読み取りのみで書き込みなし**(実態は想定より整っていた)。upsert・delete 単体・onDelete/onUpdate cascade・nested write は全てこの6箇所へ委譲されています。

## 設計

```ts
type SheetWriter = {
  appendRows(sheet, startColumnNumber, columnLength, rows): void; // getLastRow()+1 を内包
  updateRow(sheet, rowNumber, startColumnNumber, columnLength, row): void;
  deleteRow(sheet, rowNumber): void;
};
```

- `immediateSheetWriter`(既定)は従来と**同一の GAS API 呼び出し列** = 挙動不変の根拠
- 注入は `GassmaControllerUtil` の optional フィールド(fieldMapping と同パターン、グローバル状態なし)。cascade も相手 controller の util を通るため、**Phase 2 は各 controller の writer を差し替えるだけで全経路がバッファ化**されます
- `appendRows` に末尾行計算を内包したのが Phase 2 の要点(バッファ側が仮想末尾行を追跡可能に)
- 公開 API・index.d.ts 不変(verify:bundle 公開47件、diff ゼロ)
- ScriptProperties(autoincrement)は**意図して即時のまま**: 遅延すると並行トランザクションで同一 ID 衝突+read-your-writes が壊れる。rollback してもカウンタが進むのは Prisma/PostgreSQL のシーケンスと同じ挙動

## 挙動不変の証明

- 既存 **1676 テストをアサーション・モック配線とも一切無変更**で全 green(optional 注入のため既存構築箇所の変更ゼロ)
- **実バンドル新旧比較**: 2 realm ハーネスで旧(origin/main)・新の webpack bundle に対し **26 シナリオ**(read 系/create 系/update 系/upsert 両経路/cascade delete/Restrict エラー)を実行し、**出力+全シート最終状態が完全一致**(エラーメッセージまで)
- 新規10テスト: immediate 実装の GAS 呼び出しピン + **差し替え可能性のピン**(fake ライタ注入時に全書き込みが fake へ届きシート不変 = Phase 2 成立性の証明)

1676 → **1686 テスト**、tsc / lint / format / build / verify:bundle 全 green。

## 次フェーズ(スコープ外・確認済みの前提)

- Phase 2(バッファ+$transaction 本体): 読み取り経路(getTitle/getAllData)へのオーバーレイ・deleteMany の降順削除の flush 時維持・全 controller への writer 差し替え setter が必要と特定済み
- Phase 3: rollback(copyTo バックアップ+書き戻し復元+stale マーカー)。**リリースは Phase 3 まで揃ってから**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX