### PR TITLE
perf: batch existence checks and updates for nested connect

### DIFF
--- a/src/__test__/util/core/filterRowsByWhere.test.ts
+++ b/src/__test__/util/core/filterRowsByWhere.test.ts
@@ -1,0 +1,93 @@
+import type { FilterConditions, GassmaAny } from "../../../types/coreTypes";
+import { filterRowsByWhere } from "../../../util/core/filterRowsByWhere";
+import { FieldRef } from "../../../util/filterConditions/fieldRef";
+
+const fc = (obj: Record<string, unknown>) => obj as FilterConditions;
+
+describe("filterRowsByWhere", () => {
+  const titles = ["id", "name", "age", "authorId"];
+  const rows: GassmaAny[][] = [
+    [1, "田中", 20, null],
+    [2, "佐藤", 30, 1],
+    [3, "鈴木", 25, 1],
+    [4, null, 40, 2],
+  ];
+
+  it("空 where は全行を rowNumber 付きで返す", () => {
+    const result = filterRowsByWhere(rows, titles, {});
+    expect(result).toHaveLength(4);
+    expect(result[0]).toEqual({ rowNumber: 1, row: rows[0] });
+    expect(result[3]).toEqual({ rowNumber: 4, row: rows[3] });
+  });
+
+  it("単一カラム等価でマッチ行のみ返す", () => {
+    const result = filterRowsByWhere(rows, titles, { id: 2 });
+    expect(result).toEqual([{ rowNumber: 2, row: rows[1] }]);
+  });
+
+  it("複数カラムは AND で絞り込む", () => {
+    const result = filterRowsByWhere(rows, titles, { authorId: 1, age: 25 });
+    expect(result).toEqual([{ rowNumber: 3, row: rows[2] }]);
+  });
+
+  it("空文字は null として扱う", () => {
+    const result = filterRowsByWhere(rows, titles, { name: "" });
+    expect(result).toEqual([{ rowNumber: 4, row: rows[3] }]);
+  });
+
+  it("フィルタ条件 (gt) が使える", () => {
+    const result = filterRowsByWhere(rows, titles, { age: { gt: 25 } });
+    expect(result.map((r) => r.rowNumber)).toEqual([2, 4]);
+  });
+
+  it("titles に無いキーは無視され全行マッチする", () => {
+    const result = filterRowsByWhere(rows, titles, { ghost: 99 });
+    expect(result).toHaveLength(4);
+  });
+
+  it("OR で和集合を返す", () => {
+    const result = filterRowsByWhere(rows, titles, {
+      OR: [{ id: 1 }, { id: 3 }],
+    });
+    expect(result.map((r) => r.rowNumber)).toEqual([1, 3]);
+  });
+
+  it("AND 配列で積集合を返す", () => {
+    const result = filterRowsByWhere(rows, titles, {
+      AND: [{ authorId: 1 }, { age: { gte: 30 } }],
+    });
+    expect(result.map((r) => r.rowNumber)).toEqual([2]);
+  });
+
+  it("NOT で除外する", () => {
+    const result = filterRowsByWhere(rows, titles, {
+      NOT: [{ authorId: 1 }],
+    });
+    expect(result.map((r) => r.rowNumber)).toEqual([1, 4]);
+  });
+
+  it("通常キーと OR の組み合わせで両方適用される", () => {
+    const result = filterRowsByWhere(rows, titles, {
+      authorId: 1,
+      OR: [{ age: 25 }, { age: 30 }],
+    });
+    expect(result.map((r) => r.rowNumber).sort()).toEqual([2, 3]);
+  });
+
+  it("FieldRef で他カラム参照比較ができる", () => {
+    const refTitles = ["id", "score", "limit"];
+    const refRows: GassmaAny[][] = [
+      [1, 10, 5],
+      [2, 3, 5],
+    ];
+    const result = filterRowsByWhere(refRows, refTitles, {
+      score: fc({ gt: new FieldRef("Model", "limit") }),
+    });
+    expect(result.map((r) => r.rowNumber)).toEqual([1]);
+  });
+
+  it("空テーブルではどの where でも空を返す", () => {
+    expect(filterRowsByWhere([], titles, { id: 1 })).toEqual([]);
+    expect(filterRowsByWhere([], titles, {})).toEqual([]);
+  });
+});

--- a/src/__test__/util/create/nestedWrite/connectBatch/whereScan.test.ts
+++ b/src/__test__/util/create/nestedWrite/connectBatch/whereScan.test.ts
@@ -1,0 +1,66 @@
+import {
+  collectWhereFieldKeys,
+  hasTopLevelEmptyString,
+} from "../../../../../util/create/nestedWrite/connectBatch/whereScan";
+import { FieldRef } from "../../../../../util/filterConditions/fieldRef";
+
+describe("collectWhereFieldKeys", () => {
+  it("トップレベルの通常キーを収集する", () => {
+    const keys = collectWhereFieldKeys({ id: 1, name: "a" });
+    expect(keys).toEqual(new Set(["id", "name"]));
+  });
+
+  it("AND/OR/NOT は自身を収集せず中身へ再帰する", () => {
+    const keys = collectWhereFieldKeys({
+      AND: [{ a: 1 }, { OR: [{ b: 2 }] }],
+      NOT: { c: 3 },
+    });
+    expect(keys).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  it("AND が単一オブジェクトでも再帰する", () => {
+    const keys = collectWhereFieldKeys({ AND: { a: 1 } });
+    expect(keys).toEqual(new Set(["a"]));
+  });
+
+  it("フィルタ条件の演算子キーは収集しない", () => {
+    const keys = collectWhereFieldKeys({ age: { gt: 5, lte: 10 } });
+    expect(keys).toEqual(new Set(["age"]));
+  });
+
+  it("FieldRef の参照カラム名を収集する", () => {
+    const keys = collectWhereFieldKeys({
+      score: { gt: new FieldRef("Model", "limit") },
+    });
+    expect(keys).toEqual(new Set(["score", "limit"]));
+  });
+
+  it("配列の中の FieldRef も収集する", () => {
+    const keys = collectWhereFieldKeys({
+      tags: { in: [new FieldRef("Model", "x"), "y"] },
+    });
+    expect(keys).toEqual(new Set(["tags", "x"]));
+  });
+
+  it("空 where は空集合を返す", () => {
+    expect(collectWhereFieldKeys({})).toEqual(new Set());
+  });
+});
+
+describe("hasTopLevelEmptyString", () => {
+  it("トップレベルの空文字値を検出する", () => {
+    expect(hasTopLevelEmptyString({ name: "" })).toBe(true);
+  });
+
+  it("null や非空文字は検出しない", () => {
+    expect(hasTopLevelEmptyString({ name: null, age: 0, id: "a" })).toBe(false);
+  });
+
+  it("フィルタ条件内の空文字は対象外", () => {
+    expect(hasTopLevelEmptyString({ name: { equals: "" } })).toBe(false);
+  });
+
+  it("AND/OR/NOT 配下の空文字は対象外", () => {
+    expect(hasTopLevelEmptyString({ AND: [{ name: "" }] })).toBe(false);
+  });
+});

--- a/src/__test__/util/create/nestedWrite/processAfterCreateBatching.test.ts
+++ b/src/__test__/util/create/nestedWrite/processAfterCreateBatching.test.ts
@@ -1,0 +1,428 @@
+import { NestedWriteConnectNotFoundError } from "../../../../errors/relation/nestedWriteError";
+import type { FilterConditions, WhereUse } from "../../../../types/coreTypes";
+import type { NestedWriteOperation } from "../../../../types/nestedWriteTypes";
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../../types/relationTypes";
+import { processAfterCreate } from "../../../../util/create/nestedWrite/processAfterCreate";
+import { FieldRef } from "../../../../util/filterConditions/fieldRef";
+
+const fc = (obj: Record<string, unknown>) => obj as FilterConditions;
+
+type Row = Record<string, unknown>;
+
+const matchesPlain = (record: Row, where: Record<string, unknown>): boolean =>
+  Object.entries(where).every(([key, value]) => {
+    if (key === "OR") {
+      const branches = Array.isArray(value) ? value : [value];
+      return branches.some(
+        (branch) => typeof branch === "object" && matchesPlain(record, branch),
+      );
+    }
+    if (!(key in record)) return true;
+    if (value !== null && typeof value === "object") return false;
+    const wanted = value === "" ? null : value;
+    return record[key] === wanted;
+  });
+
+const makeSheet = (initialRows: Row[]) => {
+  const rows: Row[] = initialRows.map((row) => ({ ...row }));
+
+  const findManyOnSheet = jest.fn(
+    (_sheet: string, findData: { where?: WhereUse }) => {
+      const where = findData.where ?? {};
+      if (Object.keys(where).length === 0) return rows.map((r) => ({ ...r }));
+      return rows
+        .filter((row) => matchesPlain(row, where))
+        .map((r) => ({ ...r }));
+    },
+  );
+
+  const updateManyOnSheet = jest.fn(
+    (_sheet: string, updateData: { where?: WhereUse; data: Row }) => {
+      const where = updateData.where ?? {};
+      let count = 0;
+      rows.forEach((row) => {
+        if (!matchesPlain(row, where)) return;
+        Object.assign(row, updateData.data);
+        count += 1;
+      });
+      return { count };
+    },
+  );
+
+  const createOnSheet = jest.fn((_sheet: string, createData: { data: Row }) => {
+    const record = { ...createData.data };
+    rows.push(record);
+    return { ...record };
+  });
+
+  return { rows, findManyOnSheet, updateManyOnSheet, createOnSheet };
+};
+
+const postsRelation: RelationDefinition = {
+  type: "oneToMany",
+  to: "Posts",
+  field: "id",
+  reference: "authorId",
+};
+
+const makeContext = (
+  sheet: ReturnType<typeof makeSheet>,
+  relationNames?: string[],
+): RelationContext => {
+  const context: RelationContext = {
+    relations: { posts: postsRelation },
+    findManyOnSheet: sheet.findManyOnSheet,
+    updateManyOnSheet: sheet.updateManyOnSheet,
+    createOnSheet: sheet.createOnSheet,
+  };
+  if (relationNames) {
+    context.relationNamesOnSheet = () => relationNames;
+  }
+  return context;
+};
+
+const runConnect = (
+  sheet: ReturnType<typeof makeSheet>,
+  connect: WhereUse[],
+  relationNames?: string[],
+) => {
+  const relationOps = new Map<string, NestedWriteOperation>();
+  relationOps.set("posts", { connect });
+  processAfterCreate(
+    { id: 1, name: "田中" },
+    relationOps,
+    makeContext(sheet, relationNames),
+  );
+};
+
+const runConnectOrCreate = (
+  sheet: ReturnType<typeof makeSheet>,
+  connectOrCreate: { where: WhereUse; create: Row }[],
+) => {
+  const relationOps = new Map<string, NestedWriteOperation>();
+  relationOps.set("posts", { connectOrCreate });
+  processAfterCreate({ id: 1, name: "田中" }, relationOps, makeContext(sheet));
+};
+
+describe("processAfterCreate connect のバッチ化", () => {
+  it("複数 connect は読み 1 回・書き 1 回にまとまる", () => {
+    const sheet = makeSheet([
+      { id: 10, title: "A", authorId: null },
+      { id: 11, title: "B", authorId: null },
+      { id: 12, title: "C", authorId: null },
+      { id: 13, title: "D", authorId: null },
+    ]);
+
+    runConnect(sheet, [{ id: 10 }, { id: 11 }, { id: 12 }]);
+
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.findManyOnSheet).toHaveBeenCalledWith("Posts", {});
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: { OR: [{ id: 10 }, { id: 11 }, { id: 12 }] },
+      data: { authorId: 1 },
+    });
+    expect(sheet.createOnSheet).not.toHaveBeenCalled();
+    expect(sheet.rows.map((row) => row.authorId)).toEqual([1, 1, 1, null]);
+  });
+
+  it("1件でも不在なら 1 セルも書かずに従来と同一のエラーを投げる", () => {
+    const sheet = makeSheet([
+      { id: 10, title: "A", authorId: null },
+      { id: 11, title: "B", authorId: null },
+    ]);
+    const run = () => runConnect(sheet, [{ id: 10 }, { id: 11 }, { id: 999 }]);
+
+    expect(run).toThrow(NestedWriteConnectNotFoundError);
+    expect(run).toThrow(
+      'Nested write connect failed: no record found in "Posts"',
+    );
+    expect(sheet.updateManyOnSheet).not.toHaveBeenCalled();
+    expect(sheet.createOnSheet).not.toHaveBeenCalled();
+    expect(sheet.rows.map((row) => row.authorId)).toEqual([null, null]);
+  });
+
+  it("where が重複していても最終状態は同じで書きは 1 回", () => {
+    const sheet = makeSheet([
+      { id: 10, title: "A", authorId: null },
+      { id: 11, title: "B", authorId: null },
+    ]);
+
+    runConnect(sheet, [{ id: 10 }, { id: 10 }, { id: 11 }]);
+
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.rows.map((row) => row.authorId)).toEqual([1, 1]);
+  });
+
+  it("複数行にマッチする where もまとめて更新される", () => {
+    const sheet = makeSheet([
+      { id: 10, flag: true, authorId: null },
+      { id: 11, flag: true, authorId: null },
+      { id: 12, flag: false, authorId: null },
+    ]);
+
+    runConnect(sheet, [{ flag: true }, { id: 12 }]);
+
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.rows.map((row) => row.authorId)).toEqual([1, 1, 1]);
+  });
+
+  it("connect が空配列なら何も呼ばれない", () => {
+    const sheet = makeSheet([{ id: 10, authorId: null }]);
+
+    runConnect(sheet, []);
+
+    expect(sheet.findManyOnSheet).not.toHaveBeenCalled();
+    expect(sheet.updateManyOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("テーブルに無いキーを含む項目はその項目だけ従来の個別読み書きに戻す", () => {
+    const sheet = makeSheet([
+      { id: 10, title: "A", authorId: null },
+      { id: 11, title: "B", authorId: null },
+    ]);
+
+    runConnect(sheet, [{ id: 10 }, { ghost: 9 }]);
+
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheet.findManyOnSheet).toHaveBeenCalledWith("Posts", {});
+    expect(sheet.findManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: { ghost: 9 },
+    });
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: { id: 10 },
+      data: { authorId: 1 },
+    });
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: { ghost: 9 },
+      data: { authorId: 1 },
+    });
+  });
+
+  it("トップレベルに空文字を含む項目は OR 合成せず個別更新する", () => {
+    const sheet = makeSheet([
+      { id: 10, name: null, authorId: null },
+      { id: 11, name: "x", authorId: null },
+    ]);
+
+    runConnect(sheet, [{ id: 11 }, { name: "" }]);
+
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: { id: 11 },
+      data: { authorId: 1 },
+    });
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: { name: "" },
+      data: { authorId: 1 },
+    });
+    expect(sheet.rows.map((row) => row.authorId)).toEqual([1, 1]);
+  });
+
+  it("ターゲットのリレーション名と同名キーを含む項目は個別処理に戻す", () => {
+    const sheet = makeSheet([
+      { id: 10, author: "x", authorId: null },
+      { id: 11, author: "y", authorId: null },
+    ]);
+
+    runConnect(sheet, [{ id: 10 }, { author: "y" }], ["author"]);
+
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheet.findManyOnSheet).toHaveBeenCalledWith("Posts", {});
+    expect(sheet.findManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: { author: "y" },
+    });
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheet.rows.map((row) => row.authorId)).toEqual([1, 1]);
+  });
+
+  it("FieldRef を含む where もローカル判定で読み 1 回になる", () => {
+    const sheet = makeSheet([
+      { id: 10, score: 5, cap: 3, authorId: null },
+      { id: 11, score: 2, cap: 3, authorId: null },
+    ]);
+
+    runConnect(sheet, [
+      { score: fc({ gt: new FieldRef("Posts", "cap") }) },
+      { id: 11 },
+    ]);
+
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: {
+        OR: [{ score: fc({ gt: new FieldRef("Posts", "cap") }) }, { id: 11 }],
+      },
+      data: { authorId: 1 },
+    });
+  });
+
+  it("空シートへの複数 connect は読み 1 回で書かずにエラー", () => {
+    const sheet = makeSheet([]);
+    const run = () => runConnect(sheet, [{ id: 1 }, { id: 2 }]);
+
+    expect(run).toThrow(NestedWriteConnectNotFoundError);
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.findManyOnSheet).toHaveBeenCalledWith("Posts", {});
+    expect(sheet.updateManyOnSheet).not.toHaveBeenCalled();
+  });
+
+  it("空シートでもリレーション名キーを含む項目は個別読みに回す", () => {
+    const sheet = makeSheet([]);
+    const run = () =>
+      runConnect(
+        sheet,
+        [{ id: 1 }, { author: { is: { name: "x" } } }],
+        ["author"],
+      );
+
+    expect(run).toThrow(NestedWriteConnectNotFoundError);
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheet.findManyOnSheet).toHaveBeenCalledWith("Posts", {});
+    expect(sheet.findManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: { author: { is: { name: "x" } } },
+    });
+    expect(sheet.updateManyOnSheet).not.toHaveBeenCalled();
+  });
+});
+
+describe("processAfterCreate connectOrCreate のバッチ化", () => {
+  it("全件既存なら読み 1 回・更新 1 回・作成 0 回", () => {
+    const sheet = makeSheet([
+      { id: 10, title: "A", authorId: null },
+      { id: 11, title: "B", authorId: null },
+      { id: 12, title: "C", authorId: null },
+    ]);
+
+    runConnectOrCreate(sheet, [
+      { where: { id: 10 }, create: { id: 10, title: "A" } },
+      { where: { id: 11 }, create: { id: 11, title: "B" } },
+      { where: { id: 12 }, create: { id: 12, title: "C" } },
+    ]);
+
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.findManyOnSheet).toHaveBeenCalledWith("Posts", {});
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: { OR: [{ id: 10 }, { id: 11 }, { id: 12 }] },
+      data: { authorId: 1 },
+    });
+    expect(sheet.createOnSheet).not.toHaveBeenCalled();
+    expect(sheet.rows.map((row) => row.authorId)).toEqual([1, 1, 1]);
+  });
+
+  it("全件不在なら items 順で作成される", () => {
+    const sheet = makeSheet([{ id: 10, title: "A", authorId: null }]);
+
+    runConnectOrCreate(sheet, [
+      { where: { id: 20 }, create: { id: 20, title: "X" } },
+      { where: { id: 21 }, create: { id: 21, title: "Y" } },
+      { where: { id: 22 }, create: { id: 22, title: "Z" } },
+    ]);
+
+    expect(sheet.createOnSheet).toHaveBeenCalledTimes(3);
+    expect(sheet.createOnSheet).toHaveBeenNthCalledWith(1, "Posts", {
+      data: { id: 20, title: "X", authorId: 1 },
+    });
+    expect(sheet.createOnSheet).toHaveBeenNthCalledWith(2, "Posts", {
+      data: { id: 21, title: "Y", authorId: 1 },
+    });
+    expect(sheet.createOnSheet).toHaveBeenNthCalledWith(3, "Posts", {
+      data: { id: 22, title: "Z", authorId: 1 },
+    });
+    expect(sheet.updateManyOnSheet).not.toHaveBeenCalled();
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(3);
+    expect(sheet.findManyOnSheet).toHaveBeenCalledWith("Posts", {});
+    expect(sheet.rows.map((row) => row.id)).toEqual([10, 20, 21, 22]);
+  });
+
+  it("同一 where の重複項目は 2 重作成されない", () => {
+    const sheet = makeSheet([]);
+
+    runConnectOrCreate(sheet, [
+      { where: { email: "a" }, create: { email: "a", title: "X" } },
+      { where: { email: "a" }, create: { email: "a", title: "Y" } },
+    ]);
+
+    expect(sheet.createOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.createOnSheet).toHaveBeenCalledWith("Posts", {
+      data: { email: "a", title: "X", authorId: 1 },
+    });
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: { email: "a" },
+      data: { authorId: 1 },
+    });
+    expect(sheet.rows).toHaveLength(1);
+  });
+
+  it("既存と不在の混在では読み 1 回・作成は items 順", () => {
+    const sheet = makeSheet([
+      { id: 10, title: "A", authorId: null },
+      { id: 11, title: "B", authorId: null },
+    ]);
+
+    runConnectOrCreate(sheet, [
+      { where: { id: 10 }, create: { id: 10, title: "A" } },
+      { where: { id: 20 }, create: { id: 20, title: "N" } },
+      { where: { id: 11 }, create: { id: 11, title: "B" } },
+    ]);
+
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.createOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.createOnSheet).toHaveBeenCalledWith("Posts", {
+      data: { id: 20, title: "N", authorId: 1 },
+    });
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledWith("Posts", {
+      where: { OR: [{ id: 10 }, { id: 11 }] },
+      data: { authorId: 1 },
+    });
+    const createOrder = sheet.createOnSheet.mock.invocationCallOrder[0];
+    const updateOrder = sheet.updateManyOnSheet.mock.invocationCallOrder[0];
+    expect(createOrder).toBeLessThan(updateOrder);
+    expect(sheet.rows.map((row) => row.id)).toEqual([10, 11, 20]);
+    expect(sheet.rows.map((row) => row.authorId)).toEqual([1, 1, 1]);
+  });
+
+  it("FK カラムを参照する where を含む場合は全体を従来動作に戻す", () => {
+    const sheet = makeSheet([
+      { id: 10, title: "A", authorId: null },
+      { id: 11, title: "B", authorId: 9 },
+    ]);
+
+    runConnectOrCreate(sheet, [
+      { where: { authorId: null }, create: { id: 30, title: "N" } },
+      { where: { id: 11 }, create: { id: 11, title: "B" } },
+    ]);
+
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheet.findManyOnSheet).toHaveBeenNthCalledWith(1, "Posts", {
+      where: { authorId: null },
+    });
+    expect(sheet.findManyOnSheet).toHaveBeenNthCalledWith(2, "Posts", {
+      where: { id: 11 },
+    });
+    expect(sheet.updateManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheet.rows.map((row) => row.authorId)).toEqual([1, 1]);
+  });
+
+  it("空シートでは作成が進むたびに再読して重複作成を防ぐ", () => {
+    const sheet = makeSheet([]);
+
+    runConnectOrCreate(sheet, [
+      { where: { id: 20 }, create: { id: 20, title: "X" } },
+      { where: { id: 21 }, create: { id: 21, title: "Y" } },
+    ]);
+
+    expect(sheet.findManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheet.createOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheet.rows.map((row) => row.id)).toEqual([20, 21]);
+  });
+});

--- a/src/__test__/util/create/nestedWrite/processManyToManyBatching.test.ts
+++ b/src/__test__/util/create/nestedWrite/processManyToManyBatching.test.ts
@@ -1,0 +1,203 @@
+import { NestedWriteConnectNotFoundError } from "../../../../errors/relation/nestedWriteError";
+import type { WhereUse } from "../../../../types/coreTypes";
+import type { NestedWriteOperation } from "../../../../types/nestedWriteTypes";
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../../types/relationTypes";
+import { processManyToMany } from "../../../../util/create/nestedWrite/processManyToMany";
+
+type Row = Record<string, unknown>;
+
+const matchesPlain = (record: Row, where: Record<string, unknown>): boolean =>
+  Object.entries(where).every(([key, value]) => {
+    if (!(key in record)) return true;
+    if (value !== null && typeof value === "object") return false;
+    const wanted = value === "" ? null : value;
+    return record[key] === wanted;
+  });
+
+const makeTagSheets = (initialTags: Row[]) => {
+  const tags: Row[] = initialTags.map((row) => ({ ...row }));
+  const junctions: Row[] = [];
+
+  const findManyOnSheet = jest.fn(
+    (_sheet: string, findData: { where?: WhereUse }) => {
+      const where = findData.where ?? {};
+      if (Object.keys(where).length === 0) return tags.map((r) => ({ ...r }));
+      return tags
+        .filter((row) => matchesPlain(row, where))
+        .map((r) => ({ ...r }));
+    },
+  );
+
+  const createOnSheet = jest.fn((sheet: string, createData: { data: Row }) => {
+    const record = { ...createData.data };
+    if (sheet === "PostTags") junctions.push(record);
+    else tags.push(record);
+    return { ...record };
+  });
+
+  return { tags, junctions, findManyOnSheet, createOnSheet };
+};
+
+const tagsRelation: RelationDefinition = {
+  type: "manyToMany",
+  to: "Tags",
+  field: "id",
+  reference: "id",
+  through: {
+    sheet: "PostTags",
+    field: "postId",
+    reference: "tagId",
+  },
+};
+
+const runOps = (
+  sheets: ReturnType<typeof makeTagSheets>,
+  ops: NestedWriteOperation,
+  relation: RelationDefinition = tagsRelation,
+) => {
+  const relationOps = new Map<string, NestedWriteOperation>();
+  relationOps.set("tags", ops);
+  const context: RelationContext = {
+    relations: { tags: relation },
+    findManyOnSheet: sheets.findManyOnSheet,
+    createOnSheet: sheets.createOnSheet,
+  };
+  processManyToMany({ id: 1, title: "記事A" }, relationOps, context);
+};
+
+describe("processManyToMany connect のバッチ化", () => {
+  it("複数 connect は読み 1 回で junction row は items 順に作られる", () => {
+    const sheets = makeTagSheets([
+      { id: 1, name: "TS" },
+      { id: 2, name: "JS" },
+      { id: 3, name: "GAS" },
+    ]);
+
+    runOps(sheets, { connect: [{ id: 3 }, { id: 1 }, { id: 2 }] });
+
+    expect(sheets.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheets.findManyOnSheet).toHaveBeenCalledWith("Tags", {});
+    expect(sheets.createOnSheet).toHaveBeenCalledTimes(3);
+    expect(sheets.createOnSheet).toHaveBeenNthCalledWith(1, "PostTags", {
+      data: { postId: 1, tagId: 3 },
+    });
+    expect(sheets.createOnSheet).toHaveBeenNthCalledWith(2, "PostTags", {
+      data: { postId: 1, tagId: 1 },
+    });
+    expect(sheets.createOnSheet).toHaveBeenNthCalledWith(3, "PostTags", {
+      data: { postId: 1, tagId: 2 },
+    });
+  });
+
+  it("1件でも不在なら junction row を 1 行も作らずエラーを投げる", () => {
+    const sheets = makeTagSheets([
+      { id: 1, name: "TS" },
+      { id: 2, name: "JS" },
+    ]);
+    const run = () =>
+      runOps(sheets, { connect: [{ id: 1 }, { id: 2 }, { id: 999 }] });
+
+    expect(run).toThrow(NestedWriteConnectNotFoundError);
+    expect(run).toThrow(
+      'Nested write connect failed: no record found in "Tags"',
+    );
+    expect(sheets.createOnSheet).not.toHaveBeenCalled();
+    expect(sheets.junctions).toEqual([]);
+  });
+
+  it("複数行にマッチする where は先頭行が使われる", () => {
+    const sheets = makeTagSheets([
+      { id: 1, group: "a" },
+      { id: 2, group: "a" },
+      { id: 3, group: "b" },
+    ]);
+
+    runOps(sheets, { connect: [{ group: "a" }, { id: 3 }] });
+
+    expect(sheets.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheets.junctions).toEqual([
+      { postId: 1, tagId: 1 },
+      { postId: 1, tagId: 3 },
+    ]);
+  });
+});
+
+describe("processManyToMany connectOrCreate のバッチ化", () => {
+  it("既存と不在の混在では読み 1 回・junction は items 順", () => {
+    const sheets = makeTagSheets([
+      { id: 1, name: "TS" },
+      { id: 3, name: "GAS" },
+    ]);
+
+    runOps(sheets, {
+      connectOrCreate: [
+        { where: { id: 1 }, create: { id: 1, name: "TS" } },
+        { where: { id: 9 }, create: { id: 9, name: "New" } },
+        { where: { id: 3 }, create: { id: 3, name: "GAS" } },
+      ],
+    });
+
+    expect(sheets.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheets.findManyOnSheet).toHaveBeenCalledWith("Tags", {});
+    expect(sheets.createOnSheet).toHaveBeenNthCalledWith(1, "PostTags", {
+      data: { postId: 1, tagId: 1 },
+    });
+    expect(sheets.createOnSheet).toHaveBeenNthCalledWith(2, "Tags", {
+      data: { id: 9, name: "New" },
+    });
+    expect(sheets.createOnSheet).toHaveBeenNthCalledWith(3, "PostTags", {
+      data: { postId: 1, tagId: 9 },
+    });
+    expect(sheets.createOnSheet).toHaveBeenNthCalledWith(4, "PostTags", {
+      data: { postId: 1, tagId: 3 },
+    });
+    expect(sheets.tags.map((row) => row.id)).toEqual([1, 3, 9]);
+  });
+
+  it("同一 where の重複項目はターゲットを 2 重作成しない", () => {
+    const sheets = makeTagSheets([]);
+
+    runOps(sheets, {
+      connectOrCreate: [
+        { where: { name: "TS" }, create: { id: 5, name: "TS" } },
+        { where: { name: "TS" }, create: { id: 6, name: "TS" } },
+      ],
+    });
+
+    expect(sheets.findManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheets.tags).toEqual([{ id: 5, name: "TS" }]);
+    expect(sheets.junctions).toEqual([
+      { postId: 1, tagId: 5 },
+      { postId: 1, tagId: 5 },
+    ]);
+  });
+});
+
+describe("processManyToMany 自己 junction のフォールバック", () => {
+  it("through.sheet がターゲットと同じ場合は従来の個別読みに戻す", () => {
+    const selfJunction: RelationDefinition = {
+      type: "manyToMany",
+      to: "Tags",
+      field: "id",
+      reference: "id",
+      through: { sheet: "Tags", field: "postId", reference: "tagId" },
+    };
+    const sheets = makeTagSheets([
+      { id: 1, name: "TS" },
+      { id: 2, name: "JS" },
+    ]);
+
+    runOps(sheets, { connect: [{ id: 1 }, { id: 2 }] }, selfJunction);
+
+    expect(sheets.findManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheets.findManyOnSheet).toHaveBeenCalledWith("Tags", {
+      where: { id: 1 },
+    });
+    expect(sheets.findManyOnSheet).toHaveBeenCalledWith("Tags", {
+      where: { id: 2 },
+    });
+  });
+});

--- a/src/util/andOrNot/and.ts
+++ b/src/util/andOrNot/and.ts
@@ -3,9 +3,8 @@ import type {
   GassmaAny,
   WhereUse,
 } from "../../types/coreTypes";
-import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import type { HitRowData } from "../../types/hitRowDataType";
-import { getWantFindIndex } from "../core/getWantFindIndex";
+import { getWantFindIndexFromTitles } from "../core/getWantFindIndex";
 import { matchFilterCondition } from "../filterConditions/matchFilterCondition";
 import { isDict } from "../other/isDict";
 import { isValueEqual } from "../other/isValueEqual";
@@ -15,14 +14,11 @@ const isAndMatch = (
   rowsData: HitRowData[],
   whereArray: WhereUse[],
   titles: GassmaAny[],
-  gassmaControllerUtil: GassmaControllerUtil,
 ) => {
   let resultRowsData: HitRowData[] = rowsData.concat();
 
   whereArray.forEach((where) => {
-    const wantFindIndex = getWantFindIndex(gassmaControllerUtil, {
-      where: where,
-    });
+    const wantFindIndex = getWantFindIndexFromTitles(titles, where);
 
     const findedDataIncludeNull = resultRowsData.map((row) => {
       const matchRow = wantFindIndex.filter((i) => {
@@ -46,12 +42,7 @@ const isAndMatch = (
     resultRowsData = findedDataIncludeNull.filter((data) => data !== null);
 
     if ("OR" in where || "AND" in where || "NOT" in where) {
-      resultRowsData = isLogicMatch(
-        resultRowsData,
-        where,
-        titles,
-        gassmaControllerUtil,
-      );
+      resultRowsData = isLogicMatch(resultRowsData, where, titles);
     }
   });
 

--- a/src/util/andOrNot/entry.ts
+++ b/src/util/andOrNot/entry.ts
@@ -1,5 +1,4 @@
 import type { GassmaAny, WhereUse } from "../../types/coreTypes";
-import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import type { HitRowData } from "../../types/hitRowDataType";
 import { isAndMatch } from "./and";
 import { isNotMatch } from "./not";
@@ -9,7 +8,6 @@ const isLogicMatch = (
   rowData: HitRowData[],
   where: WhereUse,
   titles: GassmaAny[],
-  gassmaControllerUtil: GassmaControllerUtil,
 ) => {
   const and = "AND" in where ? where.AND : null;
   const or = "OR" in where ? where.OR : null;
@@ -19,11 +17,11 @@ const isLogicMatch = (
 
   if (and) {
     const andArray = Array.isArray(and) ? and : [and];
-    result = isAndMatch(rowData, andArray, titles, gassmaControllerUtil);
+    result = isAndMatch(rowData, andArray, titles);
   }
 
   if (or) {
-    const orResult = isOrMatch(rowData, or, titles, gassmaControllerUtil);
+    const orResult = isOrMatch(rowData, or, titles);
 
     if (result.length === 0) result = orResult;
     else {
@@ -37,12 +35,7 @@ const isLogicMatch = (
 
   if (not) {
     const notArray = Array.isArray(not) ? not : [not];
-    const notResult = isNotMatch(
-      rowData,
-      notArray,
-      titles,
-      gassmaControllerUtil,
-    );
+    const notResult = isNotMatch(rowData, notArray, titles);
 
     if (result.length === 0) result = notResult;
     else {

--- a/src/util/andOrNot/not.ts
+++ b/src/util/andOrNot/not.ts
@@ -3,9 +3,8 @@ import type {
   GassmaAny,
   WhereUse,
 } from "../../types/coreTypes";
-import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import type { HitRowData } from "../../types/hitRowDataType";
-import { getWantFindIndex } from "../core/getWantFindIndex";
+import { getWantFindIndexFromTitles } from "../core/getWantFindIndex";
 import { matchFilterCondition } from "../filterConditions/matchFilterCondition";
 import { isDict } from "../other/isDict";
 import { isValueEqual } from "../other/isValueEqual";
@@ -15,14 +14,11 @@ const isNotMatch = (
   rowsData: HitRowData[],
   whereArray: WhereUse[],
   titles: GassmaAny[],
-  gassmaControllerUtil: GassmaControllerUtil,
 ) => {
   let resultRowsData: HitRowData[] = rowsData.concat();
 
   whereArray.forEach((where) => {
-    const wantFindIndex = getWantFindIndex(gassmaControllerUtil, {
-      where: where,
-    });
+    const wantFindIndex = getWantFindIndexFromTitles(titles, where);
 
     const findedDataIncludeNull = resultRowsData.map((row) => {
       const matchRow = wantFindIndex.filter((i) => {
@@ -47,12 +43,7 @@ const isNotMatch = (
       resultRowsData = findedDataIncludeNull.filter((data) => data !== null);
 
     if ("OR" in where || "AND" in where || "NOT" in where) {
-      resultRowsData = isLogicMatch(
-        resultRowsData,
-        where,
-        titles,
-        gassmaControllerUtil,
-      );
+      resultRowsData = isLogicMatch(resultRowsData, where, titles);
     }
   });
 

--- a/src/util/andOrNot/or.ts
+++ b/src/util/andOrNot/or.ts
@@ -3,9 +3,8 @@ import type {
   GassmaAny,
   WhereUse,
 } from "../../types/coreTypes";
-import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import type { HitRowData } from "../../types/hitRowDataType";
-import { getWantFindIndex } from "../core/getWantFindIndex";
+import { getWantFindIndexFromTitles } from "../core/getWantFindIndex";
 import { matchFilterCondition } from "../filterConditions/matchFilterCondition";
 import { isDict } from "../other/isDict";
 import { isValueEqual } from "../other/isValueEqual";
@@ -15,14 +14,11 @@ const isOrMatch = (
   rowsData: HitRowData[],
   whereArray: WhereUse[],
   titles: GassmaAny[],
-  gassmaControllerUtil: GassmaControllerUtil,
 ) => {
   let resultRowsData: HitRowData[] = rowsData.concat();
 
   whereArray.forEach((where, whereArrayIndex) => {
-    const wantFindIndex = getWantFindIndex(gassmaControllerUtil, {
-      where: where,
-    });
+    const wantFindIndex = getWantFindIndexFromTitles(titles, where);
 
     const findedDataIncludeNull = rowsData.map((row) => {
       const matchRow = wantFindIndex.filter((i) => {
@@ -46,12 +42,7 @@ const isOrMatch = (
     let findedData = findedDataIncludeNull.filter((data) => data !== null);
 
     if ("OR" in where || "AND" in where || "NOT" in where) {
-      findedData = isLogicMatch(
-        findedData,
-        where,
-        titles,
-        gassmaControllerUtil,
-      );
+      findedData = isLogicMatch(findedData, where, titles);
     }
 
     if (whereArrayIndex === 0) {

--- a/src/util/core/filterRowsByWhere.ts
+++ b/src/util/core/filterRowsByWhere.ts
@@ -1,0 +1,60 @@
+import type {
+  FilterConditions,
+  GassmaAny,
+  WhereUse,
+} from "../../types/coreTypes";
+import type { HitRowData } from "../../types/hitRowDataType";
+import { isLogicMatch } from "../andOrNot/entry";
+import { matchFilterCondition } from "../filterConditions/matchFilterCondition";
+import { isDict } from "../other/isDict";
+import { isValueEqual } from "../other/isValueEqual";
+import { getWantFindIndexFromTitles } from "./getWantFindIndex";
+
+const filterRowsByWhere = (
+  allDataList: GassmaAny[][],
+  titles: GassmaAny[],
+  where: WhereUse,
+): HitRowData[] => {
+  if (Object.keys(where).length === 0) {
+    return allDataList.map((row, index): HitRowData => {
+      return {
+        rowNumber: index + 1,
+        row: row,
+      };
+    });
+  }
+
+  const wantFindIndex = getWantFindIndexFromTitles(titles, where);
+
+  const findedDataIncludeNull = allDataList.map((row, rowNumber) => {
+    const matchRow = wantFindIndex.filter((i) => {
+      const whereOptionContent = where[String(titles[i])];
+      if (isDict(whereOptionContent))
+        return matchFilterCondition(
+          row[i],
+          whereOptionContent as FilterConditions,
+          row,
+          titles,
+        );
+
+      const replacedNullWhereOptionContent =
+        whereOptionContent === "" ? null : whereOptionContent;
+      return isValueEqual(row[i], replacedNullWhereOptionContent);
+    });
+
+    if (matchRow.length === wantFindIndex.length) {
+      const hitRowData: HitRowData = { rowNumber: rowNumber + 1, row: row };
+      return hitRowData;
+    }
+
+    return null;
+  });
+
+  const findedData = findedDataIncludeNull.filter((data) => data !== null);
+
+  if (!("OR" in where || "AND" in where || "NOT" in where)) return findedData;
+
+  return isLogicMatch(findedData, where, titles);
+};
+
+export { filterRowsByWhere };

--- a/src/util/core/getWantFindIndex.ts
+++ b/src/util/core/getWantFindIndex.ts
@@ -1,14 +1,12 @@
+import type { GassmaAny, WhereUse } from "../../types/coreTypes";
 import type { DeleteData, FindData, UpdateData } from "../../types/findTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import { getTitle } from "./getTitle";
 
-const getWantFindIndex = (
-  gassmaControllerUtil: GassmaControllerUtil,
-  wantData: FindData | DeleteData | UpdateData,
-) => {
-  const where = wantData.where;
-  const titles = getTitle(gassmaControllerUtil);
-
+const getWantFindIndexFromTitles = (
+  titles: GassmaAny[],
+  where: WhereUse,
+): number[] => {
   const wantFindKeys = Object.entries(where).map((oneData) => {
     return oneData[0];
   });
@@ -26,4 +24,13 @@ const getWantFindIndex = (
   return wantFindIndexRemovedMinusOne;
 };
 
-export { getWantFindIndex };
+const getWantFindIndex = (
+  gassmaControllerUtil: GassmaControllerUtil,
+  wantData: FindData | DeleteData | UpdateData,
+) => {
+  const titles = getTitle(gassmaControllerUtil);
+
+  return getWantFindIndexFromTitles(titles, wantData.where);
+};
+
+export { getWantFindIndex, getWantFindIndexFromTitles };

--- a/src/util/core/whereFilter.ts
+++ b/src/util/core/whereFilter.ts
@@ -1,66 +1,18 @@
-import type { FilterConditions, WhereUse } from "../../types/coreTypes";
-import type { FindData } from "../../types/findTypes";
+import type { WhereUse } from "../../types/coreTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import type { HitRowData } from "../../types/hitRowDataType";
-import { isLogicMatch } from "../andOrNot/entry";
-import { matchFilterCondition } from "../filterConditions/matchFilterCondition";
-import { isDict } from "../other/isDict";
-import { isValueEqual } from "../other/isValueEqual";
+import { filterRowsByWhere } from "./filterRowsByWhere";
 import { getAllData } from "./getAllData";
 import { getTitle } from "./getTitle";
-import { getWantFindIndex } from "./getWantFindIndex";
 
 const whereFilter = (
   where: WhereUse,
   gassmaControllerUtil: GassmaControllerUtil,
-) => {
+): HitRowData[] => {
   const allDataList = getAllData(gassmaControllerUtil);
   const titles = getTitle(gassmaControllerUtil);
 
-  if (Object.keys(where).length === 0) {
-    return allDataList.map((row, index): HitRowData => {
-      return {
-        rowNumber: index + 1,
-        row: row,
-      };
-    });
-  }
-
-  const findData: FindData = {
-    where: where,
-  };
-
-  const wantFindIndex = getWantFindIndex(gassmaControllerUtil, findData);
-
-  const findedDataIncludeNull = allDataList.map((row, rowNumber) => {
-    const matchRow = wantFindIndex.filter((i) => {
-      const whereOptionContent = where[String(titles[i])];
-      if (isDict(whereOptionContent))
-        return matchFilterCondition(
-          row[i],
-          whereOptionContent as FilterConditions,
-          row,
-          titles,
-        );
-
-      const replacedNullWhereOptionContent =
-        whereOptionContent === "" ? null : whereOptionContent;
-      return isValueEqual(row[i], replacedNullWhereOptionContent);
-    });
-
-    if (matchRow.length === wantFindIndex.length) {
-      const hitRowData: HitRowData = { rowNumber: rowNumber + 1, row: row };
-      return hitRowData;
-    }
-
-    return null;
-  });
-
-  const findedData = findedDataIncludeNull.filter((data) => data !== null);
-
-  if (!("OR" in where || "AND" in where || "NOT" in where)) return findedData;
-
-  return isLogicMatch(findedData, where, titles, gassmaControllerUtil);
+  return filterRowsByWhere(allDataList, titles, where);
 };
 
 export { whereFilter };

--- a/src/util/create/nestedWrite/connectBatch/connectItems.ts
+++ b/src/util/create/nestedWrite/connectBatch/connectItems.ts
@@ -1,0 +1,52 @@
+import { NestedWriteConnectNotFoundError } from "../../../../errors/relation/nestedWriteError";
+import type { AnyUse, WhereUse } from "../../../../types/coreTypes";
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../../types/relationTypes";
+import { createTargetTable } from "./targetTable";
+import { hasTopLevelEmptyString } from "./whereScan";
+
+const batchConnect = (
+  relation: RelationDefinition,
+  items: WhereUse[],
+  fkData: AnyUse,
+  context: RelationContext,
+): void => {
+  const table = createTargetTable(context, relation.to);
+
+  const plans = items.map((where) => {
+    const local = table.canEvaluate(where);
+    const exists = local
+      ? table.matchRecords(where).length > 0
+      : context.findManyOnSheet(relation.to, { where }).length > 0;
+    const mergeable = local && !hasTopLevelEmptyString(where);
+    return { where, exists, mergeable };
+  });
+
+  if (plans.some((plan) => !plan.exists)) {
+    throw new NestedWriteConnectNotFoundError(relation.to);
+  }
+
+  const merged = plans.filter((plan) => plan.mergeable).map((p) => p.where);
+  if (merged.length === 1) {
+    context.updateManyOnSheet(relation.to, { where: merged[0], data: fkData });
+  }
+  if (merged.length >= 2) {
+    context.updateManyOnSheet(relation.to, {
+      where: { OR: merged },
+      data: fkData,
+    });
+  }
+
+  plans
+    .filter((plan) => !plan.mergeable)
+    .forEach((plan) => {
+      context.updateManyOnSheet(relation.to, {
+        where: plan.where,
+        data: fkData,
+      });
+    });
+};
+
+export { batchConnect };

--- a/src/util/create/nestedWrite/connectBatch/connectOrCreateItems.ts
+++ b/src/util/create/nestedWrite/connectBatch/connectOrCreateItems.ts
@@ -1,0 +1,100 @@
+import type { AnyUse, GassmaAny, WhereUse } from "../../../../types/coreTypes";
+import type { ConnectOrCreateInput } from "../../../../types/nestedWriteTypes";
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../../types/relationTypes";
+import { createTargetTable } from "./targetTable";
+import { collectWhereFieldKeys, hasTopLevelEmptyString } from "./whereScan";
+
+const referencesFkColumn = (
+  items: ConnectOrCreateInput[],
+  fkColumn: string,
+): boolean =>
+  items.some((input) => collectWhereFieldKeys(input.where).has(fkColumn));
+
+const batchConnectOrCreate = (
+  relation: RelationDefinition,
+  items: ConnectOrCreateInput[],
+  parentValue: GassmaAny,
+  context: RelationContext,
+): void => {
+  const fkData: AnyUse = { [relation.reference]: parentValue };
+
+  const createItem = (input: ConnectOrCreateInput) => {
+    context.createOnSheet(relation.to, {
+      data: { ...input.create, [relation.reference]: parentValue },
+    });
+  };
+
+  const legacyItem = (input: ConnectOrCreateInput): boolean => {
+    const found = context.findManyOnSheet(relation.to, { where: input.where });
+    if (found.length > 0) {
+      context.updateManyOnSheet(relation.to, {
+        where: input.where,
+        data: fkData,
+      });
+      return false;
+    }
+    createItem(input);
+    return true;
+  };
+
+  if (referencesFkColumn(items, relation.reference)) {
+    items.forEach((input) => {
+      legacyItem(input);
+    });
+    return;
+  }
+
+  const table = createTargetTable(context, relation.to);
+  const deferredWheres: WhereUse[] = [];
+  let stale = false;
+
+  const existsLocally = (where: WhereUse): boolean => {
+    if (table.matchRecords(where).length > 0) return true;
+    if (!stale) return false;
+    table.refresh();
+    stale = false;
+    return table.matchRecords(where).length > 0;
+  };
+
+  const eligibleItem = (input: ConnectOrCreateInput) => {
+    if (!existsLocally(input.where)) {
+      createItem(input);
+      stale = true;
+      return;
+    }
+    if (hasTopLevelEmptyString(input.where)) {
+      context.updateManyOnSheet(relation.to, {
+        where: input.where,
+        data: fkData,
+      });
+      return;
+    }
+    deferredWheres.push(input.where);
+  };
+
+  items.forEach((input) => {
+    if (table.canEvaluate(input.where)) {
+      eligibleItem(input);
+      return;
+    }
+    if (legacyItem(input)) stale = true;
+  });
+
+  if (deferredWheres.length === 1) {
+    context.updateManyOnSheet(relation.to, {
+      where: deferredWheres[0],
+      data: fkData,
+    });
+  }
+  if (deferredWheres.length >= 2) {
+    context.updateManyOnSheet(relation.to, {
+      where: { OR: deferredWheres },
+      data: fkData,
+    });
+  }
+};
+
+export { batchConnectOrCreate };

--- a/src/util/create/nestedWrite/connectBatch/manyToManyItems.ts
+++ b/src/util/create/nestedWrite/connectBatch/manyToManyItems.ts
@@ -1,0 +1,84 @@
+import { NestedWriteConnectNotFoundError } from "../../../../errors/relation/nestedWriteError";
+import type { WhereUse } from "../../../../types/coreTypes";
+import type { ConnectOrCreateInput } from "../../../../types/nestedWriteTypes";
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../../types/relationTypes";
+import { createTargetTable } from "./targetTable";
+
+type JunctionWriter = (targetValue: unknown) => void;
+
+const batchManyToManyConnect = (
+  relation: RelationDefinition,
+  items: WhereUse[],
+  context: RelationContext,
+  createJunctionRow: JunctionWriter,
+): void => {
+  const table = createTargetTable(context, relation.to);
+
+  const foundRecords = items.map((where) => {
+    const found = table.canEvaluate(where)
+      ? table.matchRecords(where)
+      : context.findManyOnSheet(relation.to, { where });
+    return found.length > 0 ? found[0] : null;
+  });
+
+  if (foundRecords.some((record) => record === null)) {
+    throw new NestedWriteConnectNotFoundError(relation.to);
+  }
+
+  foundRecords.forEach((record) => {
+    createJunctionRow(record[relation.reference]);
+  });
+};
+
+const batchManyToManyConnectOrCreate = (
+  relation: RelationDefinition,
+  items: ConnectOrCreateInput[],
+  context: RelationContext,
+  createJunctionRow: JunctionWriter,
+): void => {
+  const table = createTargetTable(context, relation.to);
+  let stale = false;
+
+  const findLocally = (where: WhereUse): Record<string, unknown> | null => {
+    const matched = table.matchRecords(where);
+    if (matched.length > 0) return matched[0];
+    if (!stale) return null;
+    table.refresh();
+    stale = false;
+    const refreshed = table.matchRecords(where);
+    return refreshed.length > 0 ? refreshed[0] : null;
+  };
+
+  const createTargetWithJunction = (input: ConnectOrCreateInput) => {
+    const created = context.createOnSheet(relation.to, { data: input.create });
+    stale = true;
+    createJunctionRow(created[relation.reference]);
+  };
+
+  const legacyItem = (input: ConnectOrCreateInput) => {
+    const found = context.findManyOnSheet(relation.to, { where: input.where });
+    if (found.length > 0) {
+      createJunctionRow(found[0][relation.reference]);
+      return;
+    }
+    createTargetWithJunction(input);
+  };
+
+  items.forEach((input) => {
+    if (!table.canEvaluate(input.where)) {
+      legacyItem(input);
+      return;
+    }
+    const found = findLocally(input.where);
+    if (found !== null) {
+      createJunctionRow(found[relation.reference]);
+      return;
+    }
+    createTargetWithJunction(input);
+  });
+};
+
+export { batchManyToManyConnect, batchManyToManyConnectOrCreate };

--- a/src/util/create/nestedWrite/connectBatch/targetTable.ts
+++ b/src/util/create/nestedWrite/connectBatch/targetTable.ts
@@ -1,0 +1,62 @@
+import type { GassmaAny, WhereUse } from "../../../../types/coreTypes";
+import type { RelationContext } from "../../../../types/relationTypes";
+import { filterRowsByWhere } from "../../../core/filterRowsByWhere";
+import { isGassmaAny } from "../../../relation/collectKeys";
+import { collectWhereFieldKeys } from "./whereScan";
+
+type TargetTable = {
+  refresh: () => void;
+  canEvaluate: (where: WhereUse) => boolean;
+  matchRecords: (where: WhereUse) => Record<string, unknown>[];
+};
+
+const toCellValue = (value: unknown): GassmaAny =>
+  isGassmaAny(value) ? value : null;
+
+const createTargetTable = (
+  context: RelationContext,
+  sheetName: string,
+): TargetTable => {
+  let records: Record<string, unknown>[] | null = null;
+  let titles: string[] = [];
+  let titleSet = new Set<string>();
+  let rows: GassmaAny[][] = [];
+
+  const relationNames = new Set(
+    context.relationNamesOnSheet ? context.relationNamesOnSheet(sheetName) : [],
+  );
+
+  const refresh = () => {
+    const fetched = context.findManyOnSheet(sheetName, {});
+    records = fetched;
+    titles = fetched.length > 0 ? Object.keys(fetched[0]) : [];
+    titleSet = new Set(titles);
+    rows = fetched.map((record) => titles.map((t) => toCellValue(record[t])));
+  };
+
+  const ensure = () => {
+    if (records === null) refresh();
+  };
+
+  const canEvaluate = (where: WhereUse): boolean => {
+    ensure();
+    const emptyTable = records.length === 0;
+    let evaluable = true;
+    collectWhereFieldKeys(where).forEach((key) => {
+      if (relationNames.has(key)) evaluable = false;
+      if (!emptyTable && !titleSet.has(key)) evaluable = false;
+    });
+    return evaluable;
+  };
+
+  const matchRecords = (where: WhereUse): Record<string, unknown>[] => {
+    ensure();
+    const hits = filterRowsByWhere(rows, titles, where);
+    return hits.map((hit) => records[hit.rowNumber - 1]);
+  };
+
+  return { refresh, canEvaluate, matchRecords };
+};
+
+export { createTargetTable };
+export type { TargetTable };

--- a/src/util/create/nestedWrite/connectBatch/whereScan.ts
+++ b/src/util/create/nestedWrite/connectBatch/whereScan.ts
@@ -1,0 +1,49 @@
+import { isFieldRef } from "../../../filterConditions/fieldRef";
+import { isDict } from "../../../other/isDict";
+
+const LOGIC_KEYS = new Set(["AND", "OR", "NOT"]);
+
+const collectFieldRefNames = (value: unknown, keys: Set<string>): void => {
+  if (isFieldRef(value)) {
+    keys.add(value.name);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item) => {
+      collectFieldRefNames(item, keys);
+    });
+    return;
+  }
+  if (isDict(value)) {
+    Object.values(value).forEach((item) => {
+      collectFieldRefNames(item, keys);
+    });
+  }
+};
+
+const collectInto = (where: Record<string, unknown>, keys: Set<string>) => {
+  Object.entries(where).forEach(([key, value]) => {
+    if (LOGIC_KEYS.has(key)) {
+      const branches = Array.isArray(value) ? value : [value];
+      branches.forEach((branch) => {
+        if (isDict(branch)) collectInto(branch, keys);
+      });
+      return;
+    }
+    keys.add(key);
+    collectFieldRefNames(value, keys);
+  });
+};
+
+const collectWhereFieldKeys = (where: Record<string, unknown>): Set<string> => {
+  const keys = new Set<string>();
+  collectInto(where, keys);
+  return keys;
+};
+
+const hasTopLevelEmptyString = (where: Record<string, unknown>): boolean =>
+  Object.entries(where).some(
+    ([key, value]) => !LOGIC_KEYS.has(key) && value === "",
+  );
+
+export { collectWhereFieldKeys, hasTopLevelEmptyString };

--- a/src/util/create/nestedWrite/processAfterCreate.ts
+++ b/src/util/create/nestedWrite/processAfterCreate.ts
@@ -1,8 +1,10 @@
-import type { AnyUse } from "../../../types/coreTypes";
-import type { RelationContext } from "../../../types/relationTypes";
-import type { NestedWriteOperation } from "../../../types/nestedWriteTypes";
 import { NestedWriteConnectNotFoundError } from "../../../errors/relation/nestedWriteError";
+import type { AnyUse } from "../../../types/coreTypes";
+import type { NestedWriteOperation } from "../../../types/nestedWriteTypes";
+import type { RelationContext } from "../../../types/relationTypes";
 import { isGassmaAny } from "../../relation/collectKeys";
+import { batchConnect } from "./connectBatch/connectItems";
+import { batchConnectOrCreate } from "./connectBatch/connectOrCreateItems";
 
 const processAfterCreate = (
   createdRecord: Record<string, unknown>,
@@ -21,7 +23,7 @@ const processAfterCreate = (
     if (ops.create) {
       const items = Array.isArray(ops.create) ? ops.create : [ops.create];
       items.forEach((item) => {
-        context.createOnSheet!(relation.to, {
+        context.createOnSheet(relation.to, {
           data: { ...item, [relation.reference]: parentValue },
         });
       });
@@ -32,37 +34,45 @@ const processAfterCreate = (
         ...item,
         [relation.reference]: parentValue,
       }));
-      context.createManyOnSheet!(relation.to, { data: enrichedData });
+      context.createManyOnSheet(relation.to, { data: enrichedData });
     }
 
     if (ops.connect) {
       const items = Array.isArray(ops.connect) ? ops.connect : [ops.connect];
       const fkData: AnyUse = { [relation.reference]: parentValue };
-      items.forEach((where) => {
-        const found = context.findManyOnSheet(relation.to, { where });
-        if (found.length === 0) {
-          throw new NestedWriteConnectNotFoundError(relation.to);
-        }
-        context.updateManyOnSheet!(relation.to, { where, data: fkData });
-      });
+      if (items.length > 1) {
+        batchConnect(relation, items, fkData, context);
+      } else {
+        items.forEach((where) => {
+          const found = context.findManyOnSheet(relation.to, { where });
+          if (found.length === 0) {
+            throw new NestedWriteConnectNotFoundError(relation.to);
+          }
+          context.updateManyOnSheet(relation.to, { where, data: fkData });
+        });
+      }
     }
 
     if (ops.connectOrCreate) {
       const items = Array.isArray(ops.connectOrCreate)
         ? ops.connectOrCreate
         : [ops.connectOrCreate];
+      if (items.length > 1) {
+        batchConnectOrCreate(relation, items, parentValue, context);
+        return;
+      }
       items.forEach((input) => {
         const found = context.findManyOnSheet(relation.to, {
           where: input.where,
         });
         if (found.length > 0) {
           const fkData: AnyUse = { [relation.reference]: parentValue };
-          context.updateManyOnSheet!(relation.to, {
+          context.updateManyOnSheet(relation.to, {
             where: input.where,
             data: fkData,
           });
         } else {
-          context.createOnSheet!(relation.to, {
+          context.createOnSheet(relation.to, {
             data: { ...input.create, [relation.reference]: parentValue },
           });
         }

--- a/src/util/create/nestedWrite/processManyToMany.ts
+++ b/src/util/create/nestedWrite/processManyToMany.ts
@@ -1,6 +1,10 @@
-import type { RelationContext } from "../../../types/relationTypes";
-import type { NestedWriteOperation } from "../../../types/nestedWriteTypes";
 import { NestedWriteConnectNotFoundError } from "../../../errors/relation/nestedWriteError";
+import type { NestedWriteOperation } from "../../../types/nestedWriteTypes";
+import type { RelationContext } from "../../../types/relationTypes";
+import {
+  batchManyToManyConnect,
+  batchManyToManyConnectOrCreate,
+} from "./connectBatch/manyToManyItems";
 
 const processManyToMany = (
   createdRecord: Record<string, unknown>,
@@ -14,9 +18,10 @@ const processManyToMany = (
 
     const { through } = relation;
     const parentValue = createdRecord[relation.field];
+    const selfJunction = through.sheet === relation.to;
 
     const createJunctionRow = (targetValue: unknown) => {
-      context.createOnSheet!(through.sheet, {
+      context.createOnSheet(through.sheet, {
         data: {
           [through.field]: parentValue,
           [through.reference]: targetValue,
@@ -27,26 +32,39 @@ const processManyToMany = (
     if (ops.create) {
       const items = Array.isArray(ops.create) ? ops.create : [ops.create];
       items.forEach((item) => {
-        const created = context.createOnSheet!(relation.to, { data: item });
+        const created = context.createOnSheet(relation.to, { data: item });
         createJunctionRow(created[relation.reference]);
       });
     }
 
     if (ops.connect) {
       const items = Array.isArray(ops.connect) ? ops.connect : [ops.connect];
-      items.forEach((where) => {
-        const found = context.findManyOnSheet(relation.to, { where });
-        if (found.length === 0) {
-          throw new NestedWriteConnectNotFoundError(relation.to);
-        }
-        createJunctionRow(found[0][relation.reference]);
-      });
+      if (items.length > 1 && !selfJunction) {
+        batchManyToManyConnect(relation, items, context, createJunctionRow);
+      } else {
+        items.forEach((where) => {
+          const found = context.findManyOnSheet(relation.to, { where });
+          if (found.length === 0) {
+            throw new NestedWriteConnectNotFoundError(relation.to);
+          }
+          createJunctionRow(found[0][relation.reference]);
+        });
+      }
     }
 
     if (ops.connectOrCreate) {
       const items = Array.isArray(ops.connectOrCreate)
         ? ops.connectOrCreate
         : [ops.connectOrCreate];
+      if (items.length > 1 && !selfJunction) {
+        batchManyToManyConnectOrCreate(
+          relation,
+          items,
+          context,
+          createJunctionRow,
+        );
+        return;
+      }
       items.forEach((input) => {
         const found = context.findManyOnSheet(relation.to, {
           where: input.where,
@@ -54,7 +72,7 @@ const processManyToMany = (
         if (found.length > 0) {
           createJunctionRow(found[0][relation.reference]);
         } else {
-          const created = context.createOnSheet!(relation.to, {
+          const created = context.createOnSheet(relation.to, {
             data: input.create,
           });
           createJunctionRow(created[relation.reference]);


### PR DESCRIPTION
## 概要

N+1 調査の**発見2(nested write の K 比例 N+1)**の修正です。

`connect` は現在、**アイテムごとに** `findManyOnSheet`(存在チェック)+ `updateManyOnSheet`(書き込み)を呼んでおり、K 件つなぐと対象シートを **2K〜3K 回フル読み + K 回書き**していました(`create({ data: { posts: { connect: [50件] } } })` で数百 GAS コール = 6分制限に接触し得る)。

これを **対象シート1回読み + `{ OR: [...全where] }` に合成した updateManyOnSheet 1回**にまとめます。connect 先は全て同じ FK 値を書くので合成でき、書き込みは #170 の連続ラン束ねがさらに畳みます。

## whereFilter の分割(共有のため)

シートを再読せずに where を判定する必要があるため、`whereFilter` を **読み(`getAllData`/`getTitle`)と照合**に分離し、照合部を `filterRowsByWhere` へ**逐語移設**して両者で共有します。`and`/`or`/`not` は「titles を取るためだけ」に受け取っていた controller util をやめ titles を直接受け取ります。

**挙動不変の担保は「既存テストが無修正で全通ること」**(where 系を含む 1782 件)。

## ✅ 承認済みの挙動変更(1点のみ)

`connect` に存在しない対象があると、**先行アイテムを書く前に throw** します(現状は先行分が書かれてから throw = 部分適用が残る)。**エラーの型・メッセージは完全に同一**。

Prisma は nested write 全体がトランザクションで**親 create ごと巻き戻る**(prisma-test で実測)ため、これは Prisma に一歩近づく変更です。ただし**親 create は残ります**(完全な原子性が要るなら `$transaction`)。

## フォールバック(正しさ優先で従来動作)

ローカルのスナップショットで忠実に評価できないものは**従来の per-item 経路**に戻します:
- 対象シートの列に無いキー(globalOmit/ignore・未知キー・リレーションフィルタ)
- リレーション名と同名のキー
- トップレベルの空文字値(**書き込みのみ** per-item)
- `connectOrCreate` で FK 列を参照する項目(項目間の書き込み可視性を保つため)
- manyToMany の自己 junction(`through.sheet === relation.to`)

## 読み書き回数(K≥2)

| | before | after |
|---|---|---|
| oneToMany connect | 読み 2K〜3K / 書き K | **読み 1 / 書き 1** |
| oneToMany connectOrCreate | 読み K | **読み 1**(全件既存時) |
| manyToMany connect / connectOrCreate | 読み K | **読み 1** |

update 側(`resolveNestedUpdate`)は同じ処理を再利用しているため自動的に効きます。K≤1 は従来コードのままです。

## 検証

- `npx jest`: **1828 passed**(既存 1782 は**無修正**で全通過)
- `npx tsc --noEmit`: clean / `npm run build`: 成功 / **`npm run verify:bundle`: OK(51/51)**
- `biome`: **変更14ファイルすべて診断ゼロ**(リポジトリ全体は既存分 105 → 95 に減少)

## スコープ外(後続)

`create: [...]` 配列 / junction 行の `createMany` 化、update 側の set/disconnect/delete 配列、横断的な読みキャッシュ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)