### PR TITLE
perf: batch contiguous row writes in updateMany / deleteMany

### DIFF
--- a/src/__test__/consts/mockControllerUtil.ts
+++ b/src/__test__/consts/mockControllerUtil.ts
@@ -183,6 +183,9 @@ export const getMutableMockControllerUtil = (): MutableGassmaControllerUtil => {
       deleteRow: jest.fn((rowIndex: number) => {
         mockData.splice(rowIndex - 1, 1);
       }),
+      deleteRows: jest.fn((rowPosition: number, howMany: number) => {
+        mockData.splice(rowPosition - 1, howMany);
+      }),
       // Helper method to get current mock data state
       _getMockData: () => [...mockData],
       // Helper method to reset mock data

--- a/src/__test__/util/delete/deleteMany.test.ts
+++ b/src/__test__/util/delete/deleteMany.test.ts
@@ -252,6 +252,26 @@ describe("deleteMany functionality tests", () => {
       expect(deleteRowCallCount).toBe(EXPECTED_ENGINEER_COUNT);
     });
 
+    test("連続 3 行の削除でシートから該当行だけが消え他行が保存される", () => {
+      const result = deleteManyFunc(mockUtil, {
+        where: {
+          OR: [{ 名前: "Alice" }, { 名前: "Bob" }, { 名前: "Charlie" }],
+        },
+      });
+
+      expect(result).toEqual({ count: 3 });
+
+      const currentData = (mockUtil.sheet as any)._getMockData();
+      expect(currentData).toEqual([
+        ["名前", "年齢", "住所", "郵便番号", "職業"],
+        ["David", 45, "Kyoto", "600-8000", "Manager"],
+        ["Eve", 28, "Tokyo", "100-0003", "Engineer"],
+        ["Frank", 52, "Osaka", "550-0002", "Director"],
+        ["Grace", 31, "Tokyo", "100-0004", "Designer"],
+        ["Henry", 28, "Kyoto", "600-8001", "Engineer"],
+      ]);
+    });
+
     test("should handle empty where conditions gracefully", () => {
       const result = deleteManyFunc(mockUtil, {
         where: {},

--- a/src/__test__/util/transaction/transaction.test.ts
+++ b/src/__test__/util/transaction/transaction.test.ts
@@ -176,6 +176,85 @@ describe("$transaction の nested write / cascade", () => {
   });
 });
 
+describe("$transaction の updateMany / deleteMany 束ね", () => {
+  test("連続行の updateMany は tx 内でバッファされ flush で 1 回の setValues になる", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.updateMany({ data: { age: { increment: 1 } } });
+      expect(env.users.writes).toEqual([]);
+    });
+
+    expect(env.users.writes).toEqual([
+      {
+        method: "setValues",
+        args: [
+          2,
+          1,
+          [
+            [1, "Alice", 21],
+            [2, "Bob", 31],
+          ],
+        ],
+      },
+    ]);
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 21],
+      [2, "Bob", 31],
+    ]);
+  });
+
+  test("updateMany の行別 increment 結果が tx 内読み取りに見える", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.updateMany({ data: { age: { increment: 1 } } });
+      expect(tx.Users.findMany({})).toEqual([
+        { id: 1, name: "Alice", age: 21 },
+        { id: 2, name: "Bob", age: 31 },
+      ]);
+      expect(env.users.snapshot()).toEqual([
+        ["id", "name", "age"],
+        [1, "Alice", 20],
+        [2, "Bob", 30],
+      ]);
+    });
+  });
+
+  test("連続行の deleteMany は tx 内でバッファされ flush で 1 回の deleteRows になる", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.deleteMany({});
+      expect(tx.Users.count({})).toBe(0);
+      expect(env.users.writes).toEqual([]);
+    });
+
+    expect(env.users.writes).toEqual([{ method: "deleteRows", args: [2, 2] }]);
+    expect(env.users.snapshot()).toEqual([["id", "name", "age"]]);
+  });
+
+  test("deleteMany 後に create しても flush の発行順再生で行位置が一致する", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.deleteMany({ where: { id: 1 } });
+      tx.Users.create({ data: { id: 3, name: "Carol", age: 40 } });
+      expect(tx.Users.findMany({})).toEqual([
+        { id: 2, name: "Bob", age: 30 },
+        { id: 3, name: "Carol", age: 40 },
+      ]);
+    });
+
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [2, "Bob", 30],
+      [3, "Carol", 40],
+    ]);
+  });
+});
+
 describe("$transaction の autoincrement", () => {
   test("tx 内で即時採番され戻り値に入る", () => {
     const env = buildTxTestEnv({ autoincrement: true });

--- a/src/__test__/util/transaction/transactionBuffer.test.ts
+++ b/src/__test__/util/transaction/transactionBuffer.test.ts
@@ -1,7 +1,7 @@
+import type { GassmaControllerUtil } from "../../../types/gassmaControllerUtilType";
 import { getAllData } from "../../../util/core/getAllData";
 import { getTitle } from "../../../util/core/getTitle";
 import { createTransactionBuffer } from "../../../util/transaction/transactionBuffer";
-import type { GassmaControllerUtil } from "../../../types/gassmaControllerUtilType";
 import { makeLoggedSheet } from "./transactionTestClient";
 
 const initialUsers = [
@@ -27,6 +27,20 @@ describe("createTransactionBuffer の書き込みバッファ", () => {
 
     buffer.writer.updateRow(sheet, 2, 1, 3, [1, "Alice", 21]);
     buffer.writer.deleteRow(sheet, 3);
+
+    expect(writes).toEqual([]);
+    expect(snapshot()).toEqual(initialUsers);
+  });
+
+  test("updateRows / deleteRows も実シートに書かない", () => {
+    const { sheet, snapshot, writes } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.updateRows(sheet, 2, 1, 3, [
+      [1, "Alice", 21],
+      [2, "Bob", 31],
+    ]);
+    buffer.writer.deleteRows(sheet, 2, 2);
 
     expect(writes).toEqual([]);
     expect(snapshot()).toEqual(initialUsers);
@@ -66,6 +80,33 @@ describe("createTransactionBuffer の読み取りオーバーレイ", () => {
     expect(buffer.reader.getLastRow(sheet)).toBe(2);
     expect(buffer.reader.getRangeValues(sheet, 2, 1, 1, 3)).toEqual([
       [2, "Bob", 30],
+    ]);
+  });
+
+  test("updateRows の行ごとの変更が読み取りに見える", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.updateRows(sheet, 2, 1, 3, [
+      [1, "Alice", 21],
+      [2, "Bob", 31],
+    ]);
+
+    expect(buffer.reader.getRangeValues(sheet, 2, 1, 2, 3)).toEqual([
+      [1, "Alice", 21],
+      [2, "Bob", 31],
+    ]);
+  });
+
+  test("deleteRows で複数行がまとめて詰まる", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.deleteRows(sheet, 2, 2);
+
+    expect(buffer.reader.getLastRow(sheet)).toBe(1);
+    expect(buffer.reader.getRangeValues(sheet, 1, 1, 1, 3)).toEqual([
+      ["id", "name", "age"],
     ]);
   });
 
@@ -122,6 +163,65 @@ describe("flush の発行順再生", () => {
       { method: "deleteRow", args: [2] },
     ]);
     expect(snapshot()).toEqual([["id", "name", "age"]]);
+  });
+
+  test("updateRows は flush で 1 回の setValues として再生される", () => {
+    const { sheet, snapshot, writes } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.updateRows(sheet, 2, 1, 3, [
+      [1, "Alice", 21],
+      [2, "Bob", 31],
+    ]);
+    buffer.flush();
+
+    expect(writes).toEqual([
+      {
+        method: "setValues",
+        args: [
+          2,
+          1,
+          [
+            [1, "Alice", 21],
+            [2, "Bob", 31],
+          ],
+        ],
+      },
+    ]);
+    expect(snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 21],
+      [2, "Bob", 31],
+    ]);
+  });
+
+  test("deleteRows は flush で 1 回の deleteRows として再生される", () => {
+    const { sheet, snapshot, writes } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.deleteRows(sheet, 2, 2);
+    buffer.flush();
+
+    expect(writes).toEqual([{ method: "deleteRows", args: [2, 2] }]);
+    expect(snapshot()).toEqual([["id", "name", "age"]]);
+  });
+
+  test("deleteRows 後の append の交錯も発行順の再生で行位置が一致する", () => {
+    const { sheet, snapshot, writes } = makeLoggedSheet("Users", initialUsers);
+    const buffer = createTransactionBuffer();
+
+    buffer.writer.deleteRows(sheet, 2, 2);
+    buffer.writer.appendRows(sheet, 1, 3, [[3, "Carol", 40]]);
+    buffer.flush();
+
+    expect(writes).toEqual([
+      { method: "deleteRows", args: [2, 2] },
+      { method: "setValues", args: [2, 1, [[3, "Carol", 40]]] },
+    ]);
+    expect(snapshot()).toEqual([
+      ["id", "name", "age"],
+      [3, "Carol", 40],
+    ]);
   });
 });
 

