### PR TITLE
feat: add Gassma.migrateSheets for idempotent sheet schema sync

### DIFF
--- a/src/__test__/publicApi.test.ts
+++ b/src/__test__/publicApi.test.ts
@@ -3,6 +3,7 @@ import { GassmaClient } from "../gassma";
 import { GassmaController } from "../gassmaController";
 import * as publicApi from "../publicApi";
 import { FieldRef } from "../util/filterConditions/fieldRef";
+import { migrateSheets } from "../util/migrate/migrateSheets";
 import { skip } from "../util/skip/skip";
 import {
   buildTestClient,
@@ -25,6 +26,10 @@ describe("publicApi", () => {
     expect(publicApi.GassmaController).toBe(GassmaController);
     expect(publicApi.FieldRef).toBe(FieldRef);
     expect(publicApi.NotFoundError).toBe(NotFoundError);
+  });
+
+  test("migrateSheets は本体の関数と同一", () => {
+    expect(publicApi.migrateSheets).toBe(migrateSheets);
   });
 
   test("全 export が実体を持つ(skip 以外は function)", () => {

--- a/src/__test__/util/migrate/migrateSheets.test.ts
+++ b/src/__test__/util/migrate/migrateSheets.test.ts
@@ -9,6 +9,11 @@ type SetValuesCall = {
   values: unknown[][];
 };
 
+type InsertColumnsAfterCall = {
+  afterPosition: number;
+  howMany: number;
+};
+
 type MockRange = {
   getValues: () => unknown[][];
   setValues: (values: unknown[][]) => void;
@@ -18,45 +23,81 @@ type MockSheet = {
   getName: () => string;
   getLastRow: () => number;
   getLastColumn: () => number;
+  getMaxColumns: () => number;
   getRange: (
     row: number,
     col: number,
     numRows: number,
     numCols: number,
   ) => MockRange;
+  insertColumnsAfter: (afterPosition: number, howMany: number) => void;
 };
 
 type SheetHandle = {
   sheet: MockSheet;
   snapshot: () => unknown[][];
   writes: SetValuesCall[];
+  columnInsertions: InsertColumnsAfterCall[];
 };
 
-const makeSheet = (name: string, initial: unknown[][]): SheetHandle => {
+const DEFAULT_MAX_COLUMNS = 26;
+
+const makeSheet = (
+  name: string,
+  initial: unknown[][],
+  initialMaxColumns: number = DEFAULT_MAX_COLUMNS,
+): SheetHandle => {
   const data = initial.map((row) => [...row]);
   const writes: SetValuesCall[] = [];
+  const columnInsertions: InsertColumnsAfterCall[] = [];
+  let maxColumns = initialMaxColumns;
   const width = () => (data[0] ? data[0].length : 0);
   const sheet: MockSheet = {
     getName: () => name,
     getLastRow: () => data.length,
     getLastColumn: () => width(),
-    getRange: (row, col, numRows, numCols) => ({
-      getValues: () =>
-        data
-          .slice(row - 1, row - 1 + numRows)
-          .map((r) => r.slice(col - 1, col - 1 + numCols)),
-      setValues: (values) => {
-        writes.push({ row, col, numRows, numCols, values });
-        values.forEach((rowValues, i) => {
-          while (data.length < row + i) data.push([]);
-          rowValues.forEach((value, j) => {
-            data[row - 1 + i][col - 1 + j] = value;
+    getMaxColumns: () => maxColumns,
+    getRange: (row, col, numRows, numCols) => {
+      if (col - 1 + numCols > maxColumns) {
+        throw new Error(
+          `Range exceeds grid limits. Max columns: ${maxColumns}`,
+        );
+      }
+      return {
+        getValues: () =>
+          data
+            .slice(row - 1, row - 1 + numRows)
+            .map((r) => r.slice(col - 1, col - 1 + numCols)),
+        setValues: (values) => {
+          writes.push({ row, col, numRows, numCols, values });
+          values.forEach((rowValues, i) => {
+            while (data.length < row + i) data.push([]);
+            rowValues.forEach((value, j) => {
+              data[row - 1 + i][col - 1 + j] = value;
+            });
           });
-        });
-      },
-    }),
+        },
+      };
+    },
+    insertColumnsAfter: (afterPosition, howMany) => {
+      if (afterPosition < 1 || afterPosition > maxColumns || howMany < 1) {
+        throw new Error("Those columns are out of bounds.");
+      }
+      columnInsertions.push({ afterPosition, howMany });
+      data.forEach((row) => {
+        if (row.length <= afterPosition) return;
+        const blanks = Array.from({ length: howMany }, () => "");
+        row.splice(afterPosition, 0, ...blanks);
+      });
+      maxColumns += howMany;
+    },
   };
-  return { sheet, snapshot: () => data.map((row) => [...row]), writes };
+  return {
+    sheet,
+    snapshot: () => data.map((row) => [...row]),
+    writes,
+    columnInsertions,
+  };
 };
 
 type MockSpreadsheet = {
@@ -235,6 +276,79 @@ describe("migrateSheets 既存シートへの列追加", () => {
       expect(write.numRows).toBe(1);
     });
     expect(users.snapshot()).toEqual([["id", "flag"], [1], [2]]);
+  });
+});
+
+describe("migrateSheets グリッド上限", () => {
+  const columnNames = (count: number, prefix = "col"): string[] =>
+    Array.from({ length: count }, (_, i) => `${prefix}${i + 1}`);
+
+  test("デフォルト26列を超えるモデルは新規シートのグリッドを拡張して作成する", () => {
+    const env = makeSpreadsheet("active", []);
+    installSpreadsheetApp(env);
+    const columns = columnNames(30);
+
+    migrateSheets({ models: [{ name: "Wide", columns }] });
+
+    expect(env.handleOf("Wide").snapshot()).toEqual([columns]);
+    expect(env.handleOf("Wide").columnInsertions).toEqual([
+      { afterPosition: 26, howMany: 4 },
+    ]);
+    expect(env.handleOf("Wide").sheet.getMaxColumns()).toBe(30);
+  });
+
+  test("既存シートの空き列が足りない場合はグリッドを拡張して列を追加する", () => {
+    const columns = columnNames(24);
+    const wide = makeSheet("Wide", [columns]);
+    const env = makeSpreadsheet("active", [wide]);
+    installSpreadsheetApp(env);
+    const extras = columnNames(5, "extra");
+
+    migrateSheets({
+      models: [{ name: "Wide", columns: [...columns, ...extras] }],
+    });
+
+    expect(wide.snapshot()).toEqual([[...columns, ...extras]]);
+    expect(wide.columnInsertions).toEqual([{ afterPosition: 26, howMany: 3 }]);
+    expect(wide.sheet.getMaxColumns()).toBe(29);
+  });
+
+  test("列削除で maxColumns が詰まった既存シートにも列を追加できる", () => {
+    const trimmed = makeSheet("User", [["id", "name", "email"]], 3);
+    const env = makeSpreadsheet("active", [trimmed]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [
+        { name: "User", columns: ["id", "name", "email", "age", "flag"] },
+      ],
+    });
+
+    expect(trimmed.snapshot()).toEqual([
+      ["id", "name", "email", "age", "flag"],
+    ]);
+    expect(trimmed.columnInsertions).toEqual([
+      { afterPosition: 3, howMany: 2 },
+    ]);
+    expect(trimmed.sheet.getMaxColumns()).toBe(5);
+  });
+
+  test("グリッドに空きがある場合は insertColumnsAfter を呼ばない", () => {
+    const users = makeSheet("User", [["id", "name"]]);
+    const env = makeSpreadsheet("active", [users]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [
+        { name: "User", columns: ["id", "name", "email"] },
+        { name: "Post", columns: ["id", "title"] },
+      ],
+    });
+
+    expect(users.columnInsertions).toEqual([]);
+    expect(env.handleOf("Post").columnInsertions).toEqual([]);
+    expect(users.snapshot()).toEqual([["id", "name", "email"]]);
+    expect(env.handleOf("Post").snapshot()).toEqual([["id", "title"]]);
   });
 });
 

--- a/src/__test__/util/migrate/migrateSheets.test.ts
+++ b/src/__test__/util/migrate/migrateSheets.test.ts
@@ -1,0 +1,357 @@
+import { GassmaMissingArgumentError } from "../../../errors/argument/argumentError";
+import { migrateSheets } from "../../../util/migrate/migrateSheets";
+
+type SetValuesCall = {
+  row: number;
+  col: number;
+  numRows: number;
+  numCols: number;
+  values: unknown[][];
+};
+
+type MockRange = {
+  getValues: () => unknown[][];
+  setValues: (values: unknown[][]) => void;
+};
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => MockRange;
+};
+
+type SheetHandle = {
+  sheet: MockSheet;
+  snapshot: () => unknown[][];
+  writes: SetValuesCall[];
+};
+
+const makeSheet = (name: string, initial: unknown[][]): SheetHandle => {
+  const data = initial.map((row) => [...row]);
+  const writes: SetValuesCall[] = [];
+  const width = () => (data[0] ? data[0].length : 0);
+  const sheet: MockSheet = {
+    getName: () => name,
+    getLastRow: () => data.length,
+    getLastColumn: () => width(),
+    getRange: (row, col, numRows, numCols) => ({
+      getValues: () =>
+        data
+          .slice(row - 1, row - 1 + numRows)
+          .map((r) => r.slice(col - 1, col - 1 + numCols)),
+      setValues: (values) => {
+        writes.push({ row, col, numRows, numCols, values });
+        values.forEach((rowValues, i) => {
+          while (data.length < row + i) data.push([]);
+          rowValues.forEach((value, j) => {
+            data[row - 1 + i][col - 1 + j] = value;
+          });
+        });
+      },
+    }),
+  };
+  return { sheet, snapshot: () => data.map((row) => [...row]), writes };
+};
+
+type MockSpreadsheet = {
+  getId: () => string;
+  getSheets: () => MockSheet[];
+  getSheetByName: (name: string) => MockSheet | null;
+  insertSheet: (name: string) => MockSheet;
+};
+
+type SpreadsheetHandle = {
+  spreadsheet: MockSpreadsheet;
+  handleOf: (name: string) => SheetHandle;
+  insertedNames: string[];
+  sheetNames: () => string[];
+};
+
+const makeSpreadsheet = (
+  id: string,
+  handles: SheetHandle[],
+): SpreadsheetHandle => {
+  const all = [...handles];
+  const insertedNames: string[] = [];
+  const spreadsheet: MockSpreadsheet = {
+    getId: () => id,
+    getSheets: () => all.map((handle) => handle.sheet),
+    getSheetByName: (name) =>
+      all.find((handle) => handle.sheet.getName() === name)?.sheet ?? null,
+    insertSheet: (name) => {
+      if (all.some((handle) => handle.sheet.getName() === name)) {
+        throw new Error(`A sheet with the name "${name}" already exists.`);
+      }
+      const handle = makeSheet(name, []);
+      all.push(handle);
+      insertedNames.push(name);
+      return handle.sheet;
+    },
+  };
+  const handleOf = (name: string): SheetHandle => {
+    const found = all.find((handle) => handle.sheet.getName() === name);
+    if (!found) throw new Error(`mock sheet not found: ${name}`);
+    return found;
+  };
+  return {
+    spreadsheet,
+    handleOf,
+    insertedNames,
+    sheetNames: () => all.map((handle) => handle.sheet.getName()),
+  };
+};
+
+const installSpreadsheetApp = (
+  active: SpreadsheetHandle,
+  byId: Record<string, SpreadsheetHandle> = {},
+): { openByIdCalls: string[] } => {
+  const openByIdCalls: string[] = [];
+  Object.assign(globalThis, {
+    SpreadsheetApp: {
+      getActiveSpreadsheet: () => active.spreadsheet,
+      openById: (id: string) => {
+        openByIdCalls.push(id);
+        const target = byId[id];
+        if (!target) throw new Error(`mock spreadsheet not found: ${id}`);
+        return target.spreadsheet;
+      },
+    },
+  });
+  return { openByIdCalls };
+};
+
+let logSpy: jest.SpyInstance;
+let warnSpy: jest.SpyInstance;
+
+const messagesOf = (spy: jest.SpyInstance): string[] =>
+  spy.mock.calls.map((call) => String(call[0]));
+
+beforeEach(() => {
+  logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  warnSpy.mockRestore();
+});
+
+afterAll(() => {
+  Object.assign(globalThis, { SpreadsheetApp: undefined });
+});
+
+describe("migrateSheets 新規シート作成", () => {
+  test("存在しないシートを作成しヘッダーを1行目A列から書き込む", () => {
+    const env = makeSpreadsheet("active", []);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id", "name", "email"] }],
+    });
+
+    expect(env.insertedNames).toEqual(["User"]);
+    expect(env.handleOf("User").snapshot()).toEqual([["id", "name", "email"]]);
+    const logs = messagesOf(logSpy);
+    expect(
+      logs.some((log) => log.includes("created") && log.includes('"User"')),
+    ).toBe(true);
+  });
+
+  test("複数モデルをまとめて作成できる", () => {
+    const env = makeSpreadsheet("active", []);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [
+        { name: "User", columns: ["id", "name"] },
+        { name: "Post", columns: ["id", "authorId", "title"] },
+      ],
+    });
+
+    expect(env.sheetNames()).toEqual(["User", "Post"]);
+    expect(env.handleOf("Post").snapshot()).toEqual([
+      ["id", "authorId", "title"],
+    ]);
+  });
+});
+
+describe("migrateSheets 既存シートへの列追加", () => {
+  test("足りない列だけをヘッダー行の末尾へ追加する", () => {
+    const users = makeSheet("User", [
+      ["id", "name"],
+      [1, "Alice"],
+    ]);
+    const env = makeSpreadsheet("active", [users]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id", "name", "email", "age"] }],
+    });
+
+    expect(users.snapshot()).toEqual([
+      ["id", "name", "email", "age"],
+      [1, "Alice"],
+    ]);
+    expect(env.insertedNames).toEqual([]);
+    const logs = messagesOf(logSpy);
+    expect(
+      logs.some(
+        (log) =>
+          log.includes("added") &&
+          log.includes("email") &&
+          log.includes("age") &&
+          log.includes('"User"'),
+      ),
+    ).toBe(true);
+  });
+
+  test("既存の空シートには全列を1行目A列から書き込む", () => {
+    const empty = makeSheet("User", []);
+    const env = makeSpreadsheet("active", [empty]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({ models: [{ name: "User", columns: ["id", "name"] }] });
+
+    expect(empty.snapshot()).toEqual([["id", "name"]]);
+    expect(env.insertedNames).toEqual([]);
+  });
+
+  test("列追加時もヘッダー行(1行目)以外には書き込まない", () => {
+    const users = makeSheet("User", [["id"], [1], [2]]);
+    const env = makeSpreadsheet("active", [users]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({ models: [{ name: "User", columns: ["id", "flag"] }] });
+
+    expect(users.writes.length).toBeGreaterThan(0);
+    users.writes.forEach((write) => {
+      expect(write.row).toBe(1);
+      expect(write.numRows).toBe(1);
+    });
+    expect(users.snapshot()).toEqual([["id", "flag"], [1], [2]]);
+  });
+});
+
+describe("migrateSheets 冪等性", () => {
+  test("2回実行しても2回目は書き込みが発生しない", () => {
+    const users = makeSheet("User", [["id"], [1]]);
+    const env = makeSpreadsheet("active", [users]);
+    installSpreadsheetApp(env);
+    const models = [
+      { name: "User", columns: ["id", "name"] },
+      { name: "Post", columns: ["id", "title"] },
+    ];
+
+    migrateSheets({ models });
+    const userSnapshot = users.snapshot();
+    const postSnapshot = env.handleOf("Post").snapshot();
+    const userWriteCount = users.writes.length;
+    const postWriteCount = env.handleOf("Post").writes.length;
+    const logCountAfterFirst = logSpy.mock.calls.length;
+
+    migrateSheets({ models });
+
+    expect(env.insertedNames).toEqual(["Post"]);
+    expect(users.snapshot()).toEqual(userSnapshot);
+    expect(env.handleOf("Post").snapshot()).toEqual(postSnapshot);
+    expect(users.writes.length).toBe(userWriteCount);
+    expect(env.handleOf("Post").writes.length).toBe(postWriteCount);
+    const secondRunLogs = messagesOf(logSpy).slice(logCountAfterFirst);
+    expect(secondRunLogs.some((log) => log.includes("up to date"))).toBe(true);
+    expect(
+      secondRunLogs.some(
+        (log) => log.includes("created") || log.includes("added"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("migrateSheets 非破壊", () => {
+  test("既存列の順序が schema と違っても並べ替えない", () => {
+    const users = makeSheet("User", [
+      ["name", "id"],
+      ["Alice", 1],
+    ]);
+    const env = makeSpreadsheet("active", [users]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({ models: [{ name: "User", columns: ["id", "name"] }] });
+
+    expect(users.snapshot()).toEqual([
+      ["name", "id"],
+      ["Alice", 1],
+    ]);
+    expect(users.writes).toEqual([]);
+  });
+
+  test("schema に無い列とシートは削除せず console.warn する", () => {
+    const users = makeSheet("User", [
+      ["id", "", "legacy"],
+      [1, "", "x"],
+    ]);
+    const old = makeSheet("Old", [["a"]]);
+    const env = makeSpreadsheet("active", [users, old]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({ models: [{ name: "User", columns: ["id"] }] });
+
+    expect(users.snapshot()).toEqual([
+      ["id", "", "legacy"],
+      [1, "", "x"],
+    ]);
+    expect(users.writes).toEqual([]);
+    expect(env.sheetNames()).toEqual(["User", "Old"]);
+    const warns = messagesOf(warnSpy);
+    expect(
+      warns.some(
+        (warn) => warn.includes('"legacy"') && warn.includes('"User"'),
+      ),
+    ).toBe(true);
+    expect(warns.some((warn) => warn.includes('"Old"'))).toBe(true);
+    expect(warns.some((warn) => warn.includes('""'))).toBe(false);
+  });
+});
+
+describe("migrateSheets 引数の検証", () => {
+  test("models が無い場合は GassmaMissingArgumentError を投げる", () => {
+    installSpreadsheetApp(makeSpreadsheet("active", []));
+    const callUnsafely: (options: unknown) => void = migrateSheets;
+
+    expect(() => callUnsafely(undefined)).toThrow(GassmaMissingArgumentError);
+    expect(() => callUnsafely({})).toThrow(GassmaMissingArgumentError);
+  });
+});
+
+describe("migrateSheets スプレッドシートの解決", () => {
+  test("spreadsheetId 指定時は openById のスプレッドシートへ適用する", () => {
+    const active = makeSpreadsheet("active", []);
+    const target = makeSpreadsheet("target", []);
+    const { openByIdCalls } = installSpreadsheetApp(active, {
+      "target-id": target,
+    });
+
+    migrateSheets({
+      spreadsheetId: "target-id",
+      models: [{ name: "User", columns: ["id"] }],
+    });
+
+    expect(openByIdCalls).toEqual(["target-id"]);
+    expect(target.insertedNames).toEqual(["User"]);
+    expect(active.insertedNames).toEqual([]);
+  });
+
+  test("spreadsheetId 未指定時はアクティブなスプレッドシートへ適用する", () => {
+    const active = makeSpreadsheet("active", []);
+    installSpreadsheetApp(active);
+
+    migrateSheets({ models: [{ name: "User", columns: ["id"] }] });
+
+    expect(active.insertedNames).toEqual(["User"]);
+  });
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -308,6 +308,25 @@ declare namespace Gassma {
     strictUndefinedChecks?: boolean;
   };
 
+  type MigrateModel = {
+    name: string;
+    columns: string[];
+  };
+
+  type MigrateSheetsOptions = {
+    spreadsheetId?: string;
+    models: MigrateModel[];
+  };
+
+  /**
+   * Synchronizes the spreadsheet with the given models like `prisma db push`:
+   * missing sheets are created and missing columns are appended, idempotently.
+   * Assumes the header row is row 1 starting at column A on every sheet
+   * (header positions moved via changeSettings are not supported).
+   * Never deletes or reorders existing sheets/columns, never touches data rows.
+   */
+  function migrateSheets(options: MigrateSheetsOptions): void;
+
   type ConnectOrCreateInput = {
     where: WhereUse;
     create: Record<string, unknown>;

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -12,6 +12,7 @@ import * as whereRelationErrors from "./errors/relation/whereRelationError";
 import { GassmaClient as GassmaClientClass } from "./gassma";
 import { GassmaController as GassmaControllerClass } from "./gassmaController";
 import { FieldRef as FieldRefClass } from "./util/filterConditions/fieldRef";
+import { migrateSheets as migrateSheetsFunc } from "./util/migrate/migrateSheets";
 import { skip as skipSymbol } from "./util/skip/skip";
 
 // GAS ライブラリとして公開する実体。src/index.d.ts の namespace Gassma と 1:1 に保つ。
@@ -21,6 +22,7 @@ export const GassmaClient = GassmaClientClass;
 export const GassmaController = GassmaControllerClass;
 export const FieldRef = FieldRefClass;
 export const skip = skipSymbol;
+export const migrateSheets = migrateSheetsFunc;
 
 export const GassmaSkipNegativeError = findErrors.GassmaSkipNegativeError;
 export const GassmaFindFirstTakeError = findErrors.GassmaFindFirstTakeError;

--- a/src/types/migrateTypes.ts
+++ b/src/types/migrateTypes.ts
@@ -1,0 +1,11 @@
+type MigrateModel = {
+  name: string;
+  columns: string[];
+};
+
+type MigrateSheetsOptions = {
+  spreadsheetId?: string;
+  models: MigrateModel[];
+};
+
+export type { MigrateModel, MigrateSheetsOptions };

--- a/src/util/migrate/migrateSheets.ts
+++ b/src/util/migrate/migrateSheets.ts
@@ -1,0 +1,97 @@
+import { GassmaMissingArgumentError } from "../../errors/argument/argumentError";
+import type {
+  MigrateModel,
+  MigrateSheetsOptions,
+} from "../../types/migrateTypes";
+
+type Sheet = GoogleAppsScript.Spreadsheet.Sheet;
+type Spreadsheet = GoogleAppsScript.Spreadsheet.Spreadsheet;
+
+const LOG_PREFIX = "Gassma.migrateSheets:";
+
+const readHeaders = (sheet: Sheet): string[] => {
+  const lastColumn = sheet.getLastColumn();
+  if (lastColumn < 1) return [];
+  const titles = sheet.getRange(1, 1, 1, lastColumn).getValues()[0];
+  return titles.map((title) => String(title));
+};
+
+const createSheetWithHeaders = (
+  spreadsheet: Spreadsheet,
+  model: MigrateModel,
+) => {
+  const sheet = spreadsheet.insertSheet(model.name);
+  if (model.columns.length > 0) {
+    sheet.getRange(1, 1, 1, model.columns.length).setValues([model.columns]);
+  }
+  console.log(
+    `${LOG_PREFIX} created sheet "${model.name}" with columns [${model.columns.join(", ")}]`,
+  );
+};
+
+const warnExtraColumns = (headers: string[], model: MigrateModel) => {
+  headers.forEach((header) => {
+    if (header === "" || model.columns.includes(header)) return;
+    console.warn(
+      `${LOG_PREFIX} column "${header}" on sheet "${model.name}" is not in the schema. It is left untouched.`,
+    );
+  });
+};
+
+const appendMissingColumns = (sheet: Sheet, model: MigrateModel) => {
+  const headers = readHeaders(sheet);
+  const missingColumns = model.columns.filter(
+    (column) => !headers.includes(column),
+  );
+  if (missingColumns.length === 0) {
+    console.log(`${LOG_PREFIX} sheet "${model.name}" is up to date`);
+  } else {
+    sheet
+      .getRange(1, headers.length + 1, 1, missingColumns.length)
+      .setValues([missingColumns]);
+    console.log(
+      `${LOG_PREFIX} added columns [${missingColumns.join(", ")}] to sheet "${model.name}"`,
+    );
+  }
+  warnExtraColumns(headers, model);
+};
+
+const warnExtraSheets = (spreadsheet: Spreadsheet, models: MigrateModel[]) => {
+  const modelNames = models.map((model) => model.name);
+  spreadsheet.getSheets().forEach((sheet) => {
+    const sheetName = sheet.getName();
+    if (modelNames.includes(sheetName)) return;
+    console.warn(
+      `${LOG_PREFIX} sheet "${sheetName}" is not in the schema. It is left untouched.`,
+    );
+  });
+};
+
+/**
+ * Synchronizes the spreadsheet with the given models like `prisma db push`:
+ * missing sheets are created and missing columns are appended, idempotently.
+ * Assumes the header row is row 1 starting at column A on every sheet
+ * (header positions moved via changeSettings are not supported).
+ * Never deletes or reorders existing sheets/columns, never touches data rows.
+ */
+const migrateSheets = (options: MigrateSheetsOptions): void => {
+  if (!options || !options.models) {
+    throw new GassmaMissingArgumentError("models");
+  }
+  const spreadsheet = options.spreadsheetId
+    ? SpreadsheetApp.openById(options.spreadsheetId)
+    : SpreadsheetApp.getActiveSpreadsheet();
+
+  options.models.forEach((model) => {
+    const sheet = spreadsheet.getSheetByName(model.name);
+    if (sheet === null) {
+      createSheetWithHeaders(spreadsheet, model);
+      return;
+    }
+    appendMissingColumns(sheet, model);
+  });
+
+  warnExtraSheets(spreadsheet, options.models);
+};
+
+export { migrateSheets };

--- a/src/util/migrate/migrateSheets.ts
+++ b/src/util/migrate/migrateSheets.ts
@@ -16,12 +16,19 @@ const readHeaders = (sheet: Sheet): string[] => {
   return titles.map((title) => String(title));
 };
 
+const ensureColumnCapacity = (sheet: Sheet, requiredColumns: number) => {
+  const maxColumns = sheet.getMaxColumns();
+  if (requiredColumns <= maxColumns) return;
+  sheet.insertColumnsAfter(maxColumns, requiredColumns - maxColumns);
+};
+
 const createSheetWithHeaders = (
   spreadsheet: Spreadsheet,
   model: MigrateModel,
 ) => {
   const sheet = spreadsheet.insertSheet(model.name);
   if (model.columns.length > 0) {
+    ensureColumnCapacity(sheet, model.columns.length);
     sheet.getRange(1, 1, 1, model.columns.length).setValues([model.columns]);
   }
   console.log(
@@ -46,6 +53,7 @@ const appendMissingColumns = (sheet: Sheet, model: MigrateModel) => {
   if (missingColumns.length === 0) {
     console.log(`${LOG_PREFIX} sheet "${model.name}" is up to date`);
   } else {
+    ensureColumnCapacity(sheet, headers.length + missingColumns.length);
     sheet
       .getRange(1, headers.length + 1, 1, missingColumns.length)
       .setValues([missingColumns]);


### PR DESCRIPTION
## 概要

`npx gassma migrate`(CLI 側は別 PR で実装)から呼ばれる、**スプレッドシートのスキーマ同期 API** をライブラリに追加します。schema.prisma を元にシート(テーブル)と列を自動生成するための本体側の実装です。

```js
Gassma.migrateSheets({
  spreadsheetId: "...",           // 省略時はアクティブなスプレッドシート
  models: [{ name: "User", columns: ["id", "name", "email"] }],
});
```

意味論は Prisma の `db push` 相当で、**履歴を持たず毎回ライブのシート状態と突き合わせて差分を適用する冪等な同期**です。

## なぜ GAS 側で実行するのか

CLI から Google Sheets API を直接叩く案を検証しましたが、**clasp の OAuth クライアントが属する GCP プロジェクトで Sheets API が無効**(`SERVICE_DISABLED`、Google 所有のためこちらから有効化不可)で不可能でした。`scripts.run` はユーザーに GCP プロジェクト作成を強制し、自前 OAuth クライアント同梱は sensitive scope の審査が恒久コストになります。GAS ランタイム内で `SpreadsheetApp` を使えば、これらを一切踏まずに実現できます。

## 仕様

- **シート**: `getSheetByName` で存在確認し、**無い時だけ** `insertSheet`(GAS は同名 `insertSheet` で例外を投げるため)
- **列**: 既存ヘッダーを読み、**足りない列だけヘッダー行の末尾に追加**
- **既存列の並べ替えはしない** — スプレッドシートは列の位置がデータそのものなので、並べ替えはデータ破壊になります
- schema 順でヘッダーを書くのは**新規シート作成時のみ**
- **非破壊**: schema に無い列・シートは削除せず `console.warn` のみ。**ヘッダー行以外(データセル)には一切書き込みません**
- `models[].columns` は**物理列名**で、そのまま verbatim で書きます(`@map`/`@@map` の解決は CLI 側の責務)

### 割り切り

ヘッダー行は **1行目・A列開始**を前提としています(`changeSettings()` で位置を変えている場合は非対応)。CLI 側は利用者の実行時設定を知り得ないためです。この前提は実装と `index.d.ts` の JSDoc 両方に明記しています。

## グリッド列数上限への対応

レビューで**実機で例外になるバグ**が見つかったため修正しています。`insertSheet` の新規シートはデフォルト26列しかなく、`setValues` はグリッドを自動拡張しないため、**27列以上のモデル**や**列数が詰まった既存シート**で `Range exceeds grid limits` の例外になります。書き込み前に `getMaxColumns()` を確認し、不足分だけ `insertColumnsAfter` で拡張するようにしました(足りていれば何もしません)。

このバグは**テストのモックにグリッド上限の概念が無かったため検出できていませんでした**。モック側に上限と実機準拠の例外を実装し、同種のバグを今後も検出できる状態にしています。

## テスト

t-wada 流 TDD(Red → Green を各サイクルで確認)で実装。**16ケース追加、全体 1798件パス**。

- 新規シート作成 + ヘッダー書き込み / 複数モデル一括
- 既存シートへの末尾列追加 / 既存の空シート
- **2回実行しても2回目は書き込みが発生しない(冪等)**
- 既存列の順序が schema と違っても並べ替えない
- ヘッダー行以外に書き込まない(全 `setValues` が row=1・numRows=1 であることを検証)
- schema に無い列・シートを削除せず warn するだけ
- `spreadsheetId` 指定 / 未指定の両方
- グリッド拡張(26列超の新規作成 / 24列+5列 / maxColumns が詰まったシート / 空きがある時は `insertColumnsAfter` を呼ばない)

独立した検証エージェントによる敵対的レビューも実施し、実装に意図的なバグを4種注入して既存テストが検出することを確認しています(追加位置の off-by-one、存在チェック除去、全列書き直し、warn ガード除去)。

## 公開

`publicApi.ts` に `export const migrateSheets = migrateSheetsFunc;` として登録(gas-webpack-plugin は代入式のみ検出するため)、`index.d.ts` の namespace も 1:1 で更新。`npm run verify:bundle` で公開シンボル 51→52 件、バンドル出力にグローバル関数が存在することを確認済みです。

## 残作業

- CLI 側 `npx gassma migrate` コマンド(別 PR)
- gassma-test での実機確認(特に新規シート作成・26列超の列追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja