### PR TITLE
feat: add transaction rollback via sheet backups (phase 3 of 3)

### DIFF
--- a/src/__test__/util/transaction/transactionRollback.test.ts
+++ b/src/__test__/util/transaction/transactionRollback.test.ts
@@ -1,0 +1,273 @@
+import { GassmaTransactionRollbackError } from "../../../errors/transaction/transactionError";
+import { buildBackupName } from "../../../util/transaction/transactionBackup";
+import { buildTxTestEnv, clearGasGlobals } from "./transactionTestClient";
+
+const MARKER_KEY = "gassma_tx_backup_tx-test";
+
+const initialUsers = [
+  ["id", "name", "age"],
+  [1, "Alice", 20],
+  [2, "Bob", 30],
+];
+
+afterEach(() => {
+  clearGasGlobals();
+  jest.restoreAllMocks();
+});
+
+describe("backup ライフサイクル", () => {
+  test("成功時に backup が作成→削除されマーカーも消える", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+    });
+
+    expect(env.users.copyToCallCount()).toBe(1);
+    expect(env.posts.copyToCallCount()).toBe(0);
+    expect(env.sheetNames()).toEqual(["Users", "Posts"]);
+    expect(
+      env.propsLog
+        .filter((call) => call.key === MARKER_KEY)
+        .map((call) => call.method),
+    ).toEqual(["setProperty", "deleteProperty"]);
+    expect(env.propsStore[MARKER_KEY]).toBeUndefined();
+    expect(env.users.snapshot()).toHaveLength(4);
+  });
+
+  test("マーカーには backup 名一覧の JSON が入る", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+    });
+
+    const setCall = env.propsLog.find(
+      (call) => call.method === "setProperty" && call.key === MARKER_KEY,
+    );
+    const names = JSON.parse(setCall?.value ?? "[]");
+    expect(names).toHaveLength(1);
+    expect(names[0]).toMatch(/^_gassma_tx_\d+_Users$/);
+  });
+
+  test("rollback: false では copyTo もマーカーも一切ない", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction(
+      (tx) => {
+        tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+      },
+      { rollback: false },
+    );
+
+    expect(env.users.copyToCallCount()).toBe(0);
+    expect(env.propsLog).toEqual([]);
+    expect(env.users.snapshot()).toHaveLength(4);
+  });
+
+  test("読み取りのみの tx では backup を作らない", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => tx.Users.count({}));
+
+    expect(env.users.copyToCallCount()).toBe(0);
+    expect(env.propsLog).toEqual([]);
+  });
+
+  test("fn throw では backup を作らず無書き込みのまま", () => {
+    const env = buildTxTestEnv();
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+
+    expect(env.users.copyToCallCount()).toBe(0);
+    expect(env.propsLog).toEqual([]);
+    expect(env.users.snapshot()).toEqual(initialUsers);
+  });
+});
+
+describe("mid-flush 失敗からの復元", () => {
+  test("値と数式が tx 前と完全一致に戻り元エラーが rethrow される", () => {
+    const env = buildTxTestEnv({
+      usersConfig: {
+        formulas: [
+          ["", "", ""],
+          ["", "", ""],
+          ["", "", "=A2*15"],
+        ],
+        failOnWriteCall: 2,
+      },
+    });
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+        tx.Users.update({ where: { id: 1 }, data: { age: 21 } });
+      }),
+    ).toThrow("mock write failure at call 2");
+
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.users.formulaSnapshot()).toEqual([
+      ["", "", ""],
+      ["", "", ""],
+      ["", "", "=A2*15"],
+    ]);
+    expect(env.sheetNames()).toEqual(["Users", "Posts"]);
+    expect(env.propsStore[MARKER_KEY]).toBeUndefined();
+    expect(env.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  test("append 済みで死んでも行数が戻る", () => {
+    const env = buildTxTestEnv({
+      usersConfig: { failOnWriteCall: 2 },
+    });
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+        tx.Users.create({ data: { id: 4, name: "Dave", age: 50 } });
+      }),
+    ).toThrow("mock write failure at call 2");
+
+    expect(env.users.snapshot()).toHaveLength(3);
+    expect(env.users.snapshot()).toEqual(initialUsers);
+  });
+
+  test("複数シートに書いていた場合は全シートが復元される", () => {
+    const env = buildTxTestEnv({
+      postsConfig: { failOnWriteCall: 1 },
+    });
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+        tx.Posts.create({ data: { id: 103, authorId: 3, title: "C" } });
+      }),
+    ).toThrow("mock write failure at call 1");
+
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.posts.snapshot()).toEqual([
+      ["id", "authorId", "title"],
+      [101, 1, "Post A"],
+      [102, 2, "Post B"],
+    ]);
+    expect(env.sheetNames()).toEqual(["Users", "Posts"]);
+    expect(env.propsStore[MARKER_KEY]).toBeUndefined();
+  });
+
+  test("エラー後は再び $transaction を開始できる", () => {
+    const env = buildTxTestEnv({
+      usersConfig: { failOnWriteCall: 1 },
+    });
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+      }),
+    ).toThrow("mock write failure at call 1");
+
+    const result = env.client.$transaction((tx) => tx.Users.count({}));
+    expect(result).toBe(2);
+  });
+});
+
+describe("復元も失敗した場合", () => {
+  test("backup を温存し backup 名入りの GassmaTransactionRollbackError", () => {
+    const env = buildTxTestEnv({
+      usersConfig: { failOnWriteCall: 1, failOnClearContents: true },
+    });
+
+    let thrown: unknown = null;
+    try {
+      env.client.$transaction((tx) => {
+        tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(GassmaTransactionRollbackError);
+    const error =
+      thrown instanceof GassmaTransactionRollbackError ? thrown : null;
+    expect(error?.backupSheetNames).toHaveLength(1);
+    const backupName = error?.backupSheetNames[0] ?? "";
+    expect(backupName).toMatch(/^_gassma_tx_\d+_Users$/);
+    expect(String(error?.message)).toContain(backupName);
+    expect(env.sheetNames()).toContain(backupName);
+    const backupSheet: any = env.spreadsheet.getSheetByName(backupName);
+    expect(backupSheet.isSheetHidden()).toBe(true);
+    expect(env.propsStore[MARKER_KEY]).toBe(JSON.stringify([backupName]));
+    expect(env.releaseLock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("backup 作成中の失敗", () => {
+  test("copyTo 失敗時は作成済み backup を破棄しエラーを rethrow・無書き込み", () => {
+    const env = buildTxTestEnv({
+      postsConfig: { failOnCopyTo: true },
+    });
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+        tx.Posts.create({ data: { id: 103, authorId: 3, title: "C" } });
+      }),
+    ).toThrow("mock copyTo failure");
+
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.sheetNames()).toEqual(["Users", "Posts"]);
+    expect(env.propsStore[MARKER_KEY]).toBeUndefined();
+    expect(
+      env.propsLog.filter((call) => call.method === "setProperty"),
+    ).toEqual([]);
+  });
+});
+
+describe("stale マーカー検出", () => {
+  test("残存マーカーがあると警告して続行しマーカーは上書き後に消える", () => {
+    const env = buildTxTestEnv();
+    env.propsStore[MARKER_KEY] = JSON.stringify(["_gassma_tx_1_Users"]);
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    env.client.$transaction((tx) => {
+      tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain(MARKER_KEY);
+    expect(env.users.snapshot()).toHaveLength(4);
+    expect(
+      env.propsLog
+        .filter((call) => call.key === MARKER_KEY)
+        .map((call) => call.method),
+    ).toEqual(["setProperty", "deleteProperty"]);
+    expect(env.propsStore[MARKER_KEY]).toBeUndefined();
+  });
+
+  test("マーカーがなければ警告しない", () => {
+    const env = buildTxTestEnv();
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    env.client.$transaction((tx) => tx.Users.count({}));
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildBackupName", () => {
+  test("短い名前は _gassma_tx_<ts>_<name> のまま", () => {
+    expect(buildBackupName(123, "Users", 0)).toBe("_gassma_tx_123_Users");
+  });
+
+  test("100 文字を超える場合は切り詰めて index で一意化", () => {
+    const longName = "x".repeat(120);
+    const name = buildBackupName(1721990000000, longName, 3);
+    expect(name.length).toBeLessThanOrEqual(100);
+    expect(name.startsWith("_gassma_tx_1721990000000_")).toBe(true);
+    expect(name.endsWith("_3")).toBe(true);
+  });
+});

--- a/src/__test__/util/transaction/transactionTestClient.ts
+++ b/src/__test__/util/transaction/transactionTestClient.ts
@@ -3,43 +3,144 @@ import type { GassmaClientOptions } from "../../../types/relationTypes";
 
 type WriteCall = { method: string; args: unknown[] };
 
+type SheetMockConfig = {
+  formulas?: string[][];
+  formulaResults?: Record<string, unknown>;
+  failOnWriteCall?: number;
+  failOnClearContents?: boolean;
+  failOnCopyTo?: boolean;
+};
+
 type LoggedSheet = {
   sheet: GoogleAppsScript.Spreadsheet.Sheet;
   snapshot: () => unknown[][];
+  formulaSnapshot: () => string[][];
   writes: WriteCall[];
+  copyToCallCount: () => number;
+  setParent: (spreadsheet: unknown) => void;
 };
 
-const makeLoggedSheet = (name: string, initial: unknown[][]): LoggedSheet => {
+const makeLoggedSheet = (
+  name: string,
+  initial: unknown[][],
+  config?: SheetMockConfig,
+): LoggedSheet => {
   const data = initial.map((row) => [...row]);
+  const formulas = initial.map((row, i) =>
+    row.map((_, j) => config?.formulas?.[i]?.[j] ?? ""),
+  );
+  const formulaResults: Record<string, unknown> = {
+    ...config?.formulaResults,
+  };
+  formulas.forEach((row, i) => {
+    row.forEach((formula, j) => {
+      if (formula !== "" && !(formula in formulaResults)) {
+        formulaResults[formula] = data[i][j];
+      }
+    });
+  });
+  let sheetName = name;
+  let hidden = false;
+  let copyToCalls = 0;
+  let writeCalls = 0;
+  let parent: unknown = null;
   const writes: WriteCall[] = [];
+  const width = () => (data[0] ? data[0].length : 0);
+  const beginWrite = (method: string, args: unknown[]) => {
+    writeCalls += 1;
+    if (config?.failOnWriteCall && writeCalls === config.failOnWriteCall) {
+      throw new Error(`mock write failure at call ${writeCalls}`);
+    }
+    writes.push({ method, args });
+  };
   const sheet = {
-    getName: () => name,
+    getName: () => sheetName,
+    setName: (newName: string) => {
+      sheetName = newName;
+    },
+    hideSheet: () => {
+      hidden = true;
+    },
+    isSheetHidden: () => hidden,
+    getParent: () => parent,
     getLastRow: () => data.length,
-    getLastColumn: () => (data[0] ? data[0].length : 0),
+    getLastColumn: () => width(),
     getRange: (row: number, col: number, numRows: number, numCols: number) => ({
       getValues: () =>
         data
           .slice(row - 1, row - 1 + numRows)
           .map((r) => r.slice(col - 1, col - 1 + numCols)),
+      getFormulas: () =>
+        Array.from({ length: numRows }, (_, i) =>
+          Array.from(
+            { length: numCols },
+            (_, j) => formulas[row - 1 + i]?.[col - 1 + j] ?? "",
+          ),
+        ),
       setValues: (values: unknown[][]) => {
-        writes.push({ method: "setValues", args: [row, col, values] });
+        beginWrite("setValues", [row, col, values]);
         values.forEach((rowValues, i) => {
           while (data.length < row + i) {
-            data.push(Array(data[0].length).fill(""));
+            data.push(Array(width()).fill(""));
+            formulas.push(Array(width()).fill(""));
           }
           rowValues.forEach((value, j) => {
-            data[row - 1 + i][col - 1 + j] = value;
+            const isFormula =
+              typeof value === "string" && value.startsWith("=");
+            data[row - 1 + i][col - 1 + j] = isFormula
+              ? (formulaResults[value] ?? `#MOCK(${value})`)
+              : value;
+            formulas[row - 1 + i][col - 1 + j] = isFormula ? value : "";
           });
         });
       },
     }),
     getDataRange: () => ({ getValues: () => data.map((r) => [...r]) }),
     deleteRow: (rowIndex: number) => {
-      writes.push({ method: "deleteRow", args: [rowIndex] });
+      beginWrite("deleteRow", [rowIndex]);
       data.splice(rowIndex - 1, 1);
+      formulas.splice(rowIndex - 1, 1);
+    },
+    clearContents: () => {
+      if (config?.failOnClearContents) {
+        throw new Error("mock clearContents failure");
+      }
+      data.splice(0);
+      formulas.splice(0);
+    },
+    copyTo: (target: any) => {
+      copyToCalls += 1;
+      if (config?.failOnCopyTo) {
+        throw new Error("mock copyTo failure");
+      }
+      const copied = makeLoggedSheet(
+        `Copy of ${sheetName}`,
+        data.map((r) => [...r]),
+        {
+          formulas: formulas.map((r) =>
+            Array.from({ length: r.length }, (_, j) => r[j] ?? ""),
+          ),
+          formulaResults,
+        },
+      );
+      copied.setParent(target);
+      target._addSheet(copied.sheet);
+      return copied.sheet;
     },
   } as any;
-  return { sheet, snapshot: () => data.map((r) => [...r]), writes };
+  return {
+    sheet,
+    snapshot: () => data.map((r) => [...r]),
+    formulaSnapshot: () =>
+      data.map((r, i) =>
+        Array.from({ length: r.length }, (_, j) => formulas[i]?.[j] ?? ""),
+      ),
+    writes,
+    copyToCallCount: () => copyToCalls,
+    setParent: (spreadsheet: unknown) => {
+      parent = spreadsheet;
+    },
+  };
 };
 
 type TxTestEnvConfig = {
@@ -47,7 +148,11 @@ type TxTestEnvConfig = {
   cascade?: boolean;
   autoincrement?: boolean;
   waitLockError?: boolean;
+  usersConfig?: SheetMockConfig;
+  postsConfig?: SheetMockConfig;
 };
+
+type PropsCall = { method: string; key: string; value?: string };
 
 type TxTestEnv = {
   client: GassmaClient;
@@ -56,26 +161,49 @@ type TxTestEnv = {
   waitLock: jest.Mock;
   releaseLock: jest.Mock;
   propsStore: Record<string, string>;
+  propsLog: PropsCall[];
+  spreadsheet: any;
+  sheetNames: () => string[];
 };
 
 const buildTxTestEnv = (config?: TxTestEnvConfig): TxTestEnv => {
-  const users = makeLoggedSheet("Users", [
-    ["id", "name", "age"],
-    [1, "Alice", 20],
-    [2, "Bob", 30],
-  ]);
-  const posts = makeLoggedSheet("Posts", [
-    ["id", "authorId", "title"],
-    [101, 1, "Post A"],
-    [102, 2, "Post B"],
-  ]);
+  const users = makeLoggedSheet(
+    "Users",
+    [
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+    ],
+    config?.usersConfig,
+  );
+  const posts = makeLoggedSheet(
+    "Posts",
+    [
+      ["id", "authorId", "title"],
+      [101, 1, "Post A"],
+      [102, 2, "Post B"],
+    ],
+    config?.postsConfig,
+  );
   const sheets = [users.sheet, posts.sheet];
-  const spreadsheet = {
+  const spreadsheet: any = {
     getId: () => "tx-test",
     getSheets: () => sheets,
     getSheetByName: (n: string) =>
       sheets.find((s: any) => s.getName() === n) ?? null,
+    deleteSheet: (sheet: any) => {
+      const index = sheets.indexOf(sheet);
+      if (index === -1) {
+        throw new Error("mock deleteSheet: sheet not found");
+      }
+      sheets.splice(index, 1);
+    },
+    _addSheet: (sheet: any) => {
+      sheets.push(sheet);
+    },
   };
+  users.setParent(spreadsheet);
+  posts.setParent(spreadsheet);
   const waitLock = jest.fn(
     config?.waitLockError
       ? () => {
@@ -85,6 +213,7 @@ const buildTxTestEnv = (config?: TxTestEnvConfig): TxTestEnv => {
   );
   const releaseLock = jest.fn();
   const propsStore: Record<string, string> = {};
+  const propsLog: PropsCall[] = [];
   Object.assign(globalThis, {
     SpreadsheetApp: { getActiveSpreadsheet: () => spreadsheet },
     LockService: { getScriptLock: () => ({ waitLock, releaseLock }) },
@@ -92,8 +221,14 @@ const buildTxTestEnv = (config?: TxTestEnvConfig): TxTestEnv => {
       getScriptProperties: () => ({
         getProperty: (key: string) => propsStore[key] ?? null,
         setProperty: (key: string, value: string) => {
+          propsLog.push({ method: "setProperty", key, value });
           propsStore[key] = value;
         },
+        deleteProperty: (key: string) => {
+          propsLog.push({ method: "deleteProperty", key });
+          delete propsStore[key];
+        },
+        getKeys: () => Object.keys(propsStore),
       }),
     },
   });
@@ -128,7 +263,17 @@ const buildTxTestEnv = (config?: TxTestEnvConfig): TxTestEnv => {
     config?.relations || config?.autoincrement
       ? new GassmaClient(options)
       : new GassmaClient();
-  return { client, users, posts, waitLock, releaseLock, propsStore };
+  return {
+    client,
+    users,
+    posts,
+    waitLock,
+    releaseLock,
+    propsStore,
+    propsLog,
+    spreadsheet,
+    sheetNames: () => sheets.map((s: any) => s.getName()),
+  };
 };
 
 const clearGasGlobals = () => {
@@ -140,4 +285,4 @@ const clearGasGlobals = () => {
 };
 
 export { buildTxTestEnv, clearGasGlobals, makeLoggedSheet };
-export type { LoggedSheet, TxTestEnv };
+export type { LoggedSheet, SheetMockConfig, TxTestEnv };

--- a/src/errors/transaction/transactionError.ts
+++ b/src/errors/transaction/transactionError.ts
@@ -25,8 +25,24 @@ class GassmaNestedTransactionError extends Error {
   }
 }
 
+class GassmaTransactionRollbackError extends Error {
+  readonly backupSheetNames: string[];
+
+  constructor(backupSheetNames: string[]) {
+    const names = Array.isArray(backupSheetNames)
+      ? backupSheetNames
+      : [String(backupSheetNames)];
+    super(
+      `Transaction API error: The transaction failed during commit and automatic rollback also failed. The affected sheets may be in an inconsistent state. Backup sheets are preserved for manual recovery: ${names.join(", ")}`,
+    );
+    this.name = "GassmaTransactionRollbackError";
+    this.backupSheetNames = names;
+  }
+}
+
 export {
   GassmaNestedTransactionError,
   GassmaTransactionLockTimeoutError,
+  GassmaTransactionRollbackError,
   GassmaTransactionTimeoutError,
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -51,6 +51,7 @@ declare namespace Gassma {
   type GassmaTransactionOptions = {
     maxWait?: number;
     timeout?: number;
+    rollback?: boolean;
   };
 
   type GassmaTransactionClient = {
@@ -631,6 +632,10 @@ declare namespace Gassma {
   }
   class GassmaNestedTransactionError extends Error {
     constructor();
+  }
+  class GassmaTransactionRollbackError extends Error {
+    constructor(backupSheetNames: string[]);
+    readonly backupSheetNames: string[];
   }
 }
 

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -116,3 +116,5 @@ export const GassmaTransactionTimeoutError =
   transactionErrors.GassmaTransactionTimeoutError;
 export const GassmaNestedTransactionError =
   transactionErrors.GassmaNestedTransactionError;
+export const GassmaTransactionRollbackError =
+  transactionErrors.GassmaTransactionRollbackError;

--- a/src/types/transactionTypes.ts
+++ b/src/types/transactionTypes.ts
@@ -11,6 +11,7 @@ type SheetIo = {
 type GassmaTransactionOptions = {
   maxWait?: number;
   timeout?: number;
+  rollback?: boolean;
 };
 
 type TransactionClientCore = {

--- a/src/util/transaction/runTransaction.ts
+++ b/src/util/transaction/runTransaction.ts
@@ -8,6 +8,10 @@ import type {
   SheetIo,
 } from "../../types/transactionTypes";
 import { buildTransactionClient } from "./buildTransactionClient";
+import {
+  flushWithBackup,
+  warnStaleTransactionBackups,
+} from "./transactionBackup";
 import { createTransactionBuffer } from "./transactionBuffer";
 import { createTransactionDeadline } from "./transactionDeadline";
 
@@ -36,9 +40,11 @@ const runTransaction = <T>(
   }
   const maxWaitMs = options?.maxWait ?? DEFAULT_MAX_WAIT_MS;
   const timeoutMs = options?.timeout ?? DEFAULT_TIMEOUT_MS;
+  const rollback = options?.rollback ?? true;
   const lock = acquireScriptLock(maxWaitMs);
   transactionInProgress = true;
   try {
+    warnStaleTransactionBackups();
     const checkDeadline = createTransactionDeadline(timeoutMs);
     const buffer = createTransactionBuffer();
     const baseClient = buildBufferedClient({
@@ -48,7 +54,11 @@ const runTransaction = <T>(
     const tx = buildTransactionClient(baseClient, () => checkDeadline("query"));
     const result = fn(tx);
     checkDeadline("commit");
-    buffer.flush();
+    if (rollback) {
+      flushWithBackup(buffer);
+    } else {
+      buffer.flush();
+    }
     return result;
   } finally {
     transactionInProgress = false;

--- a/src/util/transaction/transactionBackup.ts
+++ b/src/util/transaction/transactionBackup.ts
@@ -1,0 +1,137 @@
+import { GassmaTransactionRollbackError } from "../../errors/transaction/transactionError";
+import type { TransactionBuffer } from "./transactionBuffer";
+
+type Sheet = GoogleAppsScript.Spreadsheet.Sheet;
+type Spreadsheet = GoogleAppsScript.Spreadsheet.Spreadsheet;
+
+const MARKER_KEY_PREFIX = "gassma_tx_backup_";
+const BACKUP_NAME_PREFIX = "_gassma_tx_";
+const SHEET_NAME_MAX_LENGTH = 100;
+
+type BackupEntry = { original: Sheet; backup: Sheet; backupName: string };
+
+type TransactionBackup = {
+  spreadsheet: Spreadsheet;
+  markerKey: string;
+  entries: BackupEntry[];
+};
+
+const buildBackupName = (
+  timestamp: number,
+  sheetName: string,
+  index: number,
+): string => {
+  const base = `${BACKUP_NAME_PREFIX}${timestamp}_${sheetName}`;
+  if (base.length <= SHEET_NAME_MAX_LENGTH) return base;
+  const suffix = `_${index}`;
+  return base.slice(0, SHEET_NAME_MAX_LENGTH - suffix.length) + suffix;
+};
+
+const warnStaleTransactionBackups = () => {
+  const props = PropertiesService.getScriptProperties();
+  props.getKeys().forEach((key) => {
+    if (!key.startsWith(MARKER_KEY_PREFIX)) return;
+    console.warn(
+      `Gassma: a stale transaction backup marker was found (${key} = ${props.getProperty(key)}). A previous transaction may have been interrupted before it completed. The listed backup sheets are kept for manual recovery.`,
+    );
+  });
+};
+
+const deleteBackupSheetQuietly = (
+  spreadsheet: Spreadsheet,
+  entry: BackupEntry,
+): boolean => {
+  try {
+    spreadsheet.deleteSheet(entry.backup);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const createTransactionBackup = (sheets: Sheet[]): TransactionBackup => {
+  const spreadsheet = sheets[0].getParent();
+  const timestamp = Date.now();
+  const entries: BackupEntry[] = [];
+  try {
+    sheets.forEach((original, index) => {
+      const backupName = buildBackupName(timestamp, original.getName(), index);
+      const backup = original.copyTo(spreadsheet);
+      entries.push({ original, backup, backupName });
+      backup.setName(backupName);
+      backup.hideSheet();
+    });
+  } catch (error) {
+    entries.forEach((entry) => {
+      deleteBackupSheetQuietly(spreadsheet, entry);
+    });
+    throw error;
+  }
+  const markerKey = `${MARKER_KEY_PREFIX}${spreadsheet.getId()}`;
+  PropertiesService.getScriptProperties().setProperty(
+    markerKey,
+    JSON.stringify(entries.map((entry) => entry.backupName)),
+  );
+  return { spreadsheet, markerKey, entries };
+};
+
+const restoreSheetContent = (original: Sheet, backup: Sheet) => {
+  const lastRow = backup.getLastRow();
+  const lastColumn = backup.getLastColumn();
+  original.clearContents();
+  if (lastRow < 1 || lastColumn < 1) return;
+  const range = backup.getRange(1, 1, lastRow, lastColumn);
+  const values: unknown[][] = range.getValues();
+  const formulas = range.getFormulas();
+  const merged = values.map((row, rowIndex) =>
+    row.map((value, columnIndex) => {
+      const formula = formulas[rowIndex][columnIndex];
+      return formula === "" ? value : formula;
+    }),
+  );
+  original.getRange(1, 1, lastRow, lastColumn).setValues(merged);
+};
+
+const restoreTransactionBackup = (backup: TransactionBackup) => {
+  try {
+    backup.entries.forEach((entry) => {
+      restoreSheetContent(entry.original, entry.backup);
+    });
+  } catch {
+    throw new GassmaTransactionRollbackError(
+      backup.entries.map((entry) => entry.backupName),
+    );
+  }
+};
+
+const cleanupTransactionBackup = (backup: TransactionBackup) => {
+  const allDeleted = backup.entries
+    .map((entry) => deleteBackupSheetQuietly(backup.spreadsheet, entry))
+    .every((deleted) => deleted);
+  if (!allDeleted) {
+    console.warn(
+      `Gassma: failed to delete some transaction backup sheets. The marker (${backup.markerKey}) is kept so the next transaction can report them.`,
+    );
+    return;
+  }
+  PropertiesService.getScriptProperties().deleteProperty(backup.markerKey);
+};
+
+const flushWithBackup = (buffer: TransactionBuffer) => {
+  const sheets = buffer.affectedSheets();
+  if (sheets.length === 0) {
+    buffer.flush();
+    return;
+  }
+  const backup = createTransactionBackup(sheets);
+  try {
+    buffer.flush();
+  } catch (flushError) {
+    restoreTransactionBackup(backup);
+    cleanupTransactionBackup(backup);
+    throw flushError;
+  }
+  cleanupTransactionBackup(backup);
+};
+
+export { buildBackupName, flushWithBackup, warnStaleTransactionBackups };

--- a/src/util/transaction/transactionBuffer.ts
+++ b/src/util/transaction/transactionBuffer.ts
@@ -8,10 +8,13 @@ import type { SheetOp } from "../write/bufferedSheetWriter";
 import type { SheetWriter } from "../write/sheetWriter";
 import { createVirtualSheetStore } from "./virtualSheetStore";
 
+type Sheet = GoogleAppsScript.Spreadsheet.Sheet;
+
 type TransactionBuffer = {
   writer: SheetWriter;
   reader: SheetReader;
   flush: () => void;
+  affectedSheets: () => Sheet[];
 };
 
 const createTransactionBuffer = (): TransactionBuffer => {
@@ -21,6 +24,13 @@ const createTransactionBuffer = (): TransactionBuffer => {
     writer: createBufferedSheetWriter(store, ops),
     reader: createBufferedSheetReader(store),
     flush: () => replaySheetOps(ops),
+    affectedSheets: () => {
+      const sheets: Sheet[] = [];
+      ops.forEach((op) => {
+        if (sheets.indexOf(op.sheet) === -1) sheets.push(op.sheet);
+      });
+      return sheets;
+    },
   };
 };
 


### PR DESCRIPTION
## 概要

**$transaction 3フェーズ計画の最終 Phase 3 = rollback** です(仕様承認済み: `rollback?: boolean` **既定 true**)。これで $transaction は仕様の完成形になり、リリース時セットが解禁されます。

## 動作(rollback: true 時)

1. fn 完走+commit deadline 通過後、**影響シートのみ**を `copyTo` → `_gassma_tx_<ts>_<シート名>` に改名+hidden(100文字上限は切り詰め+index で一意化)
2. **全 backup 作成完了後に** ScriptProperties へマーカー(spreadsheet 単位キー、backup 名一覧の JSON)— 作成途中で死んだ場合は1セルも書いていないので復旧不要、という順序設計
3. flush 成功 → backup 全削除+マーカー削除
4. **flush 中に例外** → **gid 維持の書き戻し復元**: swap(delete+rename)は外部参照式を #REF! に永久破壊するため不使用。`clearContents` → backup の `getValues()`+`getFormulas()` を**セル単位マージ**(数式があれば数式)して単一 `setValues()` で書き戻し(GAS は `=` 始まりを数式として解釈)→ 復元成功なら backup 削除+**元の例外を rethrow**
5. **復元も失敗** → backup を**全温存**(復元済みシート分も含む — 復旧素材を減らさない側に倒す)し、`GassmaTransactionRollbackError`(`backupSheetNames` プロパティ付き、公開 **50→51**)を throw
6. **stale マーカー検出**: タイムアウト死等の残骸を次回 $transaction 開始時に検出して**警告のみ**(死後の手動編集量が不明なため自動復元しない)

`{ rollback: false }` は Phase 2 の高速パスそのまま(copyTo ゼロをテストでピン)。

## エッジの設計判断(記録)

- backup 作成中の失敗: 作成済みコピーを best-effort 削除して中断(この時点で書き込みゼロ=安全)
- **コミット成功後の cleanup 失敗**: 例外化せず警告+マーカー温存(成功した commit を掃除失敗で失敗扱いにしない。次回の stale 警告が拾う)

## テスト

1717 → **1732(+15)**、既存は無変更 green(モック拡張のみ: copyTo/setName/hideSheet/getFormulas/失敗注入など)。新テスト: backup ライフサイクル / **failing writer 注入による mid-flush 失敗→数式込み完全復元** / 行数が変わる失敗からの復元 / 復元失敗→backup 温存+新エラー / stale 警告 / rollback:false。verify:bundle は宣言のみで Red(50/51)を実測→ Green(51)。**実バンドル 2 realm ハーネス**: 既存 26+19 に加え rollback 5 シナリオ(R1〜R5)一致。tsc / lint / format / build 全 green。

## マージ後

cli 追随(`GassmaTransactionOptions.rollback` 解禁 = #130 の「rollback は型エラー」ピンの反転 + RollbackError ミラー)→ gassma-test 追随(成功 tx の残骸なし・rollback:false・stale 警告の目視手順。mid-flush 失敗は実機で決定的に再現不能のため単体+モック担保)→ **$transaction 完成、リリース時セットへ**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtvX