### PR TITLE
fix: stop cascaded key updates from catching their own writes

### DIFF
--- a/src/__test__/util/relation/onUpdate/cascadeTempValue.test.ts
+++ b/src/__test__/util/relation/onUpdate/cascadeTempValue.test.ts
@@ -1,0 +1,34 @@
+import {
+  CASCADE_TEMP_PREFIX,
+  createTempValueFactory,
+} from "../../../../util/relation/onUpdate/cascadeTempValue";
+
+describe("createTempValueFactory", () => {
+  it("呼び出すたびに異なる値を返す", () => {
+    const next = createTempValueFactory(() => false);
+
+    const values = [next(), next(), next()];
+
+    expect(new Set(values).size).toBe(3);
+    values.forEach((value) => {
+      expect(value.startsWith(CASCADE_TEMP_PREFIX)).toBe(true);
+    });
+  });
+
+  it("使用中の候補はスキップして別の値を返す", () => {
+    const next = createTempValueFactory(
+      (candidate) => candidate === `${CASCADE_TEMP_PREFIX}0`,
+    );
+
+    expect(next()).toBe(`${CASCADE_TEMP_PREFIX}0_`);
+    expect(next()).toBe(`${CASCADE_TEMP_PREFIX}1`);
+  });
+
+  it("プローブが常に使用中と答えても停止する", () => {
+    const isTaken = jest.fn(() => true);
+    const next = createTempValueFactory(isTaken);
+
+    expect(next()).toBe(`${CASCADE_TEMP_PREFIX}0${"_".repeat(32)}`);
+    expect(isTaken).toHaveBeenCalledTimes(32);
+  });
+});

