### PR TITLE
feat: add $transaction (interactive transactions, phase 2 of 3)

### DIFF
--- a/src/__test__/util/transaction/transaction.test.ts
+++ b/src/__test__/util/transaction/transaction.test.ts
@@ -1,0 +1,359 @@
+import {
+  GassmaNestedTransactionError,
+  GassmaTransactionLockTimeoutError,
+  GassmaTransactionTimeoutError,
+} from "../../../errors/transaction/transactionError";
+import { buildTxTestEnv, clearGasGlobals } from "./transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+  jest.restoreAllMocks();
+});
+
+describe("$transaction の基本動作", () => {
+  test("fn 正常終了で flush され戻り値が返る", () => {
+    const env = buildTxTestEnv();
+
+    const result = env.client.$transaction((tx) => {
+      tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+      expect(env.users.writes).toEqual([]);
+      return "done";
+    });
+
+    expect(result).toBe("done");
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+      [3, "Carol", 40],
+    ]);
+    expect(env.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fn throw で 1 セルも書かれず lock 解放して rethrow", () => {
+    const env = buildTxTestEnv();
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+
+    expect(env.users.writes).toEqual([]);
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+    ]);
+    expect(env.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  test("tx 終了後の元 client は immediate のまま", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => tx.Users.count({}));
+    const writesBefore = env.users.writes.length;
+    (env.client as any).Users.update({
+      where: { id: 1 },
+      data: { age: 21 },
+    });
+
+    expect(env.users.writes.length).toBe(writesBefore + 1);
+    expect(env.users.snapshot()[1]).toEqual([1, "Alice", 21]);
+  });
+});
+
+describe("$transaction の read-your-writes", () => {
+  test("create → findMany で未 flush の行が見える", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+      const found = tx.Users.findMany({});
+      expect(found).toHaveLength(3);
+      expect(found[2]).toEqual({ id: 3, name: "Carol", age: 40 });
+      expect(env.users.writes).toEqual([]);
+    });
+  });
+
+  test("update → findFirst で未 flush の変更が見える", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.update({ where: { id: 1 }, data: { age: 21 } });
+      expect(tx.Users.findFirst({ where: { id: 1 } })).toEqual({
+        id: 1,
+        name: "Alice",
+        age: 21,
+      });
+      expect(env.users.snapshot()[1]).toEqual([1, "Alice", 20]);
+    });
+  });
+
+  test("delete → count で未 flush の削除が見える", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.delete({ where: { id: 2 } });
+      expect(tx.Users.count({})).toBe(1);
+      expect(env.users.snapshot()).toHaveLength(3);
+    });
+  });
+
+  test("include がオーバーレイ越しに効く", () => {
+    const env = buildTxTestEnv({ relations: true });
+
+    env.client.$transaction((tx) => {
+      tx.Posts.create({ data: { id: 103, authorId: 1, title: "New" } });
+      const found: any[] = tx.Users.findMany({
+        where: { id: 1 },
+        include: { posts: true },
+      });
+      expect(found[0].posts).toHaveLength(2);
+      expect(found[0].posts[1]).toEqual({
+        id: 103,
+        authorId: 1,
+        title: "New",
+      });
+    });
+  });
+});
+
+describe("$transaction の nested write / cascade", () => {
+  test("nested create が tx 内で完結し flush で両シートに反映される", () => {
+    const env = buildTxTestEnv({ relations: true });
+
+    const carol: any = {
+      id: 3,
+      name: "Carol",
+      age: 40,
+      posts: { create: { id: 103, title: "C post" } },
+    };
+
+    env.client.$transaction((tx) => {
+      tx.Users.create({ data: carol });
+      expect(env.users.writes).toEqual([]);
+      expect(env.posts.writes).toEqual([]);
+      expect(tx.Posts.count({})).toBe(3);
+    });
+
+    expect(env.users.snapshot()).toHaveLength(4);
+    expect(env.posts.snapshot()[3]).toEqual([103, 3, "C post"]);
+  });
+
+  test("onDelete Cascade が tx 内で完結する", () => {
+    const env = buildTxTestEnv({ relations: true, cascade: true });
+
+    env.client.$transaction((tx) => {
+      tx.Users.delete({ where: { id: 1 } });
+      expect(tx.Posts.count({})).toBe(1);
+      expect(env.users.writes).toEqual([]);
+      expect(env.posts.writes).toEqual([]);
+    });
+
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [2, "Bob", 30],
+    ]);
+    expect(env.posts.snapshot()).toEqual([
+      ["id", "authorId", "title"],
+      [102, 2, "Post B"],
+    ]);
+  });
+
+  test("onUpdate Cascade が tx 内で完結する", () => {
+    const env = buildTxTestEnv({ relations: true, cascade: true });
+
+    env.client.$transaction((tx) => {
+      tx.Users.update({ where: { id: 1 }, data: { id: 10 } });
+      const post: any = tx.Posts.findFirst({ where: { id: 101 } });
+      expect(post.authorId).toBe(10);
+      expect(env.posts.writes).toEqual([]);
+    });
+
+    expect(env.posts.snapshot()[1]).toEqual([101, 10, "Post A"]);
+  });
+});
+
+describe("$transaction の autoincrement", () => {
+  test("tx 内で即時採番され戻り値に入る", () => {
+    const env = buildTxTestEnv({ autoincrement: true });
+    const key = "gassma_autoincrement_tx-test_Users_id";
+
+    env.client.$transaction((tx) => {
+      const created: any = tx.Users.create({
+        data: { name: "Carol", age: 40 },
+      });
+      expect(created.id).toBe(1);
+      expect(env.propsStore[key]).toBe("1");
+      expect(env.users.writes).toEqual([]);
+    });
+
+    expect(env.users.snapshot()[3]).toEqual([1, "Carol", 40]);
+  });
+
+  test("fn throw でもシーケンスは巻き戻らない", () => {
+    const env = buildTxTestEnv({ autoincrement: true });
+    const key = "gassma_autoincrement_tx-test_Users_id";
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.create({ data: { name: "Carol", age: 40 } });
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+
+    expect(env.propsStore[key]).toBe("1");
+    expect(env.users.snapshot()).toHaveLength(3);
+  });
+});
+
+describe("$transaction のエラー", () => {
+  test("maxWait 超過で GassmaTransactionLockTimeoutError", () => {
+    const env = buildTxTestEnv({ waitLockError: true });
+    const fn = jest.fn();
+
+    expect(() => env.client.$transaction(fn, { maxWait: 500 })).toThrow(
+      GassmaTransactionLockTimeoutError,
+    );
+    expect(() => env.client.$transaction(fn, { maxWait: 500 })).toThrow(
+      "Transaction API error: Unable to start a transaction in the given time.",
+    );
+    expect(fn).not.toHaveBeenCalled();
+    expect(env.waitLock).toHaveBeenCalledWith(500);
+    expect(env.releaseLock).not.toHaveBeenCalled();
+  });
+
+  test("maxWait / timeout の既定値は 20000 / 60000", () => {
+    const env = buildTxTestEnv();
+    let now = 0;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+
+    env.client.$transaction((tx) => {
+      now = 59999;
+      expect(() => tx.Users.count({})).not.toThrow();
+    });
+
+    expect(env.waitLock).toHaveBeenCalledWith(20000);
+  });
+
+  test("timeout 超過後の tx メソッドは GassmaTransactionTimeoutError", () => {
+    const env = buildTxTestEnv();
+    let now = 0;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+    let queryError: unknown = null;
+
+    expect(() =>
+      env.client.$transaction(
+        (tx) => {
+          tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+          now = 1500;
+          try {
+            tx.Users.findMany({});
+          } catch (e) {
+            queryError = e;
+            throw e;
+          }
+        },
+        { timeout: 1000 },
+      ),
+    ).toThrow(GassmaTransactionTimeoutError);
+
+    expect(queryError).toBeInstanceOf(GassmaTransactionTimeoutError);
+    expect(String((queryError as Error).message)).toBe(
+      "Transaction API error: A query cannot be executed on an expired transaction. The timeout for this transaction was 1000 ms, however 1500 ms passed since the start of the transaction. Consider increasing the transaction timeout or doing less work in the transaction.",
+    );
+    expect(env.users.writes).toEqual([]);
+    expect(env.users.snapshot()).toHaveLength(3);
+    expect(env.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  test("flush 開始前の timeout 超過ではクリーンに中断される", () => {
+    const env = buildTxTestEnv();
+    let now = 0;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+
+    expect(() =>
+      env.client.$transaction(
+        (tx) => {
+          tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+          now = 2000;
+        },
+        { timeout: 1000 },
+      ),
+    ).toThrow(
+      "Transaction API error: A commit cannot be executed on an expired transaction. The timeout for this transaction was 1000 ms, however 2000 ms passed since the start of the transaction. Consider increasing the transaction timeout or doing less work in the transaction.",
+    );
+
+    expect(env.users.writes).toEqual([]);
+    expect(env.users.snapshot()).toHaveLength(3);
+    expect(env.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  test("tx 内で元 client の $transaction を呼ぶと GassmaNestedTransactionError", () => {
+    const env = buildTxTestEnv();
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.count({});
+        env.client.$transaction(() => null);
+      }),
+    ).toThrow(GassmaNestedTransactionError);
+
+    expect(env.users.writes).toEqual([]);
+  });
+
+  test("tx client の $transaction 呼び出しも GassmaNestedTransactionError", () => {
+    const env = buildTxTestEnv();
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        (tx as any).$transaction(() => null);
+      }),
+    ).toThrow(GassmaNestedTransactionError);
+  });
+
+  test("エラー後は再び $transaction を開始できる", () => {
+    const env = buildTxTestEnv();
+
+    expect(() =>
+      env.client.$transaction(() => {
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+
+    const result = env.client.$transaction((tx) => {
+      tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+      return tx.Users.count({});
+    });
+
+    expect(result).toBe(3);
+    expect(env.users.snapshot()).toHaveLength(4);
+  });
+});
+
+describe("$transaction と $extends", () => {
+  test("tx client の $extends 経由でもバッファされる", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      const extended = tx.$extends({
+        result: {
+          Users: {
+            label: {
+              needs: { name: true },
+              compute: (record: any) => `user:${record.name}`,
+            },
+          },
+        },
+      });
+      extended.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+      expect(env.users.writes).toEqual([]);
+      const found: any = extended.Users.findFirst({ where: { id: 3 } });
+      expect(found.label).toBe("user:Carol");
+    });
+
+    expect(env.users.snapshot()).toHaveLength(4);
+  });
+});

--- a/src/__test__/util/transaction/transactionBuffer.test.ts
+++ b/src/__test__/util/transaction/transactionBuffer.test.ts
@@ -1,0 +1,172 @@
+import { getAllData } from "../../../util/core/getAllData";
+import { getTitle } from "../../../util/core/getTitle";
+import { createTransactionBuffer } from "../../../util/transaction/transactionBuffer";
+import type { GassmaControllerUtil } from "../../../types/gassmaControllerUtilType";
+import { makeLoggedSheet } from "./transactionTestClient";
+
+const initialUsers = [
+  ["id", "name", "age"],
+  [1, "Alice", 20],
+  [2, "Bob", 30],
+];
+
+describe("createTransactionBuffer の書き込みバッファ", () => {
+  test("appendRows は実シートに書かずバッファされる", () => {
+    const { sheet, snapshot, writes } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.appendRows(sheet, 1, 3, [[3, "Carol", 40]]);
+
+    expect(writes).toEqual([]);
+    expect(snapshot()).toEqual(initialUsers);
+  });
+
+  test("updateRow / deleteRow も実シートに書かない", () => {
+    const { sheet, snapshot, writes } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.updateRow(sheet, 2, 1, 3, [1, "Alice", 21]);
+    buffer.writer.deleteRow(sheet, 3);
+
+    expect(writes).toEqual([]);
+    expect(snapshot()).toEqual(initialUsers);
+  });
+});
+
+describe("createTransactionBuffer の読み取りオーバーレイ", () => {
+  test("append した行が読み取りに見える", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.appendRows(sheet, 1, 3, [[3, "Carol", 40]]);
+
+    expect(buffer.reader.getLastRow(sheet)).toBe(4);
+    expect(buffer.reader.getRangeValues(sheet, 4, 1, 1, 3)).toEqual([
+      [3, "Carol", 40],
+    ]);
+  });
+
+  test("updateRow の変更が読み取りに見える", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.updateRow(sheet, 2, 1, 3, [1, "Alice", 21]);
+
+    expect(buffer.reader.getRangeValues(sheet, 2, 1, 1, 3)).toEqual([
+      [1, "Alice", 21],
+    ]);
+  });
+
+  test("deleteRow で行が詰まる", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.deleteRow(sheet, 2);
+
+    expect(buffer.reader.getLastRow(sheet)).toBe(2);
+    expect(buffer.reader.getRangeValues(sheet, 2, 1, 1, 3)).toEqual([
+      [2, "Bob", 30],
+    ]);
+  });
+
+  test("スナップショット後の実シート変更は tx 内読み取りに影響しない", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    expect(buffer.reader.getLastRow(sheet)).toBe(3);
+    sheet.getRange(2, 3, 1, 1).setValues([[99]]);
+
+    expect(buffer.reader.getRangeValues(sheet, 2, 1, 1, 3)).toEqual([
+      [1, "Alice", 20],
+    ]);
+  });
+});
+
+describe("flush の発行順再生", () => {
+  test("append→update→delete→append の交錯を発行順に再生する", () => {
+    const { sheet, snapshot, writes } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.appendRows(sheet, 1, 3, [[3, "Carol", 40]]);
+    buffer.writer.updateRow(sheet, 2, 1, 3, [1, "Alice", 21]);
+    buffer.writer.deleteRow(sheet, 3);
+    buffer.writer.appendRows(sheet, 1, 3, [[4, "Dave", 50]]);
+
+    expect(writes).toEqual([]);
+    buffer.flush();
+
+    expect(writes).toEqual([
+      { method: "setValues", args: [4, 1, [[3, "Carol", 40]]] },
+      { method: "setValues", args: [2, 1, [[1, "Alice", 21]]] },
+      { method: "deleteRow", args: [3] },
+      { method: "setValues", args: [4, 1, [[4, "Dave", 50]]] },
+    ]);
+    expect(snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 21],
+      [3, "Carol", 40],
+      [4, "Dave", 50],
+    ]);
+  });
+
+  test("降順 deleteRow の順序が保存される", () => {
+    const { sheet, snapshot, writes } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.deleteRow(sheet, 3);
+    buffer.writer.deleteRow(sheet, 2);
+    buffer.flush();
+
+    expect(writes).toEqual([
+      { method: "deleteRow", args: [3] },
+      { method: "deleteRow", args: [2] },
+    ]);
+    expect(snapshot()).toEqual([["id", "name", "age"]]);
+  });
+});
+
+describe("getAllData / getTitle のオーバーレイ経由読み取り", () => {
+  const buildUtil = (
+    sheet: GoogleAppsScript.Spreadsheet.Sheet,
+    reader: GassmaControllerUtil["reader"],
+  ): GassmaControllerUtil => ({
+    sheet,
+    startRowNumber: 1,
+    startColumnNumber: 1,
+    endColumnNumber: 3,
+    reader,
+  });
+
+  test("getAllData は積んだ append を含み、空文字は null になる", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.appendRows(sheet, 1, 3, [[3, "Carol", ""]]);
+
+    expect(getAllData(buildUtil(sheet, buffer.reader))).toEqual([
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+      [3, "Carol", null],
+    ]);
+  });
+
+  test("getTitle はスナップショットからヘッダを返す", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    expect(getTitle(buildUtil(sheet, buffer.reader))).toEqual([
+      "id",
+      "name",
+      "age",
+    ]);
+  });
+
+  test("reader 未指定なら従来どおり実シートを読む", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+
+    expect(getAllData(buildUtil(sheet, undefined))).toEqual([
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+    ]);
+  });
+});