--- a/src/__test__/util/transaction/transactionRollback.test.ts
+++ b/src/__test__/util/transaction/transactionRollback.test.ts
@@ -159,6 +159,37 @@ describe("mid-flush 失敗からの復元", () => {
     expect(env.propsStore[MARKER_KEY]).toBeUndefined();
   });
 
+  test("updateMany の一括 setValues が失敗しても全行が復元される", () => {
+    const env = buildTxTestEnv({
+      usersConfig: { failOnWriteCall: 1 },
+    });
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.updateMany({ data: { age: { increment: 1 } } });
+      }),
+    ).toThrow("mock write failure at call 1");
+
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.sheetNames()).toEqual(["Users", "Posts"]);
+    expect(env.propsStore[MARKER_KEY]).toBeUndefined();
+  });
+
+  test("deleteMany の一括 deleteRows が失敗しても行数が戻る", () => {
+    const env = buildTxTestEnv({
+      usersConfig: { failOnWriteCall: 1 },
+    });
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.deleteMany({});
+      }),
+    ).toThrow("mock write failure at call 1");
+
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.propsStore[MARKER_KEY]).toBeUndefined();
+  });
+
   test("エラー後は再び $transaction を開始できる", () => {
     const env = buildTxTestEnv({
       usersConfig: { failOnWriteCall: 1 },

--- a/src/__test__/util/transaction/transactionTestClient.ts
+++ b/src/__test__/util/transaction/transactionTestClient.ts
@@ -101,6 +101,11 @@ const makeLoggedSheet = (
       data.splice(rowIndex - 1, 1);
       formulas.splice(rowIndex - 1, 1);
     },
+    deleteRows: (rowPosition: number, howMany: number) => {
+      beginWrite("deleteRows", [rowPosition, howMany]);
+      data.splice(rowPosition - 1, howMany);
+      formulas.splice(rowPosition - 1, howMany);
+    },
     clearContents: () => {
       if (config?.failOnClearContents) {
         throw new Error("mock clearContents failure");

--- a/src/__test__/util/update/updateMany.test.ts
+++ b/src/__test__/util/update/updateMany.test.ts
@@ -559,6 +559,38 @@ describe("updateMany NumberOperation tests", () => {
     expect(davidRow[1]).toBe(22.5); // 45 / 2
   });
 
+  test("連続行への increment は各行の元値から計算されシートに行別の値が書かれる", () => {
+    const result = updateManyFunc(mockUtil, {
+      where: { OR: [{ 名前: "Alice" }, { 名前: "Bob" }, { 名前: "Charlie" }] },
+      data: { 年齢: { increment: 5 } },
+    });
+
+    expect(result).toEqual({ count: 3 });
+
+    const currentData = (mockUtil.sheet as any)._getMockData();
+    expect(currentData[1]).toEqual([
+      "Alice",
+      33,
+      "Tokyo",
+      "100-0001",
+      "Engineer",
+    ]);
+    expect(currentData[2]).toEqual([
+      "Bob",
+      40,
+      "Osaka",
+      "550-0001",
+      "Designer",
+    ]);
+    expect(currentData[3]).toEqual([
+      "Charlie",
+      27,
+      "Tokyo",
+      "100-0002",
+      "Student",
+    ]);
+  });
+
   test("NumberOperation と通常値の混在が正しく動作する", () => {
     const result = updateManyFunc(mockUtil, {
       where: { 名前: "Eve" },

--- a/src/__test__/util/write/rowRuns.test.ts
+++ b/src/__test__/util/write/rowRuns.test.ts
@@ -1,0 +1,132 @@
+import {
+  groupDeleteBlocksDescending,
+  groupUpdateRuns,
+} from "../../../util/write/rowRuns";
+
+describe("groupUpdateRuns", () => {
+  test("連続する行番号は 1 ランにまとまり、行ごとの値が行順で 2D 配列になる", () => {
+    const runs = groupUpdateRuns([
+      { rowNumber: 2, row: ["a", 1] },
+      { rowNumber: 3, row: ["b", 2] },
+      { rowNumber: 4, row: ["c", 3] },
+    ]);
+
+    expect(runs).toEqual([
+      {
+        startRowNumber: 2,
+        rows: [
+          ["a", 1],
+          ["b", 2],
+          ["c", 3],
+        ],
+      },
+    ]);
+  });
+
+  test("1 行おきの行はそれぞれ別ランになる", () => {
+    const runs = groupUpdateRuns([
+      { rowNumber: 2, row: ["a"] },
+      { rowNumber: 4, row: ["b"] },
+      { rowNumber: 6, row: ["c"] },
+    ]);
+
+    expect(runs).toEqual([
+      { startRowNumber: 2, rows: [["a"]] },
+      { startRowNumber: 4, rows: [["b"]] },
+      { startRowNumber: 6, rows: [["c"]] },
+    ]);
+  });
+
+  test("連続ブロックが 2 つあれば 2 ランになる", () => {
+    const runs = groupUpdateRuns([
+      { rowNumber: 2, row: ["a"] },
+      { rowNumber: 3, row: ["b"] },
+      { rowNumber: 6, row: ["c"] },
+      { rowNumber: 7, row: ["d"] },
+    ]);
+
+    expect(runs).toEqual([
+      { startRowNumber: 2, rows: [["a"], ["b"]] },
+      { startRowNumber: 6, rows: [["c"], ["d"]] },
+    ]);
+  });
+
+  test("入力順が乱れていても行番号昇順に並べてまとめる", () => {
+    const runs = groupUpdateRuns([
+      { rowNumber: 4, row: ["c"] },
+      { rowNumber: 2, row: ["a"] },
+      { rowNumber: 3, row: ["b"] },
+    ]);
+
+    expect(runs).toEqual([{ startRowNumber: 2, rows: [["a"], ["b"], ["c"]] }]);
+  });
+
+  test("入力の並びは破壊しない", () => {
+    const entries = [
+      { rowNumber: 4, row: ["c"] },
+      { rowNumber: 2, row: ["a"] },
+    ];
+
+    groupUpdateRuns(entries);
+
+    expect(entries.map((entry) => entry.rowNumber)).toEqual([4, 2]);
+  });
+
+  test("単一行は 1 ランになる", () => {
+    expect(groupUpdateRuns([{ rowNumber: 5, row: ["a"] }])).toEqual([
+      { startRowNumber: 5, rows: [["a"]] },
+    ]);
+  });
+
+  test("空入力は空配列を返す", () => {
+    expect(groupUpdateRuns([])).toEqual([]);
+  });
+});
+
+describe("groupDeleteBlocksDescending", () => {
+  test("連続行は先頭行番号と行数の 1 ブロックにまとまる", () => {
+    expect(groupDeleteBlocksDescending([2, 3, 4])).toEqual([
+      { rowPosition: 2, howMany: 3 },
+    ]);
+  });
+
+  test("ブロックは行番号降順に並ぶ", () => {
+    expect(groupDeleteBlocksDescending([2, 3, 7, 8])).toEqual([
+      { rowPosition: 7, howMany: 2 },
+      { rowPosition: 2, howMany: 2 },
+    ]);
+  });
+
+  test("散在行は各 1 行ブロックとして降順に並ぶ", () => {
+    expect(groupDeleteBlocksDescending([2, 4, 6])).toEqual([
+      { rowPosition: 6, howMany: 1 },
+      { rowPosition: 4, howMany: 1 },
+      { rowPosition: 2, howMany: 1 },
+    ]);
+  });
+
+  test("入力順が乱れていても降順にブロック化する", () => {
+    expect(groupDeleteBlocksDescending([8, 2, 7, 3])).toEqual([
+      { rowPosition: 7, howMany: 2 },
+      { rowPosition: 2, howMany: 2 },
+    ]);
+  });
+
+  test("入力の並びは破壊しない", () => {
+    const rowNumbers = [8, 2, 7, 3];
+
+    groupDeleteBlocksDescending(rowNumbers);
+
+    expect(rowNumbers).toEqual([8, 2, 7, 3]);
+  });
+
+  test("単一行は 1 行ブロックになる", () => {
+    expect(groupDeleteBlocksDescending([5])).toEqual([
+      { rowPosition: 5, howMany: 1 },
+    ]);
+  });
+
+  test("空入力は空配列を返す", () => {
+    expect(groupDeleteBlocksDescending([])).toEqual([]);
+  });
+});

--- a/src/__test__/util/write/sheetWriter.test.ts
+++ b/src/__test__/util/write/sheetWriter.test.ts
@@ -1,13 +1,13 @@
+import { createFunc } from "../../../util/create/create";
+import { createManyFunc } from "../../../util/create/createManyFunc";
+import { deleteManyFunc } from "../../../util/delete/deleteMany";
+import { resolveNestedUpdate } from "../../../util/update/nestedWrite/resolveNestedUpdate";
+import { updateManyFunc } from "../../../util/update/updateMany";
+import type { SheetWriter } from "../../../util/write/sheetWriter";
 import {
   immediateSheetWriter,
   resolveWriter,
 } from "../../../util/write/sheetWriter";
-import type { SheetWriter } from "../../../util/write/sheetWriter";
-import { createFunc } from "../../../util/create/create";
-import { createManyFunc } from "../../../util/create/createManyFunc";
-import { updateManyFunc } from "../../../util/update/updateMany";
-import { deleteManyFunc } from "../../../util/delete/deleteMany";
-import { resolveNestedUpdate } from "../../../util/update/nestedWrite/resolveNestedUpdate";
 import { getMutableMockControllerUtil } from "../../consts/mockControllerUtil";
 
 type WriterCall = { method: string; args: unknown[] };
@@ -27,8 +27,23 @@ const createFakeWriter = (): { writer: SheetWriter; calls: WriterCall[] } => {
         args: [sheet, rowNumber, startColumnNumber, columnLength, row],
       });
     },
+    updateRows: (
+      sheet,
+      startRowNumber,
+      startColumnNumber,
+      columnLength,
+      rows,
+    ) => {
+      calls.push({
+        method: "updateRows",
+        args: [sheet, startRowNumber, startColumnNumber, columnLength, rows],
+      });
+    },
     deleteRow: (sheet, rowNumber) => {
       calls.push({ method: "deleteRow", args: [sheet, rowNumber] });
+    },
+    deleteRows: (sheet, rowPosition, howMany) => {
+      calls.push({ method: "deleteRows", args: [sheet, rowPosition, howMany] });
     },
   };
   return { writer, calls };
@@ -41,6 +56,7 @@ const createSpySheet = () => {
     getLastRow: jest.fn(() => 9),
     getRange,
     deleteRow: jest.fn(),
+    deleteRows: jest.fn(),
   } as any;
   return { sheet, getRange, setValues };
 };
@@ -77,6 +93,32 @@ describe("immediateSheetWriter", () => {
     immediateSheetWriter.deleteRow(sheet, 7);
 
     expect(sheet.deleteRow).toHaveBeenCalledWith(7);
+    expect(getRange).not.toHaveBeenCalled();
+  });
+
+  test("updateRows は連続行の範囲に 1 回の setValues で書く", () => {
+    const { sheet, getRange, setValues } = createSpySheet();
+    const rows = [
+      ["a", 1, "x"],
+      ["b", 2, "y"],
+    ];
+
+    immediateSheetWriter.updateRows(sheet, 5, 2, 3, rows);
+
+    expect(getRange).toHaveBeenCalledTimes(1);
+    expect(getRange).toHaveBeenCalledWith(5, 2, 2, 3);
+    expect(setValues).toHaveBeenCalledWith(rows);
+    expect(sheet.getLastRow).not.toHaveBeenCalled();
+  });
+
+  test("deleteRows は sheet.deleteRows を 1 回で呼ぶ", () => {
+    const { sheet, getRange } = createSpySheet();
+
+    immediateSheetWriter.deleteRows(sheet, 4, 3);
+
+    expect(sheet.deleteRows).toHaveBeenCalledTimes(1);
+    expect(sheet.deleteRows).toHaveBeenCalledWith(4, 3);
+    expect(sheet.deleteRow).not.toHaveBeenCalled();
     expect(getRange).not.toHaveBeenCalled();
   });
 });

--- a/src/__test__/util/write/writeCallBatching.test.ts
+++ b/src/__test__/util/write/writeCallBatching.test.ts
@@ -1,0 +1,483 @@
+import { deleteManyFunc } from "../../../util/delete/deleteMany";
+import { updateManyFunc } from "../../../util/update/updateMany";
+import type { SheetWriter } from "../../../util/write/sheetWriter";
+import { getMutableMockControllerUtil } from "../../consts/mockControllerUtil";
+
+type WriterCall = { method: string; args: unknown[] };
+
+const createCountingWriter = (): {
+  writer: SheetWriter;
+  calls: WriterCall[];
+} => {
+  const calls: WriterCall[] = [];
+  const writer: SheetWriter = {
+    appendRows: (_sheet, startColumnNumber, columnLength, rows) => {
+      calls.push({
+        method: "appendRows",
+        args: [startColumnNumber, columnLength, rows],
+      });
+    },
+    updateRow: (_sheet, rowNumber, startColumnNumber, columnLength, row) => {
+      calls.push({
+        method: "updateRow",
+        args: [rowNumber, startColumnNumber, columnLength, row],
+      });
+    },
+    updateRows: (
+      _sheet,
+      startRowNumber,
+      startColumnNumber,
+      columnLength,
+      rows,
+    ) => {
+      calls.push({
+        method: "updateRows",
+        args: [startRowNumber, startColumnNumber, columnLength, rows],
+      });
+    },
+    deleteRow: (_sheet, rowNumber) => {
+      calls.push({ method: "deleteRow", args: [rowNumber] });
+    },
+    deleteRows: (_sheet, rowPosition, howMany) => {
+      calls.push({ method: "deleteRows", args: [rowPosition, howMany] });
+    },
+  };
+  return { writer, calls };
+};
+
+const buildUtil = () => {
+  const util = getMutableMockControllerUtil();
+  const { writer, calls } = createCountingWriter();
+  util.writer = writer;
+  return { util, calls };
+};
+
+describe("updateManyFunc の書き込みコール束ね", () => {
+  test("連続 3 行のマッチは 1 回の updateRows にまとまる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = updateManyFunc(util, {
+      where: { OR: [{ 名前: "Alice" }, { 名前: "Bob" }, { 名前: "Charlie" }] },
+      data: { 職業: "Updated" },
+    });
+
+    expect(result).toEqual({ count: 3 });
+    expect(calls).toEqual([
+      {
+        method: "updateRows",
+        args: [
+          2,
+          1,
+          5,
+          [
+            ["Alice", 28, "Tokyo", "100-0001", "Updated"],
+            ["Bob", 35, "Osaka", "550-0001", "Updated"],
+            ["Charlie", 22, "Tokyo", "100-0002", "Updated"],
+          ],
+        ],
+      },
+    ]);
+  });
+
+  test("全行マッチ(連続 8 行)は 1 回の updateRows にまとまる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = updateManyFunc(util, { data: { 職業: "Updated" } });
+
+    expect(result).toEqual({ count: 8 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("updateRows");
+    expect(calls[0].args[0]).toBe(2);
+    expect(calls[0].args[3]).toHaveLength(8);
+  });
+
+  test("1 行おきの散在マッチは行数ぶんの updateRow になる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = updateManyFunc(util, {
+      where: { 住所: "Tokyo" },
+      data: { 郵便番号: "999-9999" },
+    });
+
+    expect(result).toEqual({ count: 4 });
+    expect(calls).toEqual([
+      {
+        method: "updateRow",
+        args: [2, 1, 5, ["Alice", 28, "Tokyo", "999-9999", "Engineer"]],
+      },
+      {
+        method: "updateRow",
+        args: [4, 1, 5, ["Charlie", 22, "Tokyo", "999-9999", "Student"]],
+      },
+      {
+        method: "updateRow",
+        args: [6, 1, 5, ["Eve", 28, "Tokyo", "999-9999", "Engineer"]],
+      },
+      {
+        method: "updateRow",
+        args: [8, 1, 5, ["Grace", 31, "Tokyo", "999-9999", "Designer"]],
+      },
+    ]);
+  });
+
+  test("連続 2 ブロックのマッチは 2 回の updateRows になる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = updateManyFunc(util, {
+      where: {
+        OR: [
+          { 名前: "Alice" },
+          { 名前: "Bob" },
+          { 名前: "Eve" },
+          { 名前: "Frank" },
+        ],
+      },
+      data: { 職業: "Updated" },
+    });
+
+    expect(result).toEqual({ count: 4 });
+    expect(calls).toEqual([
+      {
+        method: "updateRows",
+        args: [
+          2,
+          1,
+          5,
+          [
+            ["Alice", 28, "Tokyo", "100-0001", "Updated"],
+            ["Bob", 35, "Osaka", "550-0001", "Updated"],
+          ],
+        ],
+      },
+      {
+        method: "updateRows",
+        args: [
+          6,
+          1,
+          5,
+          [
+            ["Eve", 28, "Tokyo", "100-0003", "Updated"],
+            ["Frank", 52, "Osaka", "550-0002", "Updated"],
+          ],
+        ],
+      },
+    ]);
+  });
+
+  test("単一行マッチは従来どおり 1 回の updateRow になる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = updateManyFunc(util, {
+      where: { 名前: "David" },
+      data: { 職業: "Updated" },
+    });
+
+    expect(result).toEqual({ count: 1 });
+    expect(calls).toEqual([
+      {
+        method: "updateRow",
+        args: [5, 1, 5, ["David", 45, "Kyoto", "600-8000", "Updated"]],
+      },
+    ]);
+  });
+
+  test("マッチ 0 件では書き込みコールしない", () => {
+    const { util, calls } = buildUtil();
+
+    const result = updateManyFunc(util, {
+      where: { 名前: "Nobody" },
+      data: { 職業: "Updated" },
+    });
+
+    expect(result).toEqual({ count: 0 });
+    expect(calls).toEqual([]);
+  });
+
+  test("limit 適用後の連続行も 1 回の updateRows にまとまる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = updateManyFunc(util, {
+      where: { OR: [{ 名前: "Alice" }, { 名前: "Bob" }, { 名前: "Charlie" }] },
+      data: { 職業: "Updated" },
+      limit: 2,
+    });
+
+    expect(result).toEqual({ count: 2 });
+    expect(calls).toEqual([
+      {
+        method: "updateRows",
+        args: [
+          2,
+          1,
+          5,
+          [
+            ["Alice", 28, "Tokyo", "100-0001", "Updated"],
+            ["Bob", 35, "Osaka", "550-0001", "Updated"],
+          ],
+        ],
+      },
+    ]);
+  });
+
+  test("increment は行ごとの既存値から個別計算され 2D 配列に行別の結果が積まれる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = updateManyFunc(util, {
+      where: { OR: [{ 名前: "Alice" }, { 名前: "Bob" }, { 名前: "Charlie" }] },
+      data: { 年齢: { increment: 5 } },
+    });
+
+    expect(result).toEqual({ count: 3 });
+    expect(calls).toEqual([
+      {
+        method: "updateRows",
+        args: [
+          2,
+          1,
+          5,
+          [
+            ["Alice", 33, "Tokyo", "100-0001", "Engineer"],
+            ["Bob", 40, "Osaka", "550-0001", "Designer"],
+            ["Charlie", 27, "Tokyo", "100-0002", "Student"],
+          ],
+        ],
+      },
+    ]);
+  });
+
+  test("更新対象が一部列のみでも各行の非対象セルがその行の値のまま保存される", () => {
+    const { util, calls } = buildUtil();
+
+    updateManyFunc(util, {
+      where: { OR: [{ 名前: "Alice" }, { 名前: "Bob" }, { 名前: "Charlie" }] },
+      data: { 郵便番号: "000-0000" },
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "updateRows",
+        args: [
+          2,
+          1,
+          5,
+          [
+            ["Alice", 28, "Tokyo", "000-0000", "Engineer"],
+            ["Bob", 35, "Osaka", "000-0000", "Designer"],
+            ["Charlie", 22, "Tokyo", "000-0000", "Student"],
+          ],
+        ],
+      },
+    ]);
+  });
+
+  test("記述式エスケープは各行に適用され、返り値レコードは元の値を保つ", () => {
+    const { util, calls } = buildUtil();
+
+    const records = updateManyFunc(
+      util,
+      {
+        where: { OR: [{ 名前: "Alice" }, { 名前: "Bob" }] },
+        data: { 住所: "=SUM(A1)" },
+      },
+      true,
+    );
+
+    expect(calls).toEqual([
+      {
+        method: "updateRows",
+        args: [
+          2,
+          1,
+          5,
+          [
+            ["Alice", 28, "'=SUM(A1)", "100-0001", "Engineer"],
+            ["Bob", 35, "'=SUM(A1)", "550-0001", "Designer"],
+          ],
+        ],
+      },
+    ]);
+    expect(records.map((record) => record["住所"])).toEqual([
+      "=SUM(A1)",
+      "=SUM(A1)",
+    ]);
+  });
+
+  test("返り値レコードは書き込みを束ねても findedData の元順と内容を維持する", () => {
+    const { util, calls } = buildUtil();
+
+    const records = updateManyFunc(
+      util,
+      {
+        where: { OR: [{ 名前: "Frank" }, { 名前: "Alice" }] },
+        data: { 職業: "Updated" },
+      },
+      true,
+    );
+
+    expect(records).toEqual([
+      {
+        名前: "Frank",
+        年齢: 52,
+        住所: "Osaka",
+        郵便番号: "550-0002",
+        職業: "Updated",
+      },
+      {
+        名前: "Alice",
+        年齢: 28,
+        住所: "Tokyo",
+        郵便番号: "100-0001",
+        職業: "Updated",
+      },
+    ]);
+    expect(calls).toEqual([
+      {
+        method: "updateRow",
+        args: [2, 1, 5, ["Alice", 28, "Tokyo", "100-0001", "Updated"]],
+      },
+      {
+        method: "updateRow",
+        args: [7, 1, 5, ["Frank", 52, "Osaka", "550-0002", "Updated"]],
+      },
+    ]);
+  });
+
+  test("空行スキップはランを分断し、前後の行を詰めて書かない", () => {
+    const { util, calls } = buildUtil();
+    const whereFilterSpy = jest.spyOn(
+      require("../../../util/core/whereFilter"),
+      "whereFilter",
+    );
+    whereFilterSpy.mockReturnValueOnce([
+      { rowNumber: 1, row: ["Alice", 28, "Tokyo", "100-0001", "Engineer"] },
+      { rowNumber: 2, row: [] },
+      { rowNumber: 3, row: ["Charlie", 22, "Tokyo", "100-0002", "Student"] },
+    ]);
+
+    const result = updateManyFunc(util, {
+      where: { 名前: "unused" },
+      data: { 職業: "Updated" },
+    });
+
+    expect(result).toEqual({ count: 3 });
+    expect(calls).toEqual([
+      {
+        method: "updateRow",
+        args: [2, 1, 5, ["Alice", 28, "Tokyo", "100-0001", "Updated"]],
+      },
+      {
+        method: "updateRow",
+        args: [4, 1, 5, ["Charlie", 22, "Tokyo", "100-0002", "Updated"]],
+      },
+    ]);
+    whereFilterSpy.mockRestore();
+  });
+});
+
+describe("deleteManyFunc の削除コール束ね", () => {
+  test("連続 3 行のマッチは 1 回の deleteRows にまとまる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = deleteManyFunc(util, {
+      where: { OR: [{ 名前: "Alice" }, { 名前: "Bob" }, { 名前: "Charlie" }] },
+    });
+
+    expect(result).toEqual({ count: 3 });
+    expect(calls).toEqual([{ method: "deleteRows", args: [2, 3] }]);
+  });
+
+  test("全行マッチ(連続 8 行)は 1 回の deleteRows にまとまる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = deleteManyFunc(util, { where: {} });
+
+    expect(result).toEqual({ count: 8 });
+    expect(calls).toEqual([{ method: "deleteRows", args: [2, 8] }]);
+  });
+
+  test("1 行おきの散在マッチは行数ぶんの deleteRow を降順で呼ぶ", () => {
+    const { util, calls } = buildUtil();
+
+    const result = deleteManyFunc(util, { where: { 住所: "Tokyo" } });
+
+    expect(result).toEqual({ count: 4 });
+    expect(calls).toEqual([
+      { method: "deleteRow", args: [8] },
+      { method: "deleteRow", args: [6] },
+      { method: "deleteRow", args: [4] },
+      { method: "deleteRow", args: [2] },
+    ]);
+  });
+
+  test("連続 2 ブロックのマッチはブロックごとの deleteRows を降順で呼ぶ", () => {
+    const { util, calls } = buildUtil();
+
+    const result = deleteManyFunc(util, {
+      where: {
+        OR: [
+          { 名前: "Alice" },
+          { 名前: "Bob" },
+          { 名前: "Eve" },
+          { 名前: "Frank" },
+        ],
+      },
+    });
+
+    expect(result).toEqual({ count: 4 });
+    expect(calls).toEqual([
+      { method: "deleteRows", args: [6, 2] },
+      { method: "deleteRows", args: [2, 2] },
+    ]);
+  });
+
+  test("ブロックと単一行の混在は降順のまま束ねる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = deleteManyFunc(util, {
+      where: {
+        OR: [
+          { 名前: "Alice" },
+          { 名前: "Bob" },
+          { 名前: "Charlie" },
+          { 名前: "Frank" },
+        ],
+      },
+    });
+
+    expect(result).toEqual({ count: 4 });
+    expect(calls).toEqual([
+      { method: "deleteRow", args: [7] },
+      { method: "deleteRows", args: [2, 3] },
+    ]);
+  });
+
+  test("単一行マッチは従来どおり 1 回の deleteRow になる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = deleteManyFunc(util, { where: { 名前: "David" } });
+
+    expect(result).toEqual({ count: 1 });
+    expect(calls).toEqual([{ method: "deleteRow", args: [5] }]);
+  });
+
+  test("マッチ 0 件では削除コールしない", () => {
+    const { util, calls } = buildUtil();
+
+    const result = deleteManyFunc(util, { where: { 名前: "Nobody" } });
+
+    expect(result).toEqual({ count: 0 });
+    expect(calls).toEqual([]);
+  });
+
+  test("limit 適用後の連続行も 1 回の deleteRows にまとまる", () => {
+    const { util, calls } = buildUtil();
+
+    const result = deleteManyFunc(util, {
+      where: { OR: [{ 名前: "Alice" }, { 名前: "Bob" }, { 名前: "Charlie" }] },
+      limit: 2,
+    });
+
+    expect(result).toEqual({ count: 2 });
+    expect(calls).toEqual([{ method: "deleteRows", args: [2, 2] }]);
+  });
+});