--- a/src/__test__/util/relation/onUpdate/cascadeUpdateOrder.test.ts
+++ b/src/__test__/util/relation/onUpdate/cascadeUpdateOrder.test.ts
@@ -1,0 +1,453 @@
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../../types/relationTypes";
+import {
+  containsValue,
+  isValueEqual,
+} from "../../../../util/other/isValueEqual";
+import { CASCADE_TEMP_PREFIX } from "../../../../util/relation/onUpdate/cascadeTempValue";
+import { resolveOnUpdate } from "../../../../util/relation/onUpdate/resolveOnUpdate";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "../../transaction/transactionTestClient";
+
+type Row = Record<string, unknown>;
+
+const inList = (condition: unknown): unknown[] | null => {
+  if (condition === null || typeof condition !== "object") return null;
+  const candidate = Reflect.get(condition, "in");
+  return Array.isArray(candidate) ? candidate : null;
+};
+
+const matchesWhere = (row: Row, where?: Record<string, unknown>): boolean =>
+  Object.entries(where ?? {}).every(([field, condition]) => {
+    const list = inList(condition);
+    if (list) return containsValue(list, row[field]);
+    return isValueEqual(row[field], condition);
+  });
+
+type UpdateCall = { sheet: string; where: unknown; data: unknown };
+
+type Store = {
+  context: RelationContext;
+  rows: (sheet: string) => Row[];
+  updateCalls: UpdateCall[];
+  findCalls: string[];
+};
+
+const makeStore = (
+  relations: Record<string, RelationDefinition>,
+  sheets: Record<string, Row[]>,
+): Store => {
+  const data: Record<string, Row[]> = {};
+  Object.entries(sheets).forEach(([name, rows]) => {
+    data[name] = rows.map((row) => ({ ...row }));
+  });
+  const updateCalls: UpdateCall[] = [];
+  const findCalls: string[] = [];
+
+  const context: RelationContext = {
+    relations,
+    findManyOnSheet: (sheetName, findData) => {
+      findCalls.push(sheetName);
+      return (data[sheetName] ?? []).filter((row) =>
+        matchesWhere(row, findData.where),
+      );
+    },
+    updateManyOnSheet: (sheetName, updateData) => {
+      updateCalls.push({
+        sheet: sheetName,
+        where: updateData.where,
+        data: updateData.data,
+      });
+      const targets = (data[sheetName] ?? []).filter((row) =>
+        matchesWhere(row, updateData.where),
+      );
+      targets.forEach((row) => {
+        Object.assign(row, updateData.data);
+      });
+      return { count: targets.length };
+    },
+  };
+
+  return {
+    context,
+    rows: (sheet) => data[sheet] ?? [],
+    updateCalls,
+    findCalls,
+  };
+};
+
+const oneToManyCascade: Record<string, RelationDefinition> = {
+  posts: {
+    type: "oneToMany",
+    to: "Posts",
+    field: "id",
+    reference: "authorId",
+    onUpdate: "Cascade",
+  },
+};
+
+const manyToManyCascade: Record<string, RelationDefinition> = {
+  tags: {
+    type: "manyToMany",
+    to: "Tags",
+    field: "id",
+    reference: "id",
+    through: { sheet: "PostTags", field: "postId", reference: "tagId" },
+    onUpdate: "Cascade",
+  },
+};
+
+describe("Cascade onUpdate は先行する更新結果を拾わない（oneToMany）", () => {
+  it("id を一括インクリメントしても子の FK が玉突きしない", () => {
+    const store = makeStore(oneToManyCascade, {
+      Posts: [
+        { id: 101, authorId: 1 },
+        { id: 102, authorId: 2 },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 2 }],
+      [{ id: 2 }, { id: 3 }],
+      store.context,
+    );
+
+    expect(store.rows("Posts")).toEqual([
+      { id: 101, authorId: 2 },
+      { id: 102, authorId: 3 },
+    ]);
+  });
+
+  it("3件の連鎖インクリメントでも玉突きしない", () => {
+    const store = makeStore(oneToManyCascade, {
+      Posts: [
+        { id: 101, authorId: 1 },
+        { id: 102, authorId: 2 },
+        { id: 103, authorId: 3 },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 2 }, { id: 3 }],
+      [{ id: 2 }, { id: 3 }, { id: 4 }],
+      store.context,
+    );
+
+    expect(store.rows("Posts")).toEqual([
+      { id: 101, authorId: 2 },
+      { id: 102, authorId: 3 },
+      { id: 103, authorId: 4 },
+    ]);
+  });
+
+  it("デクリメント方向（先に空く側）でも正しい", () => {
+    const store = makeStore(oneToManyCascade, {
+      Posts: [
+        { id: 101, authorId: 2 },
+        { id: 102, authorId: 3 },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 2 }, { id: 3 }],
+      [{ id: 1 }, { id: 2 }],
+      store.context,
+    );
+
+    expect(store.rows("Posts")).toEqual([
+      { id: 101, authorId: 1 },
+      { id: 102, authorId: 2 },
+    ]);
+  });
+
+  it("2値の入れ替え（循環）でも入れ替わる", () => {
+    const store = makeStore(oneToManyCascade, {
+      Posts: [
+        { id: 101, authorId: 1 },
+        { id: 102, authorId: 2 },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 2 }],
+      [{ id: 2 }, { id: 1 }],
+      store.context,
+    );
+
+    expect(store.rows("Posts")).toEqual([
+      { id: 101, authorId: 2 },
+      { id: 102, authorId: 1 },
+    ]);
+  });
+
+  it("3値の循環（1→2→3→1）でも正しく回る", () => {
+    const store = makeStore(oneToManyCascade, {
+      Posts: [
+        { id: 101, authorId: 1 },
+        { id: 102, authorId: 2 },
+        { id: 103, authorId: 3 },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 2 }, { id: 3 }],
+      [{ id: 2 }, { id: 3 }, { id: 1 }],
+      store.context,
+    );
+
+    expect(store.rows("Posts")).toEqual([
+      { id: 101, authorId: 2 },
+      { id: 102, authorId: 3 },
+      { id: 103, authorId: 1 },
+    ]);
+  });
+
+  it("循環と非循環が混在しても両方正しい", () => {
+    const store = makeStore(oneToManyCascade, {
+      Posts: [
+        { id: 101, authorId: 1 },
+        { id: 102, authorId: 2 },
+        { id: 103, authorId: 7 },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 2 }, { id: 7 }],
+      [{ id: 2 }, { id: 1 }, { id: 8 }],
+      store.context,
+    );
+
+    expect(store.rows("Posts")).toEqual([
+      { id: 101, authorId: 2 },
+      { id: 102, authorId: 1 },
+      { id: 103, authorId: 8 },
+    ]);
+  });
+
+  it("循環処理は無関係な行を巻き込まない", () => {
+    const store = makeStore(oneToManyCascade, {
+      Posts: [
+        { id: 101, authorId: 1 },
+        { id: 102, authorId: 2 },
+        { id: 103, authorId: 5 },
+        { id: 104, authorId: null },
+        { id: 105, authorId: "keep" },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 2 }],
+      [{ id: 2 }, { id: 1 }],
+      store.context,
+    );
+
+    expect(store.rows("Posts")).toEqual([
+      { id: 101, authorId: 2 },
+      { id: 102, authorId: 1 },
+      { id: 103, authorId: 5 },
+      { id: 104, authorId: null },
+      { id: 105, authorId: "keep" },
+    ]);
+  });
+
+  it("Date キーの入れ替えでも正しい", () => {
+    const a = new Date("2026-01-01T00:00:00.000Z");
+    const b = new Date("2026-02-01T00:00:00.000Z");
+    const store = makeStore(
+      {
+        posts: {
+          type: "oneToMany",
+          to: "Posts",
+          field: "key",
+          reference: "authorKey",
+          onUpdate: "Cascade",
+        },
+      },
+      {
+        Posts: [
+          { id: 101, authorKey: new Date(a.getTime()) },
+          { id: 102, authorKey: new Date(b.getTime()) },
+        ],
+      },
+    );
+
+    resolveOnUpdate(
+      [{ key: a }, { key: b }],
+      [{ key: b }, { key: a }],
+      store.context,
+    );
+
+    expect(store.rows("Posts")).toEqual([
+      { id: 101, authorKey: b },
+      { id: 102, authorKey: a },
+    ]);
+  });
+});
+
+describe("Cascade onUpdate は先行する更新結果を拾わない（manyToMany）", () => {
+  it("中間テーブルの玉突きが起きない", () => {
+    const store = makeStore(manyToManyCascade, {
+      PostTags: [
+        { postId: 1, tagId: 9 },
+        { postId: 2, tagId: 9 },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 2 }],
+      [{ id: 2 }, { id: 3 }],
+      store.context,
+    );
+
+    expect(store.rows("PostTags")).toEqual([
+      { postId: 2, tagId: 9 },
+      { postId: 3, tagId: 9 },
+    ]);
+  });
+
+  it("中間テーブルでも入れ替え（循環）が成立する", () => {
+    const store = makeStore(manyToManyCascade, {
+      PostTags: [
+        { postId: 1, tagId: 9 },
+        { postId: 2, tagId: 9 },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 2 }],
+      [{ id: 2 }, { id: 1 }],
+      store.context,
+    );
+
+    expect(store.rows("PostTags")).toEqual([
+      { postId: 2, tagId: 9 },
+      { postId: 1, tagId: 9 },
+    ]);
+  });
+});
+
+describe("Cascade onUpdate の更新呼び出し回数", () => {
+  it("同じ新値に集約されるペアは1回の updateMany にまとめる", () => {
+    const store = makeStore(oneToManyCascade, {
+      Posts: [
+        { id: 101, authorId: 1 },
+        { id: 102, authorId: 2 },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 2 }],
+      [{ id: 9 }, { id: 9 }],
+      store.context,
+    );
+
+    expect(store.updateCalls).toEqual([
+      {
+        sheet: "Posts",
+        where: { authorId: { in: [1, 2] } },
+        data: { authorId: 9 },
+      },
+    ]);
+    expect(store.rows("Posts")).toEqual([
+      { id: 101, authorId: 9 },
+      { id: 102, authorId: 9 },
+    ]);
+  });
+
+  it("独立したペアは並べ替えても余計な往復を増やさない", () => {
+    const store = makeStore(oneToManyCascade, {
+      Posts: [
+        { id: 101, authorId: 1 },
+        { id: 102, authorId: 2 },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 2 }],
+      [{ id: 2 }, { id: 3 }],
+      store.context,
+    );
+
+    expect(store.updateCalls).toHaveLength(2);
+    expect(store.findCalls).toEqual([]);
+  });
+
+  it("同じ旧値が複数ペアに現れた場合は最初のペアを採用する", () => {
+    const store = makeStore(oneToManyCascade, {
+      Posts: [{ id: 101, authorId: 1 }],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 1 }],
+      [{ id: 5 }, { id: 6 }],
+      store.context,
+    );
+
+    expect(store.rows("Posts")).toEqual([{ id: 101, authorId: 5 }]);
+  });
+});
+
+describe("updateMany 経由の Cascade（実クライアント）", () => {
+  afterEach(() => {
+    clearGasGlobals();
+    jest.restoreAllMocks();
+  });
+
+  it("全ユーザーの id を +1 しても Post の所有者が入れ替わらない", () => {
+    const env = buildTxTestEnv({ relations: true, cascade: true });
+    const users = Reflect.get(env.client, "Users");
+
+    users.updateMany({ where: {}, data: { id: { increment: 1 } } });
+
+    expect(env.posts.snapshot()).toEqual([
+      ["id", "authorId", "title"],
+      [101, 2, "Post A"],
+      [102, 3, "Post B"],
+    ]);
+  });
+});
+
+describe("Cascade の一時値はシート上の既存値と衝突しない", () => {
+  it("一時値そのものを FK に持つ行が入れ替えに巻き込まれない", () => {
+    const store = makeStore(oneToManyCascade, {
+      Posts: [
+        { id: 101, authorId: 1 },
+        { id: 102, authorId: 2 },
+        { id: 103, authorId: `${CASCADE_TEMP_PREFIX}0` },
+      ],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: 2 }],
+      [{ id: 2 }, { id: 1 }],
+      store.context,
+    );
+
+    expect(store.rows("Posts")).toEqual([
+      { id: 101, authorId: 2 },
+      { id: 102, authorId: 1 },
+      { id: 103, authorId: `${CASCADE_TEMP_PREFIX}0` },
+    ]);
+  });
+});
+
+describe("Cascade の一時値は入れ替え対象の値とも衝突しない", () => {
+  it("親の新キーが一時値と同じ文字列でも入れ替えが成立する", () => {
+    const sentinel = `${CASCADE_TEMP_PREFIX}0`;
+    const store = makeStore(oneToManyCascade, {
+      Posts: [{ id: 101, authorId: 1 }],
+    });
+
+    resolveOnUpdate(
+      [{ id: 1 }, { id: sentinel }],
+      [{ id: sentinel }, { id: 1 }],
+      store.context,
+    );
+
+    expect(store.rows("Posts")).toEqual([{ id: 101, authorId: sentinel }]);
+  });
+});

--- a/src/__test__/util/relation/onUpdate/cascadeUpdatePlan.test.ts
+++ b/src/__test__/util/relation/onUpdate/cascadeUpdatePlan.test.ts
@@ -1,0 +1,173 @@
+import type { ChangedPair } from "../../../../util/relation/onUpdate/cascadeUpdatePlan";
+import { buildCascadeSteps } from "../../../../util/relation/onUpdate/cascadeUpdatePlan";
+
+const makeTempFactory = () => {
+  let counter = 0;
+  return jest.fn(() => {
+    const value = `tmp${counter}`;
+    counter += 1;
+    return value;
+  });
+};
+
+describe("buildCascadeSteps", () => {
+  it("独立したペアは1グループずつそのまま並ぶ", () => {
+    const factory = makeTempFactory();
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: 10 },
+        { oldValue: 2, newValue: 20 },
+      ],
+      factory,
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [1], newValue: 10 },
+      { oldValues: [2], newValue: 20 },
+    ]);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("玉突きするペアは巻き込まれる側を先に実行する順になる", () => {
+    const factory = makeTempFactory();
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: 2 },
+        { oldValue: 2, newValue: 3 },
+      ],
+      factory,
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [2], newValue: 3 },
+      { oldValues: [1], newValue: 2 },
+    ]);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("同じ新値のペアは1ステップにまとまる", () => {
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: 9 },
+        { oldValue: 2, newValue: 9 },
+      ],
+      makeTempFactory(),
+    );
+
+    expect(steps).toEqual([{ oldValues: [1, 2], newValue: 9 }]);
+  });
+
+  it("同じ旧値が複数ペアに現れた場合は最初のペアを採用する", () => {
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: 5 },
+        { oldValue: 1, newValue: 6 },
+      ],
+      makeTempFactory(),
+    );
+
+    expect(steps).toEqual([{ oldValues: [1], newValue: 5 }]);
+  });
+
+  it("2値の循環は一時値を1つ使い最後に書き戻す", () => {
+    const factory = makeTempFactory();
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: 2 },
+        { oldValue: 2, newValue: 1 },
+      ],
+      factory,
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [1], newValue: "tmp0" },
+      { oldValues: [2], newValue: 1 },
+      { oldValues: ["tmp0"], newValue: 2 },
+    ]);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("3値の循環も一時値1つで解決し書き戻しは最後に回る", () => {
+    const factory = makeTempFactory();
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: 2 },
+        { oldValue: 2, newValue: 3 },
+        { oldValue: 3, newValue: 1 },
+      ],
+      factory,
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [1], newValue: "tmp0" },
+      { oldValues: [3], newValue: 1 },
+      { oldValues: [2], newValue: 3 },
+      { oldValues: ["tmp0"], newValue: 2 },
+    ]);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("Date の新値は同時刻・別インスタンスでも同じグループにまとまる", () => {
+    const target = new Date("2026-03-01T00:00:00.000Z");
+    const sameTimeTarget = new Date(target.getTime());
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: target },
+        { oldValue: 2, newValue: sameTimeTarget },
+      ],
+      makeTempFactory(),
+    );
+
+    expect(steps).toEqual([{ oldValues: [1, 2], newValue: target }]);
+  });
+
+  it("Date 同士の入れ替えも一時値で解決する", () => {
+    const a = new Date("2026-01-01T00:00:00.000Z");
+    const b = new Date("2026-02-01T00:00:00.000Z");
+    const factory = makeTempFactory();
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: a, newValue: b },
+        { oldValue: b, newValue: a },
+      ],
+      factory,
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [a], newValue: "tmp0" },
+      { oldValues: [b], newValue: a },
+      { oldValues: ["tmp0"], newValue: b },
+    ]);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("どのステップも oldValues が空にならない", () => {
+    const scenarios: ChangedPair[][] = [
+      [],
+      [{ oldValue: 1, newValue: 2 }],
+      [
+        { oldValue: 1, newValue: 2 },
+        { oldValue: 2, newValue: 1 },
+      ],
+      [
+        { oldValue: 1, newValue: 2 },
+        { oldValue: 2, newValue: 3 },
+        { oldValue: 3, newValue: 1 },
+        { oldValue: 5, newValue: 6 },
+        { oldValue: 6, newValue: 5 },
+        { oldValue: 7, newValue: 8 },
+      ],
+    ];
+
+    scenarios.forEach((pairs) => {
+      const steps = buildCascadeSteps(pairs, makeTempFactory());
+      expect(steps.every((step) => step.oldValues.length > 0)).toBe(true);
+    });
+  });
+});

--- a/src/util/relation/onUpdate/applyCascadeUpdate.ts
+++ b/src/util/relation/onUpdate/applyCascadeUpdate.ts
@@ -1,0 +1,55 @@
+import type { GassmaAny, WhereUse } from "../../../types/coreTypes";
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../types/relationTypes";
+import { containsValue } from "../../other/isValueEqual";
+import { createTempValueFactory } from "./cascadeTempValue";
+import type { CascadeStep, ChangedPair } from "./cascadeUpdatePlan";
+import { buildCascadeSteps } from "./cascadeUpdatePlan";
+
+type CascadeTarget = { sheet: string; field: string };
+
+const resolveCascadeTarget = (relation: RelationDefinition): CascadeTarget =>
+  relation.type === "manyToMany" && relation.through
+    ? { sheet: relation.through.sheet, field: relation.through.field }
+    : { sheet: relation.to, field: relation.reference };
+
+const buildStepWhere = (field: string, step: CascadeStep): WhereUse =>
+  step.oldValues.length === 1
+    ? { [field]: step.oldValues[0] }
+    : { [field]: { in: step.oldValues } };
+
+const collectPairValues = (changed: ChangedPair[]): GassmaAny[] => {
+  const values: GassmaAny[] = [];
+  changed.forEach(({ oldValue, newValue }) => {
+    values.push(oldValue, newValue);
+  });
+  return values;
+};
+
+const applyCascadeUpdate = (
+  changed: ChangedPair[],
+  relation: RelationDefinition,
+  context: RelationContext,
+): void => {
+  if (!context.updateManyOnSheet) return;
+
+  const { sheet, field } = resolveCascadeTarget(relation);
+  const reserved = collectPairValues(changed);
+  const nextTempValue = createTempValueFactory(
+    (candidate) =>
+      containsValue(reserved, candidate) ||
+      context.findManyOnSheet(sheet, { where: { [field]: candidate } }).length >
+        0,
+  );
+
+  buildCascadeSteps(changed, nextTempValue).forEach((step) => {
+    context.updateManyOnSheet?.(sheet, {
+      where: buildStepWhere(field, step),
+      data: { [field]: step.newValue },
+    });
+  });
+};
+
+export { applyCascadeUpdate, resolveCascadeTarget };

--- a/src/util/relation/onUpdate/cascadeTempValue.ts
+++ b/src/util/relation/onUpdate/cascadeTempValue.ts
@@ -1,0 +1,21 @@
+const CASCADE_TEMP_PREFIX = "__gassma_cascade_tmp_";
+
+const MAX_PROBE_ATTEMPTS = 32;
+
+const createTempValueFactory = (
+  isTaken: (candidate: string) => boolean,
+): (() => string) => {
+  let counter = 0;
+  return () => {
+    let candidate = `${CASCADE_TEMP_PREFIX}${counter}`;
+    counter += 1;
+    let attempts = 0;
+    while (attempts < MAX_PROBE_ATTEMPTS && isTaken(candidate)) {
+      candidate += "_";
+      attempts += 1;
+    }
+    return candidate;
+  };
+};
+
+export { CASCADE_TEMP_PREFIX, createTempValueFactory };

--- a/src/util/relation/onUpdate/cascadeUpdatePlan.ts
+++ b/src/util/relation/onUpdate/cascadeUpdatePlan.ts
@@ -1,0 +1,61 @@
+import type { GassmaAny } from "../../../types/coreTypes";
+import { containsValue, isValueEqual } from "../../other/isValueEqual";
+
+type ChangedPair = {
+  oldValue: GassmaAny;
+  newValue: GassmaAny;
+};
+
+type CascadeStep = {
+  oldValues: GassmaAny[];
+  newValue: GassmaAny;
+};
+
+const groupPairsByNewValue = (pairs: ChangedPair[]): CascadeStep[] => {
+  const groups: CascadeStep[] = [];
+  const seenOldValues: GassmaAny[] = [];
+  pairs.forEach(({ oldValue, newValue }) => {
+    if (containsValue(seenOldValues, oldValue)) return;
+    seenOldValues.push(oldValue);
+    const group = groups.find((g) => isValueEqual(g.newValue, newValue));
+    if (group) {
+      group.oldValues.push(oldValue);
+      return;
+    }
+    groups.push({ oldValues: [oldValue], newValue });
+  });
+  return groups;
+};
+
+const isBlocked = (group: CascadeStep, pending: CascadeStep[]): boolean =>
+  pending.some(
+    (other) =>
+      other !== group && containsValue(other.oldValues, group.newValue),
+  );
+
+const buildCascadeSteps = (
+  pairs: ChangedPair[],
+  nextTempValue: () => GassmaAny,
+): CascadeStep[] => {
+  const pending = groupPairsByNewValue(pairs);
+  const steps: CascadeStep[] = [];
+  const deferred: CascadeStep[] = [];
+
+  while (pending.length > 0) {
+    const index = pending.findIndex((group) => !isBlocked(group, pending));
+    if (index >= 0) {
+      steps.push(pending[index]);
+      pending.splice(index, 1);
+      continue;
+    }
+    const [cyclic] = pending.splice(0, 1);
+    const tempValue = nextTempValue();
+    steps.push({ oldValues: cyclic.oldValues, newValue: tempValue });
+    deferred.push({ oldValues: [tempValue], newValue: cyclic.newValue });
+  }
+
+  return steps.concat(deferred);
+};
+
+export { buildCascadeSteps };
+export type { CascadeStep, ChangedPair };

--- a/src/util/relation/onUpdate/resolveOnUpdate.ts
+++ b/src/util/relation/onUpdate/resolveOnUpdate.ts
@@ -1,13 +1,9 @@
-import type { GassmaAny } from "../../../types/coreTypes";
-import type { RelationContext } from "../../../types/relationTypes";
 import { RelationOnUpdateRestrictError } from "../../../errors/relation/relationError";
+import type { RelationContext } from "../../../types/relationTypes";
 import { isValueEqual } from "../../other/isValueEqual";
 import { collectKeys, isGassmaAny } from "../collectKeys";
-
-type ChangedPair = {
-  oldValue: GassmaAny;
-  newValue: GassmaAny;
-};
+import { applyCascadeUpdate, resolveCascadeTarget } from "./applyCascadeUpdate";
+import type { ChangedPair } from "./cascadeUpdatePlan";
 
 const extractChangedPairs = (
   beforeRecords: Record<string, unknown>[],
@@ -47,18 +43,10 @@ const resolveOnUpdate = (
     if (changed.length === 0) return;
 
     const oldValues = changed.map(({ oldValue }) => oldValue);
+    const { sheet, field } = resolveCascadeTarget(relation);
 
-    const targetSheet =
-      relation.type === "manyToMany" && relation.through
-        ? relation.through.sheet
-        : relation.to;
-    const targetField =
-      relation.type === "manyToMany" && relation.through
-        ? relation.through.field
-        : relation.reference;
-
-    const children = context.findManyOnSheet(targetSheet, {
-      where: { [targetField]: { in: oldValues } },
+    const children = context.findManyOnSheet(sheet, {
+      where: { [field]: { in: oldValues } },
     });
 
     if (children.length > 0) {
@@ -85,19 +73,7 @@ const resolveOnUpdate = (
     if (changed.length === 0) return;
 
     if (relation.onUpdate === "Cascade") {
-      changed.forEach(({ oldValue, newValue }) => {
-        if (relation.type === "manyToMany" && relation.through) {
-          context.updateManyOnSheet?.(relation.through.sheet, {
-            where: { [relation.through.field]: oldValue },
-            data: { [relation.through.field]: newValue },
-          });
-        } else {
-          context.updateManyOnSheet?.(relation.to, {
-            where: { [relation.reference]: oldValue },
-            data: { [relation.reference]: newValue },
-          });
-        }
-      });
+      applyCascadeUpdate(changed, relation, context);
     }
 
     if (relation.onUpdate === "SetNull") {


### PR DESCRIPTION
## これは性能改善ではなく**データ破壊バグの修正**です

N+1 調査の**発見1**。調べたところ、遅いだけでなく**記事の持ち主が入れ替わる**バグでした。モック実機で再現済みです。

### 再現

- ユーザー: Alice(id=1)、Bob(id=2)
- 記事: 「Post A」は Alice のもの、「Post B」は Bob のもの

```ts
client.Users.updateMany({ where: {}, data: { id: { increment: 1 } } });
```

| | 期待 | 修正前 | 修正後 |
|---|---|---|---|
| Alice の id | 2 | 2 | 2 |
| Bob の id | 3 | 3 | 3 |
| **Post A の持ち主** | **2 (Alice)** | **3 (Bob)** ❌ | **2** ✅ |
| Post B の持ち主 | 3 | 3 | 3 |

**Post A が Alice のものから Bob のものに変わっていました。**エラーも警告も出ません。値の入れ替え(1↔2)ではさらにひどく、両方が同じ持ち主に潰れます。

### 原因

追従処理を**1組ずつ順番に**適用していたため、**後の周が前の周の書き込みを拾って**いました。

1. 「1→2」を処理 → 持ち主1の記事(Post A)が2になる
2. 「2→3」を処理 → 持ち主2の記事を探す = **さっき2にしたばかりの Post A も拾う**

## 修正方針(方式Bを採用)

**内部インターフェースの追加なし**で直します。既存の `findManyOnSheet` / `updateManyOnSheet` のみ使用。

1. **まとめ**: 変更ペアを**新しい値ごとにグループ化**。同じ値になるものは1回の更新に集約
2. **順序**: 「先に適用すると後のグループに拾われる」関係を洗い出し、**拾われない順に並べ替え**。シフトはこれだけで解決(`2→3` を `1→2` より先に実行)
3. **循環**: 並べ替えで解けない入れ替えのみ、**一時値を経由**して最後に確定

一時値は `_` 始まりなので[エスケープ対象(`= + - @`)外](https://github.com/akahoshi1421/gassma/blob/main/src/util/core/escapeFormulaInjection.ts)で、書き読みとも変質しません。加えて**移動中の値すべて(メモリ内)と対象列の実データ(シート照会)の両方**と衝突しないことを確認してから使います。

## 往復回数

| ケース | before | after |
|---|---|---|
| 独立2件 | 2 | 2 |
| シフト(1→2, 2→3) | 2(**誤答**) | 2(順序反転) |
| 同じ新値に集約(2件→1値) | 2 | **1** |
| 入れ替え | 2(**誤答**) | 3(+読み1) |

非循環では `findManyOnSheet` を**1回も呼びません**(テストで固定)。

## 意図的に変わる挙動(バグ修正なので)

- **玉突きの解消**: 上表のとおり Post A の持ち主が 3 → 2
- **入れ替え**: 潰れていたものが正しく入れ替わる
- **書き込み順**: シフト時は `2→3` を先に実行(従来は逆)
- **呼び出し回数**: 同じ新値のペアは1回に集約

**古い値が1つのグループはスカラー `where` のまま**にしています(常に `in` にはしない)。従来の呼び出し形を保つためと、`""` に対してスカラーと `in` で挙動が異なる([`filterConditions.ts`](https://github.com/akahoshi1421/gassma/blob/main/src/util/core/filterConditions.ts))ため安全側に倒しました。

## 対象外(独立に確認済み)

- **SetNull**: 元から1回で全行同じ値(null)にするため今回の問題は起きない
- **Restrict**: 読みのみで、全リレーション分が書き込みより前に完了する

## ⚠️ 別件で見つかった既存バグ(今回は触っていません)

**FK 列に `@ignore` が付いていると、子シートの全行が書き換わります。** `resolveWhere`([`gassmaController.ts:277-283`](https://github.com/akahoshi1421/gassma/blob/main/src/gassmaController.ts#L277-L283))が where から無視列を落とすため `where` が `{}` になり、全行に一致します。Cascade / SetNull / Restrict すべてに**元からある**問題で、本 PR とは独立です。報告のみ。

## その他の注意点

- 循環時、孫の `updatedAt` が2回更新されます(一時値の書き込みと確定書き込み)。従来は孫も壊れていたので改善ではありますが、完全に無害ではありません
- `$transaction` の外で循環更新が途中で例外死すると一時値が残ります(rollback を使えば戻ります)
- 一時値の再試行上限は32回です

## 検証

- `npx jest`: **1893 passed / 152 suites**(既存 1865 は**1件も書き換えず**全通過、新規28件)
  - 新規はシフト・デクリメント・2値/3値の循環・manyToMany の junction・呼び出し回数・一時値の衝突(2種)を実データストアで検証
- `npx tsc --noEmit` clean / `npm run build` 成功 / **`verify:bundle` OK(52、増減なし)**
- `biome`: 実装4ファイル診断ゼロ
- **追跡ファイルの変更は `resolveOnUpdate.ts` の1つだけ**(他は新規6ファイル)
- `as` / `for ... of` 不使用、実装は全て200行未満

🤖 Generated with [Claude Code](https://claude.com/claude-code)