--- a/src/__test__/util/transaction/transactionTestClient.ts
+++ b/src/__test__/util/transaction/transactionTestClient.ts
@@ -1,0 +1,143 @@
+import { GassmaClient } from "../../../gassma";
+import type { GassmaClientOptions } from "../../../types/relationTypes";
+
+type WriteCall = { method: string; args: unknown[] };
+
+type LoggedSheet = {
+  sheet: GoogleAppsScript.Spreadsheet.Sheet;
+  snapshot: () => unknown[][];
+  writes: WriteCall[];
+};
+
+const makeLoggedSheet = (name: string, initial: unknown[][]): LoggedSheet => {
+  const data = initial.map((row) => [...row]);
+  const writes: WriteCall[] = [];
+  const sheet = {
+    getName: () => name,
+    getLastRow: () => data.length,
+    getLastColumn: () => (data[0] ? data[0].length : 0),
+    getRange: (row: number, col: number, numRows: number, numCols: number) => ({
+      getValues: () =>
+        data
+          .slice(row - 1, row - 1 + numRows)
+          .map((r) => r.slice(col - 1, col - 1 + numCols)),
+      setValues: (values: unknown[][]) => {
+        writes.push({ method: "setValues", args: [row, col, values] });
+        values.forEach((rowValues, i) => {
+          while (data.length < row + i) {
+            data.push(Array(data[0].length).fill(""));
+          }
+          rowValues.forEach((value, j) => {
+            data[row - 1 + i][col - 1 + j] = value;
+          });
+        });
+      },
+    }),
+    getDataRange: () => ({ getValues: () => data.map((r) => [...r]) }),
+    deleteRow: (rowIndex: number) => {
+      writes.push({ method: "deleteRow", args: [rowIndex] });
+      data.splice(rowIndex - 1, 1);
+    },
+  } as any;
+  return { sheet, snapshot: () => data.map((r) => [...r]), writes };
+};
+
+type TxTestEnvConfig = {
+  relations?: boolean;
+  cascade?: boolean;
+  autoincrement?: boolean;
+  waitLockError?: boolean;
+};
+
+type TxTestEnv = {
+  client: GassmaClient;
+  users: LoggedSheet;
+  posts: LoggedSheet;
+  waitLock: jest.Mock;
+  releaseLock: jest.Mock;
+  propsStore: Record<string, string>;
+};
+
+const buildTxTestEnv = (config?: TxTestEnvConfig): TxTestEnv => {
+  const users = makeLoggedSheet("Users", [
+    ["id", "name", "age"],
+    [1, "Alice", 20],
+    [2, "Bob", 30],
+  ]);
+  const posts = makeLoggedSheet("Posts", [
+    ["id", "authorId", "title"],
+    [101, 1, "Post A"],
+    [102, 2, "Post B"],
+  ]);
+  const sheets = [users.sheet, posts.sheet];
+  const spreadsheet = {
+    getId: () => "tx-test",
+    getSheets: () => sheets,
+    getSheetByName: (n: string) =>
+      sheets.find((s: any) => s.getName() === n) ?? null,
+  };
+  const waitLock = jest.fn(
+    config?.waitLockError
+      ? () => {
+          throw new Error("Lock timeout");
+        }
+      : () => {},
+  );
+  const releaseLock = jest.fn();
+  const propsStore: Record<string, string> = {};
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => spreadsheet },
+    LockService: { getScriptLock: () => ({ waitLock, releaseLock }) },
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getProperty: (key: string) => propsStore[key] ?? null,
+        setProperty: (key: string, value: string) => {
+          propsStore[key] = value;
+        },
+      }),
+    },
+  });
+  const options: GassmaClientOptions = {};
+  if (config?.relations) {
+    options.relations = {
+      Users: {
+        posts: {
+          type: "oneToMany",
+          to: "Posts",
+          field: "id",
+          reference: "authorId",
+          ...(config?.cascade
+            ? { onDelete: "Cascade", onUpdate: "Cascade" }
+            : {}),
+        },
+      },
+      Posts: {
+        author: {
+          type: "manyToOne",
+          to: "Users",
+          field: "authorId",
+          reference: "id",
+        },
+      },
+    };
+  }
+  if (config?.autoincrement) {
+    options.autoincrement = { Users: "id" };
+  }
+  const client =
+    config?.relations || config?.autoincrement
+      ? new GassmaClient(options)
+      : new GassmaClient();
+  return { client, users, posts, waitLock, releaseLock, propsStore };
+};
+
+const clearGasGlobals = () => {
+  Object.assign(globalThis, {
+    SpreadsheetApp: undefined,
+    LockService: undefined,
+    PropertiesService: undefined,
+  });
+};
+
+export { buildTxTestEnv, clearGasGlobals, makeLoggedSheet };
+export type { LoggedSheet, TxTestEnv };