--- a/src/util/delete/deleteMany.ts
+++ b/src/util/delete/deleteMany.ts
@@ -1,7 +1,8 @@
+import { GassmaLimitNegativeError } from "../../errors/find/findError";
 import type { DeleteData, DeleteManyReturn } from "../../types/findTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
-import { GassmaLimitNegativeError } from "../../errors/find/findError";
 import { whereFilter } from "../core/whereFilter";
+import { groupDeleteBlocksDescending } from "../write/rowRuns";
 import { resolveWriter } from "../write/sheetWriter";
 
 const deleteManyFunc = (
@@ -23,13 +24,18 @@ const deleteManyFunc = (
   const findedDataLength = findedData.length;
 
   // 行を後ろから削除することで、削除による行番号のずれを回避
-  // sortDescendingを使って降順にソート
-  const sortedData = findedData.sort((a, b) => b.rowNumber - a.rowNumber);
+  // 連続する行はブロックにまとめて 1 コールで削除する
+  const actualRowNumbers = findedData.map(
+    (row) => row.rowNumber + startRowNumber,
+  );
 
   const writer = resolveWriter(gassmaControllerUtil.writer);
-  sortedData.forEach((row) => {
-    const actualRowNumber = row.rowNumber + startRowNumber;
-    writer.deleteRow(sheet, actualRowNumber);
+  groupDeleteBlocksDescending(actualRowNumbers).forEach((block) => {
+    if (block.howMany === 1) {
+      writer.deleteRow(sheet, block.rowPosition);
+      return;
+    }
+    writer.deleteRows(sheet, block.rowPosition, block.howMany);
   });
 
   return { count: findedDataLength };

--- a/src/util/transaction/virtualSheetStore.ts
+++ b/src/util/transaction/virtualSheetStore.ts
@@ -76,6 +76,10 @@ const createVirtualSheetStore = () => {
     getVirtual(sheet).grid.splice(rowNumber - 1, 1);
   };
 
+  const deleteRows = (sheet: Sheet, rowPosition: number, howMany: number) => {
+    getVirtual(sheet).grid.splice(rowPosition - 1, howMany);
+  };
+
   const getLastRow = (sheet: Sheet): number => getVirtual(sheet).grid.length;
 
   const getRangeValues = (
@@ -95,7 +99,14 @@ const createVirtualSheetStore = () => {
     });
   };
 
-  return { appendRows, updateRow, deleteRow, getLastRow, getRangeValues };
+  return {
+    appendRows,
+    updateRow,
+    deleteRow,
+    deleteRows,
+    getLastRow,
+    getRangeValues,
+  };
 };
 
 type VirtualSheetStore = ReturnType<typeof createVirtualSheetStore>;

--- a/src/util/update/updateMany.ts
+++ b/src/util/update/updateMany.ts
@@ -1,15 +1,16 @@
+import { GassmaLimitNegativeError } from "../../errors/find/findError";
 import type { UpdateData, UpdateManyReturn } from "../../types/findTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
+import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
 import { getTitle } from "../core/getTitle";
 import { getWantUpdateIndex } from "../core/getWantUpdateIndex";
 import { whereFilter } from "../core/whereFilter";
-import { GassmaLimitNegativeError } from "../../errors/find/findError";
+import { groupUpdateRuns } from "../write/rowRuns";
+import { resolveWriter } from "../write/sheetWriter";
 import {
   isNumberOperation,
   resolveNumberOperation,
 } from "./resolveNumberOperation";
-import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
-import { resolveWriter } from "../write/sheetWriter";
 
 function updateManyFunc(
   gassmaControllerUtil: GassmaControllerUtil,
@@ -48,7 +49,7 @@ function updateManyFunc(
   const wantUpdateIndex = getWantUpdateIndex(gassmaControllerUtil, updateData);
   const ColumnLength = endColumnNumber - startColumnNumber + 1;
 
-  const records = findedData.map((row) => {
+  const updates = findedData.map((row) => {
     const updatedRow = row.row.map((cell, cellIndex) => {
       if (!wantUpdateIndex.includes(cellIndex)) return cell;
       const value = data[String(titles[cellIndex])];
@@ -58,22 +59,43 @@ function updateManyFunc(
       return value;
     });
 
-    if (updatedRow.length > 0) {
-      const rowNumber = row.rowNumber + startRowNumber;
-      resolveWriter(gassmaControllerUtil.writer).updateRow(
+    return { rowNumber: row.rowNumber + startRowNumber, updatedRow };
+  });
+
+  const writeEntries = updates
+    .filter((update) => update.updatedRow.length > 0)
+    .map((update) => ({
+      rowNumber: update.rowNumber,
+      row: escapeFormulaInjectionRow(update.updatedRow),
+    }));
+
+  const writer = resolveWriter(gassmaControllerUtil.writer);
+  groupUpdateRuns(writeEntries).forEach((run) => {
+    if (run.rows.length === 1) {
+      writer.updateRow(
         sheet,
-        rowNumber,
+        run.startRowNumber,
         startColumnNumber,
         ColumnLength,
-        escapeFormulaInjectionRow(updatedRow),
+        run.rows[0],
       );
+      return;
     }
+    writer.updateRows(
+      sheet,
+      run.startRowNumber,
+      startColumnNumber,
+      ColumnLength,
+      run.rows,
+    );
+  });
 
-    return titles.reduce<Record<string, unknown>>((record, title, index) => {
+  const records = updates.map(({ updatedRow }) =>
+    titles.reduce<Record<string, unknown>>((record, title, index) => {
       record[title] = updatedRow[index];
       return record;
-    }, {});
-  });
+    }, {}),
+  );
 
   return withReturn ? records : { count: findedData.length };
 }

--- a/src/util/write/bufferedSheetWriter.ts
+++ b/src/util/write/bufferedSheetWriter.ts
@@ -21,13 +21,34 @@ type UpdateRowOp = {
   row: unknown[];
 };
 
+type UpdateRowsOp = {
+  kind: "updateRows";
+  sheet: Sheet;
+  startRowNumber: number;
+  startColumnNumber: number;
+  columnLength: number;
+  rows: unknown[][];
+};
+
 type DeleteRowOp = {
   kind: "deleteRow";
   sheet: Sheet;
   rowNumber: number;
 };
 
-type SheetOp = AppendRowsOp | UpdateRowOp | DeleteRowOp;
+type DeleteRowsOp = {
+  kind: "deleteRows";
+  sheet: Sheet;
+  rowPosition: number;
+  howMany: number;
+};
+
+type SheetOp =
+  | AppendRowsOp
+  | UpdateRowOp
+  | UpdateRowsOp
+  | DeleteRowOp
+  | DeleteRowsOp;
 
 const createBufferedSheetWriter = (
   store: VirtualSheetStore,
@@ -54,9 +75,38 @@ const createBufferedSheetWriter = (
     });
     store.updateRow(sheet, rowNumber, startColumnNumber, columnLength, row);
   },
+  updateRows: (
+    sheet,
+    startRowNumber,
+    startColumnNumber,
+    columnLength,
+    rows,
+  ) => {
+    ops.push({
+      kind: "updateRows",
+      sheet,
+      startRowNumber,
+      startColumnNumber,
+      columnLength,
+      rows,
+    });
+    rows.forEach((row, index) => {
+      store.updateRow(
+        sheet,
+        startRowNumber + index,
+        startColumnNumber,
+        columnLength,
+        row,
+      );
+    });
+  },
   deleteRow: (sheet, rowNumber) => {
     ops.push({ kind: "deleteRow", sheet, rowNumber });
     store.deleteRow(sheet, rowNumber);
+  },
+  deleteRows: (sheet, rowPosition, howMany) => {
+    ops.push({ kind: "deleteRows", sheet, rowPosition, howMany });
+    store.deleteRows(sheet, rowPosition, howMany);
   },
 });
 
@@ -78,6 +128,20 @@ const replaySheetOp = (op: SheetOp) => {
       op.columnLength,
       op.row,
     );
+    return;
+  }
+  if (op.kind === "updateRows") {
+    immediateSheetWriter.updateRows(
+      op.sheet,
+      op.startRowNumber,
+      op.startColumnNumber,
+      op.columnLength,
+      op.rows,
+    );
+    return;
+  }
+  if (op.kind === "deleteRows") {
+    immediateSheetWriter.deleteRows(op.sheet, op.rowPosition, op.howMany);
     return;
   }
   immediateSheetWriter.deleteRow(op.sheet, op.rowNumber);

--- a/src/util/write/rowRuns.ts
+++ b/src/util/write/rowRuns.ts
@@ -1,0 +1,44 @@
+type RowWrite = {
+  rowNumber: number;
+  row: unknown[];
+};
+
+type UpdateRun = {
+  startRowNumber: number;
+  rows: unknown[][];
+};
+
+type DeleteBlock = {
+  rowPosition: number;
+  howMany: number;
+};
+
+const groupUpdateRuns = (entries: RowWrite[]): UpdateRun[] => {
+  const sorted = [...entries].sort((a, b) => a.rowNumber - b.rowNumber);
+  return sorted.reduce<UpdateRun[]>((runs, entry) => {
+    const last = runs[runs.length - 1];
+    if (last && entry.rowNumber === last.startRowNumber + last.rows.length) {
+      last.rows.push(entry.row);
+      return runs;
+    }
+    runs.push({ startRowNumber: entry.rowNumber, rows: [entry.row] });
+    return runs;
+  }, []);
+};
+
+const groupDeleteBlocksDescending = (rowNumbers: number[]): DeleteBlock[] => {
+  const sorted = [...rowNumbers].sort((a, b) => b - a);
+  return sorted.reduce<DeleteBlock[]>((blocks, rowNumber) => {
+    const last = blocks[blocks.length - 1];
+    if (last && rowNumber === last.rowPosition - 1) {
+      last.rowPosition = rowNumber;
+      last.howMany += 1;
+      return blocks;
+    }
+    blocks.push({ rowPosition: rowNumber, howMany: 1 });
+    return blocks;
+  }, []);
+};
+
+export { groupDeleteBlocksDescending, groupUpdateRuns };
+export type { DeleteBlock, RowWrite, UpdateRun };

--- a/src/util/write/sheetWriter.ts
+++ b/src/util/write/sheetWriter.ts
@@ -12,7 +12,19 @@ type SheetWriter = {
     columnLength: number,
     row: unknown[],
   ): void;
+  updateRows(
+    sheet: GoogleAppsScript.Spreadsheet.Sheet,
+    startRowNumber: number,
+    startColumnNumber: number,
+    columnLength: number,
+    rows: unknown[][],
+  ): void;
   deleteRow(sheet: GoogleAppsScript.Spreadsheet.Sheet, rowNumber: number): void;
+  deleteRows(
+    sheet: GoogleAppsScript.Spreadsheet.Sheet,
+    rowPosition: number,
+    howMany: number,
+  ): void;
 };
 
 const immediateSheetWriter: SheetWriter = {
@@ -27,8 +39,22 @@ const immediateSheetWriter: SheetWriter = {
       .getRange(rowNumber, startColumnNumber, 1, columnLength)
       .setValues([row]);
   },
+  updateRows: (
+    sheet,
+    startRowNumber,
+    startColumnNumber,
+    columnLength,
+    rows,
+  ) => {
+    sheet
+      .getRange(startRowNumber, startColumnNumber, rows.length, columnLength)
+      .setValues(rows);
+  },
   deleteRow: (sheet, rowNumber) => {
     sheet.deleteRow(rowNumber);
+  },
+  deleteRows: (sheet, rowPosition, howMany) => {
+    sheet.deleteRows(rowPosition, howMany);
   },
 };
 


### PR DESCRIPTION
## 概要

N+1 調査で見つかった**書き込み側 N+1**(マッチ件数 M 比例)の修正です。`updateMany` はマッチ M 行に**1行ずつ** `setValues`、`deleteMany` は **M 回** `deleteRow` を呼んでいました。GAS は RPC 往復が支配的なので、**連続する行をラン単位にまとめて1コール**にし、書き込みコールを **M → ラン数**に削減します。

影響範囲は広く、基底の updateMany/deleteMany に加えて **onUpdate SetNull / onDelete Cascade / nested write の set・disconnect・delete** も経由します。

## 挙動は不変

**⚠️ 束ねの条件は「行番号の連続性」のみで、「値が同じこと」ではありません。**

- `setValues` は 2D 配列なので、**連続行それぞれに異なる値**を1コールで書けます。各行の値は従来どおり**その行の既存セルから個別に計算**され(`NumberOperation` の increment 等)、それを 2D 配列に積みます。「1行分を計算して繰り返す」ような実装はしていません(テストで固定)
- **返り値の順序・内容は完全に同一**。値の計算は元の `findedData` 順で行い `records` はそのパスから構築、グルーピングは**別の書き込みパス**で実施
- 空行ガードでスキップされる行は書き込み集合に入らないため、**ランを詰めずに分断**します
- `deleteMany` は降順のまま **物理削除(`deleteRow`/`deleteRows`、全列シフト)** を維持。上位ブロックの削除は下位ブロックの行番号に影響しません。**「生存行を書き戻して末尾クリア」方式は採用していません**(数式が静的値化し、削除の意味論が変わるため)
- **ラン長1は従来の `updateRow`/`deleteRow` を使用** → 散在マッチ時の writer 呼び出し列は現行と完全に同一

## トランザクション

`bufferedSheetWriter` が**バッチ op をそのまま記録**し、flush で `updateRows`/`deleteRows` の**1コールとして replay** するので、**トランザクション内でも削減が効きます**。仮想ストアには updateRows を行単位に展開して反映(read-your-writes 維持)、deleteRows は `splice(pos-1, howMany)`。rollback(copyTo バックアップ→復元)は `affectedSheets()` が op の sheet 参照を見るため無変更で機能します。

## 変更

- 新規 `src/util/write/rowRuns.ts`(ラン検出の純粋関数: 昇順ラン / 降順ブロック)
- `src/util/write/sheetWriter.ts` に `updateRows` / `deleteRows` を追加
- `src/util/update/updateMany.ts` / `src/util/delete/deleteMany.ts` をラン単位書き込みへ
- `src/util/write/bufferedSheetWriter.ts` / `src/util/transaction/virtualSheetStore.ts` がバッチ op に対応

## テスト

新規50件。連続 M→1コール / 散在→M / 複数ブロック→ブロック数 / 単一 / 0件 / limit / **increment で行ごとに異なる結果** / 部分列更新の非対象セル保存 / `records` の元順維持 / スキップ行のラン分断 / エスケープ / **tx 内のバッファ・flush 1コール化・行位置一致・rollback**。計数モック writer で「M 行 → ラン数コール」をピン留めしており、回帰防止も兼ねます。

## 検証

- `npx jest`: **142 suites / 1782 tests 全 pass**(既存 1732 件は期待値を1行も変えずに通過)
- `npx tsc --noEmit`: clean / `npm run build`: 成功 / **`npm run verify:bundle`: OK(公開シンボル 51/51)**
- `biome`: 変更16ファイルは診断ゼロ(リポジトリ全体は既存分で 101 errors → 97 に減少)

## 既知の限界

- **散在マッチ(1行おき等)はラン数 = M に縮退**し削減効果は出ません(構造上不可避)
- 書き込みコールの**順序**のみ、OR 条件で `findedData` が非昇順になる場合に「条件記述順 → 昇順」へ変わります(最終シート状態・返り値・件数は完全一致)

🤖 Generated with [Claude Code](https://claude.com/claude-code)