--- a/src/errors/transaction/transactionError.ts
+++ b/src/errors/transaction/transactionError.ts
@@ -1,0 +1,32 @@
+class GassmaTransactionLockTimeoutError extends Error {
+  constructor(maxWaitMs: number) {
+    super(
+      `Transaction API error: Unable to start a transaction in the given time. The maxWait for this transaction was ${maxWaitMs} ms.`,
+    );
+    this.name = "GassmaTransactionLockTimeoutError";
+  }
+}
+
+class GassmaTransactionTimeoutError extends Error {
+  constructor(phase: "query" | "commit", timeoutMs: number, elapsedMs: number) {
+    super(
+      `Transaction API error: A ${phase} cannot be executed on an expired transaction. The timeout for this transaction was ${timeoutMs} ms, however ${elapsedMs} ms passed since the start of the transaction. Consider increasing the transaction timeout or doing less work in the transaction.`,
+    );
+    this.name = "GassmaTransactionTimeoutError";
+  }
+}
+
+class GassmaNestedTransactionError extends Error {
+  constructor() {
+    super(
+      "Transaction API error: Nested transactions are not supported. Do not call $transaction inside an active transaction.",
+    );
+    this.name = "GassmaNestedTransactionError";
+  }
+}
+
+export {
+  GassmaNestedTransactionError,
+  GassmaTransactionLockTimeoutError,
+  GassmaTransactionTimeoutError,
+};

--- a/src/gassma.ts
+++ b/src/gassma.ts
@@ -5,10 +5,16 @@ import type {
 } from "./types/extendsTypes";
 import type { GassmaSheet } from "./types/gassmaTypes";
 import type { GassmaClientOptions } from "./types/relationTypes";
+import type {
+  GassmaTransactionClient,
+  GassmaTransactionOptions,
+  SheetIo,
+} from "./types/transactionTypes";
 import { buildExtendedClient } from "./util/extends/buildExtendedClient";
 import { isSheetIgnored } from "./util/ignore/isSheetIgnored";
 import { resolveCodeName } from "./util/map/mapSheetName";
 import { injectRelations } from "./util/relation/injectRelations";
+import { runTransaction } from "./util/transaction/runTransaction";
 
 const isClientOptions = (
   arg: string | GassmaClientOptions | undefined,
@@ -16,8 +22,14 @@ const isClientOptions = (
   return typeof arg === "object" && arg !== null;
 };
 
+const clientInitArgs = new WeakMap<
+  GassmaClient,
+  string | GassmaClientOptions | undefined
+>();
+
 class GassmaClient {
-  constructor(idOrOptions?: string | GassmaClientOptions) {
+  constructor(idOrOptions?: string | GassmaClientOptions, sheetIo?: SheetIo) {
+    clientInitArgs.set(this, idOrOptions);
     const id = isClientOptions(idOrOptions) ? idOrOptions.id : idOrOptions;
     const relations = isClientOptions(idOrOptions)
       ? idOrOptions.relations
@@ -64,7 +76,7 @@ class GassmaClient {
       const sheetName = sheet.getName();
       const codeName = resolveCodeName(sheetName, mapSheets);
       if (isSheetIgnored(codeName, ignoreSheets)) return;
-      const sheetController = new GassmaController(sheetName, id);
+      const sheetController = new GassmaController(sheetName, id, sheetIo);
       if (codeName !== sheetName) {
         sheetController._setCodeName(codeName);
       }
@@ -104,6 +116,14 @@ class GassmaClient {
     if (relations) {
       injectRelations(relations, controllers);
     }
+  }
+
+  public $transaction<T>(
+    fn: (tx: GassmaTransactionClient) => T,
+    options?: GassmaTransactionOptions,
+  ): T {
+    const initArgs = clientInitArgs.get(this);
+    return runTransaction(fn, options, (io) => new GassmaClient(initArgs, io));
   }
 
   public $extends(extension: GassmaExtension): ExtendedGassmaClient {

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -73,6 +73,9 @@ import { findManyWithRelationOrderBy } from "./util/find/findManyWithRelationOrd
 import { findFirstWithRelationOrderBy } from "./util/find/findFirstWithRelationOrderBy";
 import type { SheetWriter } from "./util/write/sheetWriter";
 import { immediateSheetWriter } from "./util/write/sheetWriter";
+import type { SheetReader } from "./util/read/sheetReader";
+import { immediateSheetReader } from "./util/read/sheetReader";
+import type { SheetIo } from "./types/transactionTypes";
 
 class GassmaController {
   private readonly sheet: GoogleAppsScript.Spreadsheet.Sheet;
@@ -90,8 +93,9 @@ class GassmaController {
   private codeName: string | null = null;
   private strictUndefinedChecks: boolean = false;
   private writer: SheetWriter = immediateSheetWriter;
+  private reader: SheetReader = immediateSheetReader;
 
-  constructor(sheetName: string, id?: string) {
+  constructor(sheetName: string, id?: string, sheetIo?: SheetIo) {
     const spreadSheet = id
       ? SpreadsheetApp.openById(id)
       : SpreadsheetApp.getActiveSpreadsheet();
@@ -99,6 +103,11 @@ class GassmaController {
 
     if (!sheet)
       throw new Error(`Error: cant access sheet. sheetName: ${sheetName}`);
+
+    if (sheetIo) {
+      this.writer = sheetIo.writer;
+      this.reader = sheetIo.reader;
+    }
 
     this.sheet = sheet;
     this.spreadsheetId = spreadSheet.getId();
@@ -242,6 +251,7 @@ class GassmaController {
       startColumnNumber: this.startColumnNumber,
       endColumnNumber: this.endColumnNumber,
       writer: this.writer,
+      reader: this.reader,
     };
     if (this.fieldMapping) {
       util.fieldMapping = this.fieldMapping;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,8 +44,25 @@ declare namespace Gassma {
     result?: ResultExtensionConfig;
   };
 
+  type ExtendedGassmaClient = {
+    $extends(extension: GassmaExtension): ExtendedGassmaClient;
+  } & GassmaSheet;
+
+  type GassmaTransactionOptions = {
+    maxWait?: number;
+    timeout?: number;
+  };
+
+  type GassmaTransactionClient = {
+    $extends(extension: GassmaExtension): ExtendedGassmaClient;
+  } & GassmaSheet;
+
   type GassmaClient = {
-    $extends(extension: GassmaExtension): GassmaClient;
+    $extends(extension: GassmaExtension): ExtendedGassmaClient;
+    $transaction<T>(
+      fn: (tx: GassmaTransactionClient) => T,
+      options?: GassmaTransactionOptions,
+    ): T;
   } & GassmaSheet;
 
   const GassmaClient: new (
@@ -601,6 +618,19 @@ declare namespace Gassma {
   }
   class GassmaRelationDuplicateError extends Error {
     constructor(sheetName: string, field: string, value: unknown);
+  }
+  class GassmaTransactionLockTimeoutError extends Error {
+    constructor(maxWaitMs: number);
+  }
+  class GassmaTransactionTimeoutError extends Error {
+    constructor(
+      phase: "query" | "commit",
+      timeoutMs: number,
+      elapsedMs: number,
+    );
+  }
+  class GassmaNestedTransactionError extends Error {
+    constructor();
   }
 }
 

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -7,6 +7,7 @@ import * as nestedWriteErrors from "./errors/relation/nestedWriteError";
 import * as relationErrors from "./errors/relation/relationError";
 import * as relationValidationErrors from "./errors/relation/relationValidationError";
 import * as skipErrors from "./errors/skip/skipError";
+import * as transactionErrors from "./errors/transaction/transactionError";
 import * as whereRelationErrors from "./errors/relation/whereRelationError";
 import { GassmaClient as GassmaClientClass } from "./gassma";
 import { GassmaController as GassmaControllerClass } from "./gassmaController";
@@ -108,3 +109,10 @@ export const GassmaIncludeSelectConflictError =
   relationErrors.GassmaIncludeSelectConflictError;
 export const GassmaRelationDuplicateError =
   relationErrors.GassmaRelationDuplicateError;
+
+export const GassmaTransactionLockTimeoutError =
+  transactionErrors.GassmaTransactionLockTimeoutError;
+export const GassmaTransactionTimeoutError =
+  transactionErrors.GassmaTransactionTimeoutError;
+export const GassmaNestedTransactionError =
+  transactionErrors.GassmaNestedTransactionError;

--- a/src/types/gassmaControllerUtilType.ts
+++ b/src/types/gassmaControllerUtilType.ts
@@ -1,4 +1,5 @@
 import type { FieldMapping } from "../util/map/mapFields";
+import type { SheetReader } from "../util/read/sheetReader";
 import type { SheetWriter } from "../util/write/sheetWriter";
 
 type GassmaControllerUtil = {
@@ -8,6 +9,7 @@ type GassmaControllerUtil = {
   endColumnNumber: number;
   fieldMapping?: FieldMapping;
   writer?: SheetWriter;
+  reader?: SheetReader;
 };
 
 export type { GassmaControllerUtil };

--- a/src/types/transactionTypes.ts
+++ b/src/types/transactionTypes.ts
@@ -1,0 +1,27 @@
+import type { SheetReader } from "../util/read/sheetReader";
+import type { SheetWriter } from "../util/write/sheetWriter";
+import type { ExtendedGassmaClient, GassmaExtension } from "./extendsTypes";
+import type { GassmaSheet } from "./gassmaTypes";
+
+type SheetIo = {
+  writer: SheetWriter;
+  reader: SheetReader;
+};
+
+type GassmaTransactionOptions = {
+  maxWait?: number;
+  timeout?: number;
+};
+
+type TransactionClientCore = {
+  $extends: (extension: GassmaExtension) => ExtendedGassmaClient;
+};
+
+type GassmaTransactionClient = TransactionClientCore & GassmaSheet;
+
+export type {
+  GassmaTransactionClient,
+  GassmaTransactionOptions,
+  SheetIo,
+  TransactionClientCore,
+};

--- a/src/util/core/getAllData.ts
+++ b/src/util/core/getAllData.ts
@@ -1,5 +1,6 @@
 import type { GassmaAny } from "../../types/coreTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
+import { resolveReader } from "../read/sheetReader";
 
 const getAllData = (
   gassmaControllerUtil: GassmaControllerUtil,
@@ -7,14 +8,19 @@ const getAllData = (
   const { sheet, startRowNumber, startColumnNumber, endColumnNumber } =
     gassmaControllerUtil;
 
-  const rowLength = sheet.getLastRow() - startRowNumber;
+  const reader = resolveReader(gassmaControllerUtil.reader);
+  const rowLength = reader.getLastRow(sheet) - startRowNumber;
   const ColumnLength = endColumnNumber - startColumnNumber + 1;
 
   if (rowLength === 0) return [];
 
-  const dataIncludeEmptyString = sheet
-    .getRange(startRowNumber + 1, startColumnNumber, rowLength, ColumnLength)
-    .getValues();
+  const dataIncludeEmptyString = reader.getRangeValues(
+    sheet,
+    startRowNumber + 1,
+    startColumnNumber,
+    rowLength,
+    ColumnLength,
+  );
 
   const data = dataIncludeEmptyString.map((row) =>
     row.map((cell) => (cell === "" ? null : cell)),

--- a/src/util/core/getTitle.ts
+++ b/src/util/core/getTitle.ts
@@ -1,5 +1,6 @@
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import { mapTitles } from "../map/mapTitles";
+import { resolveReader } from "../read/sheetReader";
 
 const getTitle = (gassmaControllerUtil: GassmaControllerUtil): string[] => {
   const {
@@ -12,9 +13,13 @@ const getTitle = (gassmaControllerUtil: GassmaControllerUtil): string[] => {
 
   const ColumnLength = endColumnNumber - startColumnNumber + 1;
 
-  const tiltes = sheet
-    .getRange(startRowNumber, startColumnNumber, 1, ColumnLength)
-    .getValues()[0];
+  const tiltes = resolveReader(gassmaControllerUtil.reader).getRangeValues(
+    sheet,
+    startRowNumber,
+    startColumnNumber,
+    1,
+    ColumnLength,
+  )[0];
 
   const stringTitles = tiltes.map((title) => String(title));
 

--- a/src/util/read/bufferedSheetReader.ts
+++ b/src/util/read/bufferedSheetReader.ts
@@ -1,0 +1,16 @@
+import type { VirtualSheetStore } from "../transaction/virtualSheetStore";
+import type { SheetReader } from "./sheetReader";
+
+const createBufferedSheetReader = (store: VirtualSheetStore): SheetReader => ({
+  getLastRow: (sheet) => store.getLastRow(sheet),
+  getRangeValues: (sheet, rowNumber, columnNumber, rowLength, columnLength) =>
+    store.getRangeValues(
+      sheet,
+      rowNumber,
+      columnNumber,
+      rowLength,
+      columnLength,
+    ),
+});
+
+export { createBufferedSheetReader };

--- a/src/util/read/sheetReader.ts
+++ b/src/util/read/sheetReader.ts
@@ -1,0 +1,24 @@
+type SheetReader = {
+  getLastRow(sheet: GoogleAppsScript.Spreadsheet.Sheet): number;
+  getRangeValues(
+    sheet: GoogleAppsScript.Spreadsheet.Sheet,
+    rowNumber: number,
+    columnNumber: number,
+    rowLength: number,
+    columnLength: number,
+  ): any[][];
+};
+
+const immediateSheetReader: SheetReader = {
+  getLastRow: (sheet) => sheet.getLastRow(),
+  getRangeValues: (sheet, rowNumber, columnNumber, rowLength, columnLength) =>
+    sheet
+      .getRange(rowNumber, columnNumber, rowLength, columnLength)
+      .getValues(),
+};
+
+const resolveReader = (reader: SheetReader | undefined): SheetReader =>
+  reader ?? immediateSheetReader;
+
+export { immediateSheetReader, resolveReader };
+export type { SheetReader };

--- a/src/util/transaction/buildTransactionClient.ts
+++ b/src/util/transaction/buildTransactionClient.ts
@@ -1,0 +1,47 @@
+import { GassmaNestedTransactionError } from "../../errors/transaction/transactionError";
+import type { GassmaController } from "../../gassmaController";
+import type { GassmaExtension } from "../../types/extendsTypes";
+import type { GassmaSheet } from "../../types/gassmaTypes";
+import type { GassmaTransactionClient } from "../../types/transactionTypes";
+import { buildExtendedClient } from "../extends/buildExtendedClient";
+
+const wrapControllerWithDeadline = (
+  controller: GassmaController,
+  checkDeadline: () => void,
+): GassmaController =>
+  new Proxy(controller, {
+    get: (target, prop, receiver) => {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") return value;
+      return (...args: unknown[]) => {
+        checkDeadline();
+        return value.apply(target, args);
+      };
+    },
+  });
+
+const buildTransactionClient = (
+  baseClient: object,
+  checkDeadline: () => void,
+): GassmaTransactionClient => {
+  const controllers: GassmaSheet = {};
+  Object.entries(baseClient).forEach(([sheetName, value]) => {
+    if (value && typeof value.findMany === "function") {
+      controllers[sheetName] = wrapControllerWithDeadline(value, checkDeadline);
+    }
+  });
+  const core = {
+    $extends: (extension: GassmaExtension) =>
+      buildExtendedClient(controllers, [extension]),
+    $transaction: () => {
+      throw new GassmaNestedTransactionError();
+    },
+  };
+  const client: GassmaTransactionClient = Object.assign(
+    Object.create(core),
+    controllers,
+  );
+  return client;
+};
+
+export { buildTransactionClient };

--- a/src/util/transaction/runTransaction.ts
+++ b/src/util/transaction/runTransaction.ts
@@ -1,0 +1,59 @@
+import {
+  GassmaNestedTransactionError,
+  GassmaTransactionLockTimeoutError,
+} from "../../errors/transaction/transactionError";
+import type {
+  GassmaTransactionClient,
+  GassmaTransactionOptions,
+  SheetIo,
+} from "../../types/transactionTypes";
+import { buildTransactionClient } from "./buildTransactionClient";
+import { createTransactionBuffer } from "./transactionBuffer";
+import { createTransactionDeadline } from "./transactionDeadline";
+
+const DEFAULT_MAX_WAIT_MS = 20000;
+const DEFAULT_TIMEOUT_MS = 60000;
+
+let transactionInProgress = false;
+
+const acquireScriptLock = (maxWaitMs: number): GoogleAppsScript.Lock.Lock => {
+  const lock = LockService.getScriptLock();
+  try {
+    lock.waitLock(maxWaitMs);
+  } catch {
+    throw new GassmaTransactionLockTimeoutError(maxWaitMs);
+  }
+  return lock;
+};
+
+const runTransaction = <T>(
+  fn: (tx: GassmaTransactionClient) => T,
+  options: GassmaTransactionOptions | undefined,
+  buildBufferedClient: (sheetIo: SheetIo) => object,
+): T => {
+  if (transactionInProgress) {
+    throw new GassmaNestedTransactionError();
+  }
+  const maxWaitMs = options?.maxWait ?? DEFAULT_MAX_WAIT_MS;
+  const timeoutMs = options?.timeout ?? DEFAULT_TIMEOUT_MS;
+  const lock = acquireScriptLock(maxWaitMs);
+  transactionInProgress = true;
+  try {
+    const checkDeadline = createTransactionDeadline(timeoutMs);
+    const buffer = createTransactionBuffer();
+    const baseClient = buildBufferedClient({
+      writer: buffer.writer,
+      reader: buffer.reader,
+    });
+    const tx = buildTransactionClient(baseClient, () => checkDeadline("query"));
+    const result = fn(tx);
+    checkDeadline("commit");
+    buffer.flush();
+    return result;
+  } finally {
+    transactionInProgress = false;
+    lock.releaseLock();
+  }
+};
+
+export { runTransaction };

--- a/src/util/transaction/transactionBuffer.ts
+++ b/src/util/transaction/transactionBuffer.ts
@@ -1,0 +1,28 @@
+import { createBufferedSheetReader } from "../read/bufferedSheetReader";
+import type { SheetReader } from "../read/sheetReader";
+import {
+  createBufferedSheetWriter,
+  replaySheetOps,
+} from "../write/bufferedSheetWriter";
+import type { SheetOp } from "../write/bufferedSheetWriter";
+import type { SheetWriter } from "../write/sheetWriter";
+import { createVirtualSheetStore } from "./virtualSheetStore";
+
+type TransactionBuffer = {
+  writer: SheetWriter;
+  reader: SheetReader;
+  flush: () => void;
+};
+
+const createTransactionBuffer = (): TransactionBuffer => {
+  const store = createVirtualSheetStore();
+  const ops: SheetOp[] = [];
+  return {
+    writer: createBufferedSheetWriter(store, ops),
+    reader: createBufferedSheetReader(store),
+    flush: () => replaySheetOps(ops),
+  };
+};
+
+export { createTransactionBuffer };
+export type { TransactionBuffer };

--- a/src/util/transaction/transactionDeadline.ts
+++ b/src/util/transaction/transactionDeadline.ts
@@ -1,0 +1,18 @@
+import { GassmaTransactionTimeoutError } from "../../errors/transaction/transactionError";
+
+type TransactionPhase = "query" | "commit";
+
+type DeadlineCheck = (phase: TransactionPhase) => void;
+
+const createTransactionDeadline = (timeoutMs: number): DeadlineCheck => {
+  const startedAt = Date.now();
+  return (phase) => {
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs > timeoutMs) {
+      throw new GassmaTransactionTimeoutError(phase, timeoutMs, elapsedMs);
+    }
+  };
+};
+
+export { createTransactionDeadline };
+export type { DeadlineCheck, TransactionPhase };

--- a/src/util/transaction/virtualSheetStore.ts
+++ b/src/util/transaction/virtualSheetStore.ts
@@ -1,0 +1,104 @@
+type Sheet = GoogleAppsScript.Spreadsheet.Sheet;
+
+type VirtualSheet = {
+  grid: unknown[][];
+  width: number;
+};
+
+const snapshotSheet = (sheet: Sheet): VirtualSheet => {
+  const lastRow = sheet.getLastRow();
+  const lastColumn = sheet.getLastColumn();
+  if (lastRow < 1 || lastColumn < 1) {
+    return { grid: [], width: Math.max(lastColumn, 0) };
+  }
+  return {
+    grid: sheet.getRange(1, 1, lastRow, lastColumn).getValues(),
+    width: lastColumn,
+  };
+};
+
+const createVirtualSheetStore = () => {
+  const virtualSheets = new Map<Sheet, VirtualSheet>();
+
+  const getVirtual = (sheet: Sheet): VirtualSheet => {
+    const existing = virtualSheets.get(sheet);
+    if (existing) return existing;
+    const created = snapshotSheet(sheet);
+    virtualSheets.set(sheet, created);
+    return created;
+  };
+
+  const appendRows = (
+    sheet: Sheet,
+    startColumnNumber: number,
+    columnLength: number,
+    rows: unknown[][],
+  ) => {
+    const virtual = getVirtual(sheet);
+    virtual.width = Math.max(
+      virtual.width,
+      startColumnNumber - 1 + columnLength,
+    );
+    rows.forEach((row) => {
+      const appended: unknown[] = Array.from(
+        { length: virtual.width },
+        () => "",
+      );
+      row.forEach((value, index) => {
+        appended[startColumnNumber - 1 + index] = value;
+      });
+      virtual.grid.push(appended);
+    });
+  };
+
+  const updateRow = (
+    sheet: Sheet,
+    rowNumber: number,
+    startColumnNumber: number,
+    columnLength: number,
+    row: unknown[],
+  ) => {
+    const virtual = getVirtual(sheet);
+    virtual.width = Math.max(
+      virtual.width,
+      startColumnNumber - 1 + columnLength,
+    );
+    while (virtual.grid.length < rowNumber) {
+      virtual.grid.push([]);
+    }
+    const target = virtual.grid[rowNumber - 1];
+    row.forEach((value, index) => {
+      target[startColumnNumber - 1 + index] = value;
+    });
+  };
+
+  const deleteRow = (sheet: Sheet, rowNumber: number) => {
+    getVirtual(sheet).grid.splice(rowNumber - 1, 1);
+  };
+
+  const getLastRow = (sheet: Sheet): number => getVirtual(sheet).grid.length;
+
+  const getRangeValues = (
+    sheet: Sheet,
+    rowNumber: number,
+    columnNumber: number,
+    rowLength: number,
+    columnLength: number,
+  ): any[][] => {
+    const virtual = getVirtual(sheet);
+    return Array.from({ length: rowLength }, (_, rowIndex) => {
+      const row = virtual.grid[rowNumber - 1 + rowIndex] ?? [];
+      return Array.from({ length: columnLength }, (_, columnIndex) => {
+        const cell = row[columnNumber - 1 + columnIndex];
+        return cell === undefined ? "" : cell;
+      });
+    });
+  };
+
+  return { appendRows, updateRow, deleteRow, getLastRow, getRangeValues };
+};
+
+type VirtualSheetStore = ReturnType<typeof createVirtualSheetStore>;
+
+export { createVirtualSheetStore };
+export type { VirtualSheetStore };

--- a/src/util/write/bufferedSheetWriter.ts
+++ b/src/util/write/bufferedSheetWriter.ts
@@ -1,0 +1,91 @@
+import type { VirtualSheetStore } from "../transaction/virtualSheetStore";
+import type { SheetWriter } from "./sheetWriter";
+import { immediateSheetWriter } from "./sheetWriter";
+
+type Sheet = GoogleAppsScript.Spreadsheet.Sheet;
+
+type AppendRowsOp = {
+  kind: "appendRows";
+  sheet: Sheet;
+  startColumnNumber: number;
+  columnLength: number;
+  rows: unknown[][];
+};
+
+type UpdateRowOp = {
+  kind: "updateRow";
+  sheet: Sheet;
+  rowNumber: number;
+  startColumnNumber: number;
+  columnLength: number;
+  row: unknown[];
+};
+
+type DeleteRowOp = {
+  kind: "deleteRow";
+  sheet: Sheet;
+  rowNumber: number;
+};
+
+type SheetOp = AppendRowsOp | UpdateRowOp | DeleteRowOp;
+
+const createBufferedSheetWriter = (
+  store: VirtualSheetStore,
+  ops: SheetOp[],
+): SheetWriter => ({
+  appendRows: (sheet, startColumnNumber, columnLength, rows) => {
+    ops.push({
+      kind: "appendRows",
+      sheet,
+      startColumnNumber,
+      columnLength,
+      rows,
+    });
+    store.appendRows(sheet, startColumnNumber, columnLength, rows);
+  },
+  updateRow: (sheet, rowNumber, startColumnNumber, columnLength, row) => {
+    ops.push({
+      kind: "updateRow",
+      sheet,
+      rowNumber,
+      startColumnNumber,
+      columnLength,
+      row,
+    });
+    store.updateRow(sheet, rowNumber, startColumnNumber, columnLength, row);
+  },
+  deleteRow: (sheet, rowNumber) => {
+    ops.push({ kind: "deleteRow", sheet, rowNumber });
+    store.deleteRow(sheet, rowNumber);
+  },
+});
+
+const replaySheetOp = (op: SheetOp) => {
+  if (op.kind === "appendRows") {
+    immediateSheetWriter.appendRows(
+      op.sheet,
+      op.startColumnNumber,
+      op.columnLength,
+      op.rows,
+    );
+    return;
+  }
+  if (op.kind === "updateRow") {
+    immediateSheetWriter.updateRow(
+      op.sheet,
+      op.rowNumber,
+      op.startColumnNumber,
+      op.columnLength,
+      op.row,
+    );
+    return;
+  }
+  immediateSheetWriter.deleteRow(op.sheet, op.rowNumber);
+};
+
+const replaySheetOps = (ops: SheetOp[]) => {
+  ops.forEach(replaySheetOp);
+};
+
+export { createBufferedSheetWriter, replaySheetOps };
+export type { SheetOp };


### PR DESCRIPTION
## 概要

**$transaction 3フェーズ計画の Phase 2** = `gassma.$transaction(fn, { maxWait = 20000, timeout = 60000 })` 本体です(仕様承認済み。rollback は Phase 3、**リリースは Phase 3 まで揃ってから**)。

## フロー

1. `LockService.getScriptLock().waitLock(maxWait)`(既定 20秒。失敗 → `GassmaTransactionLockTimeoutError`)
2. **通常のコンストラクタ経路を再実行**して tx クライアントを構築(共有バッファ SheetIo を隠し引数で注入)— injectRelations が新 client に閉じるため **cascade・nested write も全シート共有バッファ経由**
3. `fn(tx)` 実行 — 各 tx メソッド入口(controller Proxy)+ flush 前で**協調式 timeout チェック**(既定 60秒)
4. fn 正常終了 → **発行順で flush**(降順 delete の意味も自然に保存)/ fn throw → **1セルも書かず** rethrow
5. finally で lock 解放

## read-your-writes

読み取りに `SheetReader` シームを新設(Phase 1 の writer と対称)。バッファ版は **VirtualSheetStore**(初回タッチで全面 snapshot → ops をメモリ適用)を読むため、tx 内の find / include / relation filter / referential action すべてが未 flush の変更を見ます。tx 外の元 client は immediate のまま(Prisma 同様)。

## エラー文言は Prisma 実測(P2028)準拠

prisma-test で timeout 超過(クエリ時/commit 時)・maxWait 超過・fn throw の全ロールバックを実測し、文言を原文に寄せました(gassma は interactive 形のみのため "interactive" を落とし、maxWait エラーには値を付加 — 趣旨一致の調整2点)。ネスト tx は Prisma に固有エラーが無いため独自文言。

## 公開面

- `$transaction` を index.d.ts の GassmaClient に追加。`GassmaTransactionOptions` / `GassmaTransactionClient`($transaction を除いた型)を新設
- **`$extends` の戻り型を `ExtendedGassmaClient` に変更**(型の正直化: extended client に $transaction はランタイム上も元々存在しない。構造は旧 GassmaClient と同一)— 公開型の変更につき要レビュー
- 新公開エラー3種(LockTimeout / Timeout / Nested)で **47 → 50 シンボル**。verify:bundle は export 一時削除で Red ×3 を実測してから Green

## 設計判断(記録)

- autoincrement の ScriptProperties は**即時のまま**(Phase 1 決定踏襲。tx 内でも即時採番され戻り値に入る・rollback で巻き戻らないのは Prisma/PostgreSQL のシーケンスと同じ)
- 既知の制限: `changeSettings` で実行時に変えた設定は tx client に引き継がれない(コンストラクタ由来の設定は全部引き継ぐ)/ 非協調の書き手(lock を取らない直接編集)は防げない(設計どおり・reference 記載予定)
- tx 内の autoincrement による LockService 再取得は GAS のロック再入で成立する認識 — **実機統合テストで要確認**とマーク

## テスト

1686 → **1717(+31)**、Red 実測済み。バッファ再生順・オーバーレイ・read-your-writes(create/update/delete×find 系)・nested write / Cascade の tx 内完結→flush 反映・fn throw 無書き込み・maxWait/timeout(query/commit 両相)/ネスト×2 のエラー(instanceof+メッセージ完全一致)・既定値・tx 後の immediate 復帰・$extends 併用。**実バンドル 2 realm ハーネス**: tx 外 26 シナリオ挙動不変 + tx E2E 19 本一致。tsc / lint(警告数ベースライン同数)/ format / build / verify:bundle 全 green。

## マージ後

cli 追随(生成 GassmaClient への `$transaction` 露出・TransactionClient 型・エラー3種)→ gassma-test 統合テスト → Phase 3(rollback + stale マーカー)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX