### PR TITLE
perf: reuse sheet contents within one read-only query

### DIFF
--- a/src/__test__/util/read/cachedSheetReader.test.ts
+++ b/src/__test__/util/read/cachedSheetReader.test.ts
@@ -1,0 +1,241 @@
+import { createSheetReadCache } from "../../../util/read/cachedSheetReader";
+import type { SheetReader } from "../../../util/read/sheetReader";
+import type { SheetWriter } from "../../../util/write/sheetWriter";
+
+const makeBaseReader = (
+  rangeValues?: (
+    sheet: any,
+    rowNumber: number,
+    columnNumber: number,
+    rowLength: number,
+    columnLength: number,
+  ) => any[][],
+) => {
+  const getLastRow = jest.fn((sheet: any) => sheet.lastRow ?? 5);
+  const getRangeValues = jest.fn(
+    rangeValues ??
+      ((_sheet: any, r: number, c: number, rl: number, cl: number) => [
+        [`${r},${c},${rl},${cl}`],
+      ]),
+  );
+  const reader: SheetReader = { getLastRow, getRangeValues };
+  return { reader, getLastRow, getRangeValues };
+};
+
+const makeBaseWriter = () => {
+  const appendRows = jest.fn();
+  const updateRow = jest.fn();
+  const updateRows = jest.fn();
+  const deleteRow = jest.fn();
+  const deleteRows = jest.fn();
+  const writer: SheetWriter = {
+    appendRows,
+    updateRow,
+    updateRows,
+    deleteRow,
+    deleteRows,
+  };
+  return { writer, appendRows, updateRow, deleteRow };
+};
+
+describe("createSheetReadCache の reader ラップ", () => {
+  test("getLastRow は同一シートなら base を1回しか呼ばない", () => {
+    const sheetA: any = { lastRow: 7 };
+    const base = makeBaseReader();
+    const cached = createSheetReadCache().wrapReader(base.reader);
+
+    expect(cached.getLastRow(sheetA)).toBe(7);
+    expect(cached.getLastRow(sheetA)).toBe(7);
+    expect(base.getLastRow).toHaveBeenCalledTimes(1);
+  });
+
+  test("getLastRow はシートごとに別々にキャッシュする", () => {
+    const sheetA: any = { lastRow: 7 };
+    const sheetB: any = { lastRow: 3 };
+    const base = makeBaseReader();
+    const cached = createSheetReadCache().wrapReader(base.reader);
+
+    expect(cached.getLastRow(sheetA)).toBe(7);
+    expect(cached.getLastRow(sheetB)).toBe(3);
+    expect(cached.getLastRow(sheetA)).toBe(7);
+    expect(base.getLastRow).toHaveBeenCalledTimes(2);
+  });
+
+  test("getLastRow が 0 でもキャッシュされる", () => {
+    const sheetA: any = { lastRow: 0 };
+    const base = makeBaseReader();
+    const cached = createSheetReadCache().wrapReader(base.reader);
+
+    expect(cached.getLastRow(sheetA)).toBe(0);
+    expect(cached.getLastRow(sheetA)).toBe(0);
+    expect(base.getLastRow).toHaveBeenCalledTimes(1);
+  });
+
+  test("getRangeValues は同一シート・同一引数なら base を1回しか呼ばない", () => {
+    const sheetA: any = {};
+    const base = makeBaseReader();
+    const cached = createSheetReadCache().wrapReader(base.reader);
+
+    expect(cached.getRangeValues(sheetA, 1, 1, 1, 3)).toEqual([["1,1,1,3"]]);
+    expect(cached.getRangeValues(sheetA, 1, 1, 1, 3)).toEqual([["1,1,1,3"]]);
+    expect(base.getRangeValues).toHaveBeenCalledTimes(1);
+  });
+
+  test("getRangeValues は範囲引数が違えば別々に読む", () => {
+    const sheetA: any = {};
+    const base = makeBaseReader();
+    const cached = createSheetReadCache().wrapReader(base.reader);
+
+    expect(cached.getRangeValues(sheetA, 1, 1, 1, 3)).toEqual([["1,1,1,3"]]);
+    expect(cached.getRangeValues(sheetA, 2, 1, 4, 3)).toEqual([["2,1,4,3"]]);
+    expect(base.getRangeValues).toHaveBeenCalledTimes(2);
+  });
+
+  test("getRangeValues はシートが違えば同一引数でも別々に読む", () => {
+    const sheetA: any = {};
+    const sheetB: any = {};
+    const base = makeBaseReader();
+    const cached = createSheetReadCache().wrapReader(base.reader);
+
+    cached.getRangeValues(sheetA, 1, 1, 1, 3);
+    cached.getRangeValues(sheetB, 1, 1, 1, 3);
+    expect(base.getRangeValues).toHaveBeenCalledTimes(2);
+  });
+
+  test("初回は base が返した配列をそのまま返す", () => {
+    const sheetA: any = {};
+    const original = [["id", "name"]];
+    const base = makeBaseReader(() => original);
+    const cached = createSheetReadCache().wrapReader(base.reader);
+
+    expect(cached.getRangeValues(sheetA, 1, 1, 1, 2)).toBe(original);
+  });
+
+  test("ヒット時は等価な値を返すが配列インスタンスは毎回新しい", () => {
+    const sheetA: any = {};
+    const base = makeBaseReader(() => [
+      [1, "Alice"],
+      [2, "Bob"],
+    ]);
+    const cached = createSheetReadCache().wrapReader(base.reader);
+
+    const first = cached.getRangeValues(sheetA, 2, 1, 2, 2);
+    const second = cached.getRangeValues(sheetA, 2, 1, 2, 2);
+    const third = cached.getRangeValues(sheetA, 2, 1, 2, 2);
+
+    expect(second).toEqual(first);
+    expect(third).toEqual(first);
+    expect(second).not.toBe(first);
+    expect(third).not.toBe(second);
+    expect(second[0]).not.toBe(first[0]);
+    expect(third[0]).not.toBe(second[0]);
+  });
+
+  test("Date セルはヒットごとに新しいインスタンスで同時刻", () => {
+    const sheetA: any = {};
+    const fixedDate = new Date("2026-01-02T03:04:05Z");
+    const base = makeBaseReader(() => [[fixedDate]]);
+    const cached = createSheetReadCache().wrapReader(base.reader);
+
+    const first = cached.getRangeValues(sheetA, 2, 1, 1, 1);
+    const second = cached.getRangeValues(sheetA, 2, 1, 1, 1);
+    const third = cached.getRangeValues(sheetA, 2, 1, 1, 1);
+
+    expect(first[0][0]).toBe(fixedDate);
+    expect(second[0][0]).not.toBe(fixedDate);
+    expect(third[0][0]).not.toBe(second[0][0]);
+    expect(second[0][0].getTime()).toBe(fixedDate.getTime());
+    expect(third[0][0].getTime()).toBe(fixedDate.getTime());
+  });
+
+  test("初回呼び出し側が返り値を書き換えてもスナップショットは汚れない", () => {
+    const sheetA: any = {};
+    const original = [[1, "Alice"]];
+    const base = makeBaseReader(() => original);
+    const cached = createSheetReadCache().wrapReader(base.reader);
+
+    const first = cached.getRangeValues(sheetA, 2, 1, 1, 2);
+    first[0][1] = "hacked";
+
+    expect(cached.getRangeValues(sheetA, 2, 1, 1, 2)).toEqual([[1, "Alice"]]);
+  });
+});
+
+describe("createSheetReadCache の clear", () => {
+  test("clear で全シートのキャッシュが破棄される", () => {
+    const sheetA: any = { lastRow: 7 };
+    const sheetB: any = { lastRow: 3 };
+    const base = makeBaseReader();
+    const cache = createSheetReadCache();
+    const reader = cache.wrapReader(base.reader);
+
+    reader.getLastRow(sheetA);
+    reader.getRangeValues(sheetB, 1, 1, 1, 3);
+    cache.clear();
+    reader.getLastRow(sheetA);
+    reader.getRangeValues(sheetB, 1, 1, 1, 3);
+
+    expect(base.getLastRow).toHaveBeenCalledTimes(2);
+    expect(base.getRangeValues).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("createSheetReadCache の writer ラップ(安全網)", () => {
+  test("appendRows は base に委譲しつつ全キャッシュを破棄する", () => {
+    const sheetA: any = { lastRow: 7 };
+    const sheetB: any = { lastRow: 3 };
+    const baseReader = makeBaseReader();
+    const baseWriter = makeBaseWriter();
+    const cache = createSheetReadCache();
+    const reader = cache.wrapReader(baseReader.reader);
+    const writer = cache.wrapWriter(baseWriter.writer);
+
+    reader.getLastRow(sheetA);
+    reader.getLastRow(sheetB);
+    reader.getRangeValues(sheetA, 1, 1, 1, 3);
+    expect(baseReader.getLastRow).toHaveBeenCalledTimes(2);
+    expect(baseReader.getRangeValues).toHaveBeenCalledTimes(1);
+
+    writer.appendRows(sheetA, 1, 3, [[3, "Carol", 40]]);
+    expect(baseWriter.appendRows).toHaveBeenCalledWith(sheetA, 1, 3, [
+      [3, "Carol", 40],
+    ]);
+
+    reader.getLastRow(sheetA);
+    reader.getLastRow(sheetB);
+    reader.getRangeValues(sheetA, 1, 1, 1, 3);
+    expect(baseReader.getLastRow).toHaveBeenCalledTimes(4);
+    expect(baseReader.getRangeValues).toHaveBeenCalledTimes(2);
+  });
+
+  test("updateRow / updateRows / deleteRow / deleteRows も破棄と委譲を行う", () => {
+    const sheetA: any = { lastRow: 7 };
+    const baseReader = makeBaseReader();
+    const baseWriter = makeBaseWriter();
+    const cache = createSheetReadCache();
+    const reader = cache.wrapReader(baseReader.reader);
+    const writer = cache.wrapWriter(baseWriter.writer);
+
+    reader.getLastRow(sheetA);
+    writer.updateRow(sheetA, 2, 1, 3, [1, "Alice", 21]);
+    expect(baseWriter.updateRow).toHaveBeenCalledWith(sheetA, 2, 1, 3, [
+      1,
+      "Alice",
+      21,
+    ]);
+    reader.getLastRow(sheetA);
+    expect(baseReader.getLastRow).toHaveBeenCalledTimes(2);
+
+    writer.updateRows(sheetA, 2, 1, 3, [[1, "Alice", 22]]);
+    reader.getLastRow(sheetA);
+    expect(baseReader.getLastRow).toHaveBeenCalledTimes(3);
+
+    writer.deleteRow(sheetA, 2);
+    reader.getLastRow(sheetA);
+    expect(baseReader.getLastRow).toHaveBeenCalledTimes(4);
+
+    writer.deleteRows(sheetA, 2, 1);
+    reader.getLastRow(sheetA);
+    expect(baseReader.getLastRow).toHaveBeenCalledTimes(5);
+  });
+});

--- a/src/__test__/util/read/perCallReadCache.test.ts
+++ b/src/__test__/util/read/perCallReadCache.test.ts
@@ -1,0 +1,333 @@
+import { GassmaClient } from "../../../gassma";
+import { GassmaController } from "../../../gassmaController";
+import type { RelationsConfig } from "../../../types/relationTypes";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+  makeLoggedSheet,
+} from "../transaction/transactionTestClient";
+
+type CountingSheet = {
+  sheet: any;
+  readTrips: () => number;
+  resetTrips: () => void;
+  snapshot: () => unknown[][];
+};
+
+const makeCountingSheet = (
+  name: string,
+  initial: unknown[][],
+): CountingSheet => {
+  const logged = makeLoggedSheet(name, initial);
+  const base: any = logged.sheet;
+  let trips = 0;
+  const sheet: any = {
+    ...base,
+    getLastRow: () => {
+      trips += 1;
+      return base.getLastRow();
+    },
+    getRange: (row: number, col: number, numRows: number, numCols: number) => {
+      const range = base.getRange(row, col, numRows, numCols);
+      return {
+        ...range,
+        getValues: () => {
+          trips += 1;
+          return range.getValues();
+        },
+      };
+    },
+  };
+  return {
+    sheet,
+    readTrips: () => trips,
+    resetTrips: () => {
+      trips = 0;
+    },
+    snapshot: logged.snapshot,
+  };
+};
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!(controller instanceof GassmaController)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+const buildEnv = (relations: RelationsConfig) => {
+  const users = makeCountingSheet("Users", [
+    ["id", "name", "parentId"],
+    [1, "Alice", ""],
+    [2, "Bob", 1],
+    [3, "Carol", 1],
+  ]);
+  const posts = makeCountingSheet("Posts", [
+    ["id", "authorId", "title"],
+    [101, 1, "Post A"],
+    [102, 2, "Post B"],
+  ]);
+  const sheets = [users.sheet, posts.sheet];
+  const spreadsheet: any = {
+    getId: () => "read-cache-test",
+    getSheets: () => sheets,
+    getSheetByName: (n: string) =>
+      sheets.find((s: any) => s.getName() === n) ?? null,
+  };
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => spreadsheet },
+  });
+  const client = new GassmaClient({ relations });
+  users.resetTrips();
+  posts.resetTrips();
+  return {
+    client,
+    users,
+    posts,
+    totalTrips: () => users.readTrips() + posts.readTrips(),
+  };
+};
+
+const selfRelations: RelationsConfig = {
+  Users: {
+    posts: {
+      type: "oneToMany",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+    },
+    children: {
+      type: "oneToMany",
+      to: "Users",
+      field: "id",
+      reference: "parentId",
+    },
+    parent: {
+      type: "manyToOne",
+      to: "Users",
+      field: "parentId",
+      reference: "id",
+    },
+  },
+  Posts: {
+    author: {
+      type: "manyToOne",
+      to: "Users",
+      field: "authorId",
+      reference: "id",
+    },
+  },
+};
+
+const cascadeRelations: RelationsConfig = {
+  Users: {
+    posts: {
+      type: "oneToMany",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+      onUpdate: "Cascade",
+    },
+  },
+  Posts: {
+    author: {
+      type: "manyToOne",
+      to: "Users",
+      field: "authorId",
+      reference: "id",
+    },
+  },
+};
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+describe("読み取り専用クエリの往復回数", () => {
+  test("findMany({}) はシート1枚につき3往復", () => {
+    const env = buildEnv(selfRelations);
+    sheetOf(env.client, "Users").findMany({});
+    expect(env.totalTrips()).toBe(3);
+  });
+
+  test("別シート include はシート2枚で計6往復", () => {
+    const env = buildEnv(selfRelations);
+    sheetOf(env.client, "Users").findMany({ include: { posts: true } });
+    expect(env.totalTrips()).toBe(6);
+  });
+
+  test("自己参照 include 1つは3往復", () => {
+    const env = buildEnv(selfRelations);
+    sheetOf(env.client, "Users").findMany({ include: { children: true } });
+    expect(env.totalTrips()).toBe(3);
+  });
+
+  test("自己参照 include 2つでも3往復", () => {
+    const env = buildEnv(selfRelations);
+    sheetOf(env.client, "Users").findMany({
+      include: { parent: true, children: true },
+    });
+    expect(env.totalTrips()).toBe(3);
+  });
+
+  test("findFirst は3往復", () => {
+    const env = buildEnv(selfRelations);
+    sheetOf(env.client, "Users").findFirst({ where: { id: 1 } });
+    expect(env.totalTrips()).toBe(3);
+  });
+
+  test("count は3往復", () => {
+    const env = buildEnv(selfRelations);
+    sheetOf(env.client, "Users").count({});
+    expect(env.totalTrips()).toBe(3);
+  });
+
+  test("aggregate は3往復", () => {
+    const env = buildEnv(selfRelations);
+    sheetOf(env.client, "Users").aggregate({ _count: { id: true } });
+    expect(env.totalTrips()).toBe(3);
+  });
+
+  test("groupBy は3往復", () => {
+    const env = buildEnv(selfRelations);
+    sheetOf(env.client, "Users").groupBy({ by: ["parentId"] });
+    expect(env.totalTrips()).toBe(3);
+  });
+});
+
+describe("キャッシュの寿命(トップレベル呼び出しごとに破棄)", () => {
+  test("findMany を2回呼ぶと往復は倍になる(呼び出しを跨いで使い回さない)", () => {
+    const env = buildEnv(selfRelations);
+    const controller = sheetOf(env.client, "Users");
+    controller.findMany({});
+    const afterFirst = env.totalTrips();
+    controller.findMany({});
+    expect(env.totalTrips()).toBe(afterFirst * 2);
+  });
+});
+
+describe("キャッシュ有効時の結果の正しさ", () => {
+  test("別シート include の結果は従来と同一", () => {
+    const env = buildEnv(selfRelations);
+    const result = sheetOf(env.client, "Users").findMany({
+      include: { posts: true },
+    });
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: "Alice",
+        parentId: null,
+        posts: [{ id: 101, authorId: 1, title: "Post A" }],
+      },
+      {
+        id: 2,
+        name: "Bob",
+        parentId: 1,
+        posts: [{ id: 102, authorId: 2, title: "Post B" }],
+      },
+      { id: 3, name: "Carol", parentId: 1, posts: [] },
+    ]);
+  });
+
+  test("自己参照 parent + children の結果は従来と同一", () => {
+    const env = buildEnv(selfRelations);
+    const result = sheetOf(env.client, "Users").findMany({
+      include: { parent: true, children: true },
+    });
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: "Alice",
+        parentId: null,
+        parent: null,
+        children: [
+          { id: 2, name: "Bob", parentId: 1 },
+          { id: 3, name: "Carol", parentId: 1 },
+        ],
+      },
+      {
+        id: 2,
+        name: "Bob",
+        parentId: 1,
+        parent: { id: 1, name: "Alice", parentId: null },
+        children: [],
+      },
+      {
+        id: 3,
+        name: "Carol",
+        parentId: 1,
+        parent: { id: 1, name: "Alice", parentId: null },
+        children: [],
+      },
+    ]);
+  });
+});
+
+describe("書き込み経路の鮮度(キャッシュを持ち込まない)", () => {
+  test("findMany → update → findMany で2回目は新しい値を返す", () => {
+    const env = buildEnv(selfRelations);
+    const controller = sheetOf(env.client, "Users");
+
+    const before = controller.findMany({ where: { id: 2 } });
+    expect(before).toEqual([{ id: 2, name: "Bob", parentId: 1 }]);
+
+    controller.update({ where: { id: 2 }, data: { name: "Bobby" } });
+
+    const after = controller.findMany({ where: { id: 2 } });
+    expect(after).toEqual([{ id: 2, name: "Bobby", parentId: 1 }]);
+  });
+
+  test("findMany 直後の Cascade update でも子シートが追従し一時値が残らない", () => {
+    const env = buildEnv(cascadeRelations);
+    const usersController = sheetOf(env.client, "Users");
+    const postsController = sheetOf(env.client, "Posts");
+
+    usersController.findMany({ include: { posts: true } });
+    usersController.update({ where: { id: 1 }, data: { id: 10 } });
+
+    expect(postsController.findMany({ orderBy: { id: "asc" } })).toEqual([
+      { id: 101, authorId: 10, title: "Post A" },
+      { id: 102, authorId: 2, title: "Post B" },
+    ]);
+    expect(usersController.findMany({ orderBy: { id: "asc" } })).toEqual([
+      { id: 2, name: "Bob", parentId: 1 },
+      { id: 3, name: "Carol", parentId: 1 },
+      { id: 10, name: "Alice", parentId: null },
+    ]);
+    expect(JSON.stringify(env.users.snapshot())).not.toContain(
+      "__gassma_cascade",
+    );
+    expect(JSON.stringify(env.posts.snapshot())).not.toContain(
+      "__gassma_cascade",
+    );
+  });
+
+  test("Cascade update の読み往復数は従来から変わらない", () => {
+    const env = buildEnv(cascadeRelations);
+    sheetOf(env.client, "Users").update({ where: { id: 1 }, data: { id: 10 } });
+    expect(env.totalTrips()).toBe(18);
+  });
+
+  test("$transaction 内の findMany → update → findMany で2回目は新しい値を返す", () => {
+    const env = buildTxTestEnv();
+    const result = env.client.$transaction((tx) => {
+      const first = tx.Users.findMany({ where: { id: 1 } });
+      tx.Users.update({ where: { id: 1 }, data: { age: 99 } });
+      const second = tx.Users.findMany({ where: { id: 1 } });
+      return { first, second };
+    });
+
+    expect(result.first).toEqual([{ id: 1, name: "Alice", age: 20 }]);
+    expect(result.second).toEqual([{ id: 1, name: "Alice", age: 99 }]);
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 99],
+      [2, "Bob", 30],
+    ]);
+  });
+});

--- a/src/__test__/util/read/readCacheContext.test.ts
+++ b/src/__test__/util/read/readCacheContext.test.ts
@@ -1,0 +1,282 @@
+import type { GassmaControllerUtil } from "../../../types/gassmaControllerUtilType";
+import {
+  applyReadCache,
+  runWithoutReadCache,
+  runWithReadCache,
+} from "../../../util/read/readCacheContext";
+import type { SheetReader } from "../../../util/read/sheetReader";
+import type { SheetWriter } from "../../../util/write/sheetWriter";
+
+const makeSpyReader = () => {
+  const getLastRow = jest.fn(() => 3);
+  const getRangeValues = jest.fn(() => [[1, "Alice"]]);
+  const reader: SheetReader = { getLastRow, getRangeValues };
+  return { reader, getLastRow, getRangeValues };
+};
+
+const makeSpyWriter = () => {
+  const appendRows = jest.fn();
+  const updateRow = jest.fn();
+  const updateRows = jest.fn();
+  const deleteRow = jest.fn();
+  const deleteRows = jest.fn();
+  const writer: SheetWriter = {
+    appendRows,
+    updateRow,
+    updateRows,
+    deleteRow,
+    deleteRows,
+  };
+  return { writer, appendRows };
+};
+
+const makeUtil = (
+  reader: SheetReader,
+  writer: SheetWriter,
+): GassmaControllerUtil => {
+  const sheet: any = {};
+  return {
+    sheet,
+    startRowNumber: 1,
+    startColumnNumber: 1,
+    endColumnNumber: 2,
+    reader,
+    writer,
+  };
+};
+
+describe("readCacheContext", () => {
+  test("コンテキスト外では applyReadCache は util をそのまま返す", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    expect(applyReadCache(util)).toBe(util);
+  });
+
+  test("runWithReadCache は fn の戻り値をそのまま返す", () => {
+    expect(runWithReadCache(() => 42)).toBe(42);
+  });
+
+  test("コンテキスト内では同一読みが base 1回になる", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    runWithReadCache(() => {
+      const wrapped = applyReadCache(util);
+      wrapped.reader.getLastRow(util.sheet);
+      wrapped.reader.getLastRow(util.sheet);
+      wrapped.reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      wrapped.reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+    });
+
+    expect(spy.getLastRow).toHaveBeenCalledTimes(1);
+    expect(spy.getRangeValues).toHaveBeenCalledTimes(1);
+  });
+
+  test("途中で applyReadCache し直しても同じキャッシュを共有する", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    runWithReadCache(() => {
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+    });
+
+    expect(spy.getRangeValues).toHaveBeenCalledTimes(1);
+  });
+
+  test("ネストした runWithReadCache は外側のキャッシュを共有する", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    runWithReadCache(() => {
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      runWithReadCache(() => {
+        applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      });
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+    });
+
+    expect(spy.getRangeValues).toHaveBeenCalledTimes(1);
+  });
+
+  test("runWithReadCache を抜けるとキャッシュは破棄される", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    runWithReadCache(() => {
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+    });
+    runWithReadCache(() => {
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+    });
+
+    expect(spy.getRangeValues).toHaveBeenCalledTimes(2);
+    expect(applyReadCache(util)).toBe(util);
+  });
+
+  test("fn が throw してもキャッシュは破棄される", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    expect(() =>
+      runWithReadCache(() => {
+        applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+
+    expect(applyReadCache(util)).toBe(util);
+    runWithReadCache(() => {
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+    });
+    expect(spy.getRangeValues).toHaveBeenCalledTimes(2);
+  });
+
+  test("ネスト内側で throw しても外側のキャッシュは生きている", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    runWithReadCache(() => {
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      expect(() =>
+        runWithReadCache(() => {
+          throw new Error("inner");
+        }),
+      ).toThrow("inner");
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+    });
+
+    expect(spy.getRangeValues).toHaveBeenCalledTimes(1);
+  });
+
+  test("コンテキスト内の書き込みはキャッシュを破棄してから委譲される", () => {
+    const spyReader = makeSpyReader();
+    const spyWriter = makeSpyWriter();
+    const util = makeUtil(spyReader.reader, spyWriter.writer);
+
+    runWithReadCache(() => {
+      const wrapped = applyReadCache(util);
+      wrapped.reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      wrapped.writer.appendRows(util.sheet, 1, 2, [[2, "Bob"]]);
+      wrapped.reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+    });
+
+    expect(spyWriter.appendRows).toHaveBeenCalledWith(util.sheet, 1, 2, [
+      [2, "Bob"],
+    ]);
+    expect(spyReader.getRangeValues).toHaveBeenCalledTimes(2);
+  });
+
+  test("バリア内では runWithReadCache はキャッシュを作らない", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    runWithoutReadCache(() => {
+      runWithReadCache(() => {
+        expect(applyReadCache(util)).toBe(util);
+        applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+        applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      });
+    });
+
+    expect(spy.getRangeValues).toHaveBeenCalledTimes(2);
+  });
+
+  test("バリアは fn の戻り値をそのまま返す", () => {
+    expect(runWithoutReadCache(() => "ok")).toBe("ok");
+  });
+
+  test("窓が開いている最中にバリアへ入ると applyReadCache は素通しになる", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    runWithReadCache(() => {
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      runWithoutReadCache(() => {
+        expect(applyReadCache(util)).toBe(util);
+      });
+    });
+
+    expect(spy.getRangeValues).toHaveBeenCalledTimes(1);
+  });
+
+  test("窓の最中にバリアへ入ると窓のキャッシュは破棄され、バリア後は再読になる", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    runWithReadCache(() => {
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      runWithoutReadCache(() => {});
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+    });
+
+    expect(spy.getRangeValues).toHaveBeenCalledTimes(2);
+  });
+
+  test("ネストしたバリアを1つ抜けても抑止は続き、全て抜けると解除される", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    runWithoutReadCache(() => {
+      runWithoutReadCache(() => {});
+      runWithReadCache(() => {
+        expect(applyReadCache(util)).toBe(util);
+      });
+    });
+    runWithReadCache(() => {
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+    });
+
+    expect(spy.getRangeValues).toHaveBeenCalledTimes(1);
+  });
+
+  test("バリア内で throw しても抑止は解除される", () => {
+    const spy = makeSpyReader();
+    const util = makeUtil(spy.reader, makeSpyWriter().writer);
+
+    expect(() =>
+      runWithoutReadCache(() => {
+        throw new Error("write failed");
+      }),
+    ).toThrow("write failed");
+
+    runWithReadCache(() => {
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+      applyReadCache(util).reader.getRangeValues(util.sheet, 1, 1, 1, 2);
+    });
+    expect(spy.getRangeValues).toHaveBeenCalledTimes(1);
+  });
+
+  test("reader / writer 未指定の util でも immediate にフォールバックして動く", () => {
+    const getLastRow = jest.fn(() => 2);
+    const getValues = jest.fn(() => [["id", "name"]]);
+    const sheet: any = {
+      getLastRow,
+      getRange: () => ({ getValues }),
+    };
+    const util: GassmaControllerUtil = {
+      sheet,
+      startRowNumber: 1,
+      startColumnNumber: 1,
+      endColumnNumber: 2,
+    };
+
+    runWithReadCache(() => {
+      const wrapped = applyReadCache(util);
+      expect(wrapped.reader.getLastRow(sheet)).toBe(2);
+      expect(wrapped.reader.getLastRow(sheet)).toBe(2);
+      expect(wrapped.reader.getRangeValues(sheet, 1, 1, 1, 2)).toEqual([
+        ["id", "name"],
+      ]);
+      expect(wrapped.reader.getRangeValues(sheet, 1, 1, 1, 2)).toEqual([
+        ["id", "name"],
+      ]);
+    });
+
+    expect(getLastRow).toHaveBeenCalledTimes(1);
+    expect(getValues).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -1,35 +1,23 @@
-import { applyAutoincrement } from "./util/defaults/applyAutoincrement";
-import { applyDefaults } from "./util/defaults/applyDefaults";
-import { applyUpdatedAt } from "./util/defaults/applyUpdatedAt";
-import { generateAutoincrementValues } from "./util/defaults/generateAutoincrementValues";
-import type { DefaultsForSheet } from "./util/defaults/applyDefaults";
-import { FieldRef } from "./util/filterConditions/fieldRef";
-import { stripIgnoredFields } from "./util/ignore/stripIgnoredFields";
-import { stripIgnoreFromSelect } from "./util/ignore/stripIgnoreFromSelect";
-import type { FieldMapping } from "./util/map/mapFields";
+import { GassmaMissingArgumentError } from "./errors/argument/argumentError";
 import {
   GassmaFindSelectOmitConflictError,
   NotFoundError,
 } from "./errors/find/findError";
-import { findedDataSelect } from "./util/find/findUtil/findDataSelect";
-import { omitFunc } from "./util/find/findUtil/omit";
-import { resolveGlobalOmit } from "./util/omit/resolveGlobalOmit";
 import { GassmaIncludeSelectConflictError } from "./errors/relation/relationError";
 import { IncludeWithoutRelationsError } from "./errors/relation/relationValidationError";
-import { GassmaMissingArgumentError } from "./errors/argument/argumentError";
 import type { AggregateData } from "./types/aggregateType";
 import type {
   AnyUse,
-  Select,
   Omit,
   QueryOmit,
+  Select,
   WhereUse,
 } from "./types/coreTypes";
 import type { CountData } from "./types/countType";
 import type {
   CreateData,
-  CreateManyData,
   CreateManyAndReturnData,
+  CreateManyData,
 } from "./types/createTypes";
 import type {
   DeleteData,
@@ -43,6 +31,7 @@ import type {
 import type { GassmaControllerUtil } from "./types/gassmaControllerUtilType";
 import type { GroupByData } from "./types/groupByType";
 import type { RelationContext } from "./types/relationTypes";
+import type { SheetIo } from "./types/transactionTypes";
 import { aggregateFunc } from "./util/aggregate/aggregate";
 import { changeSettingsFunc } from "./util/changeSettings/changeSettings";
 import { getTitle } from "./util/core/getTitle";
@@ -50,32 +39,48 @@ import { countFunc } from "./util/count/count";
 import { createFunc } from "./util/create/create";
 import { createManyFunc } from "./util/create/createManyFunc";
 import { resolveNestedCreate } from "./util/create/nestedWrite/resolveNestedCreate";
-import { normalizeQueryInput } from "./util/skip/normalizeQueryInput";
+import { applyAutoincrement } from "./util/defaults/applyAutoincrement";
+import type { DefaultsForSheet } from "./util/defaults/applyDefaults";
+import { applyDefaults } from "./util/defaults/applyDefaults";
+import { applyUpdatedAt } from "./util/defaults/applyUpdatedAt";
+import { generateAutoincrementValues } from "./util/defaults/generateAutoincrementValues";
 import { deleteFunc } from "./util/delete/delete";
 import { deleteManyFunc } from "./util/delete/deleteMany";
+import { FieldRef } from "./util/filterConditions/fieldRef";
 import { findFirstFunc } from "./util/find/findFirst";
+import { findFirstWithRelationOrderBy } from "./util/find/findFirstWithRelationOrderBy";
 import { findManyFunc } from "./util/find/findMany";
-import { groupByFunc } from "./util/groupby/groupby";
-import { resolveOnDelete } from "./util/relation/onDelete/resolveOnDelete";
-import { resolveOnUpdate } from "./util/relation/onUpdate/resolveOnUpdate";
-import { resolveInclude } from "./util/relation/resolveInclude";
-import { resolveCount } from "./util/relation/resolveCount";
+import { findManyWithRelationOrderBy } from "./util/find/findManyWithRelationOrderBy";
 import { applySelectCount } from "./util/find/findUtil/applySelectCount";
 import { applySelectRelations } from "./util/find/findUtil/applySelectRelations";
 import { extractSelectRelations } from "./util/find/findUtil/extractSelectRelations";
-import { resolveWhereRelation } from "./util/relation/whereRelation/resolveWhereRelation";
-import { resolveNestedUpdate } from "./util/update/nestedWrite/resolveNestedUpdate";
-import { updateManyFunc } from "./util/update/updateMany";
-import { resolveNumberOperations } from "./util/update/resolveNumberOperation";
-import { upsertFunc } from "./util/upsert/upsert";
+import { findedDataSelect } from "./util/find/findUtil/findDataSelect";
+import { omitFunc } from "./util/find/findUtil/omit";
 import { separateRelationOrderBy } from "./util/find/findUtil/separateRelationOrderBy";
-import { findManyWithRelationOrderBy } from "./util/find/findManyWithRelationOrderBy";
-import { findFirstWithRelationOrderBy } from "./util/find/findFirstWithRelationOrderBy";
-import type { SheetWriter } from "./util/write/sheetWriter";
-import { immediateSheetWriter } from "./util/write/sheetWriter";
+import { groupByFunc } from "./util/groupby/groupby";
+import { stripIgnoredFields } from "./util/ignore/stripIgnoredFields";
+import { stripIgnoreFromSelect } from "./util/ignore/stripIgnoreFromSelect";
+import type { FieldMapping } from "./util/map/mapFields";
+import { resolveGlobalOmit } from "./util/omit/resolveGlobalOmit";
+import {
+  applyReadCache,
+  runWithoutReadCache,
+  runWithReadCache,
+} from "./util/read/readCacheContext";
 import type { SheetReader } from "./util/read/sheetReader";
 import { immediateSheetReader } from "./util/read/sheetReader";
-import type { SheetIo } from "./types/transactionTypes";
+import { resolveOnDelete } from "./util/relation/onDelete/resolveOnDelete";
+import { resolveOnUpdate } from "./util/relation/onUpdate/resolveOnUpdate";
+import { resolveCount } from "./util/relation/resolveCount";
+import { resolveInclude } from "./util/relation/resolveInclude";
+import { resolveWhereRelation } from "./util/relation/whereRelation/resolveWhereRelation";
+import { normalizeQueryInput } from "./util/skip/normalizeQueryInput";
+import { resolveNestedUpdate } from "./util/update/nestedWrite/resolveNestedUpdate";
+import { resolveNumberOperations } from "./util/update/resolveNumberOperation";
+import { updateManyFunc } from "./util/update/updateMany";
+import { upsertFunc } from "./util/upsert/upsert";
+import type { SheetWriter } from "./util/write/sheetWriter";
+import { immediateSheetWriter } from "./util/write/sheetWriter";
 
 class GassmaController {
   private readonly sheet: GoogleAppsScript.Spreadsheet.Sheet;
@@ -256,7 +261,7 @@ class GassmaController {
     if (this.fieldMapping) {
       util.fieldMapping = this.fieldMapping;
     }
-    return util;
+    return applyReadCache(util);
   }
 
   private resolveEffectiveOmit(
@@ -334,6 +339,10 @@ class GassmaController {
   }
 
   public createMany(createdData: CreateManyData) {
+    return runWithoutReadCache(() => this.createManyRaw(createdData));
+  }
+
+  private createManyRaw(createdData: CreateManyData) {
     createdData = this.normalizeInput(createdData);
     if (createdData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
@@ -345,6 +354,10 @@ class GassmaController {
   }
 
   public createManyAndReturn(createdData: CreateManyAndReturnData) {
+    return runWithoutReadCache(() => this.createManyAndReturnRaw(createdData));
+  }
+
+  private createManyAndReturnRaw(createdData: CreateManyAndReturnData) {
     createdData = this.normalizeInput(createdData);
     if (createdData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
@@ -387,6 +400,10 @@ class GassmaController {
   }
 
   public create(createdData: CreateData) {
+    return runWithoutReadCache(() => this.createRaw(createdData));
+  }
+
+  private createRaw(createdData: CreateData) {
     createdData = this.normalizeInput(createdData);
     if (createdData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
@@ -438,7 +455,9 @@ class GassmaController {
   }
 
   public findFirst(findData: FindFirstData) {
-    return this.findFirstRaw(this.normalizeInput(findData));
+    return runWithReadCache(() =>
+      this.findFirstRaw(this.normalizeInput(findData)),
+    );
   }
 
   private findFirstRaw(findData: FindFirstData) {
@@ -630,7 +649,9 @@ class GassmaController {
   }
 
   public findMany(findData: FindData) {
-    return this.findManyRaw(this.normalizeInput(findData));
+    return runWithReadCache(() =>
+      this.findManyRaw(this.normalizeInput(findData)),
+    );
   }
 
   private findManyRaw(findData: FindData) {
@@ -796,6 +817,10 @@ class GassmaController {
   }
 
   public update(updateData: UpdateSingleData) {
+    return runWithoutReadCache(() => this.updateRaw(updateData));
+  }
+
+  private updateRaw(updateData: UpdateSingleData) {
     updateData = this.normalizeInput(updateData);
     if (updateData.where === undefined) {
       throw new GassmaMissingArgumentError("where");
@@ -860,6 +885,10 @@ class GassmaController {
   }
 
   public updateMany(updateData: UpdateData) {
+    return runWithoutReadCache(() => this.updateManyRaw(updateData));
+  }
+
+  private updateManyRaw(updateData: UpdateData) {
     updateData = this.normalizeInput(updateData);
     if (updateData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
@@ -893,6 +922,10 @@ class GassmaController {
   }
 
   public updateManyAndReturn(updateData: UpdateData) {
+    return runWithoutReadCache(() => this.updateManyAndReturnRaw(updateData));
+  }
+
+  private updateManyAndReturnRaw(updateData: UpdateData) {
     updateData = this.normalizeInput(updateData);
     if (updateData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
@@ -935,6 +968,10 @@ class GassmaController {
   }
 
   public upsert(upsertData: UpsertSingleData) {
+    return runWithoutReadCache(() => this.upsertRaw(upsertData));
+  }
+
+  private upsertRaw(upsertData: UpsertSingleData) {
     upsertData = this.normalizeInput(upsertData);
     if (upsertData.where === undefined) {
       throw new GassmaMissingArgumentError("where");
@@ -985,6 +1022,10 @@ class GassmaController {
   }
 
   public delete(deleteData: DeleteSingleData) {
+    return runWithoutReadCache(() => this.deleteRaw(deleteData));
+  }
+
+  private deleteRaw(deleteData: DeleteSingleData) {
     deleteData = this.normalizeInput(deleteData);
     if (deleteData.where === undefined) {
       throw new GassmaMissingArgumentError("where");
@@ -1017,6 +1058,10 @@ class GassmaController {
   }
 
   public deleteMany(deleteData: DeleteData) {
+    return runWithoutReadCache(() => this.deleteManyRaw(deleteData));
+  }
+
+  private deleteManyRaw(deleteData: DeleteData) {
     deleteData = this.normalizeInput(deleteData);
     deleteData = { ...deleteData, where: this.resolveWhere(deleteData.where) };
 
@@ -1033,7 +1078,12 @@ class GassmaController {
   }
 
   public aggregate(aggregateData: AggregateData) {
-    aggregateData = this.normalizeInput(aggregateData);
+    return runWithReadCache(() =>
+      this.aggregateRaw(this.normalizeInput(aggregateData)),
+    );
+  }
+
+  private aggregateRaw(aggregateData: AggregateData) {
     aggregateData = {
       ...aggregateData,
       where: this.resolveWhere(aggregateData.where),
@@ -1042,13 +1092,23 @@ class GassmaController {
   }
 
   public count(countData: CountData) {
-    countData = this.normalizeInput(countData);
+    return runWithReadCache(() =>
+      this.countRaw(this.normalizeInput(countData)),
+    );
+  }
+
+  private countRaw(countData: CountData) {
     countData = { ...countData, where: this.resolveWhere(countData.where) };
     return countFunc(this.getGassmaControllerUtil(), countData);
   }
 
   public groupBy(groupByData: GroupByData) {
-    groupByData = this.normalizeInput(groupByData);
+    return runWithReadCache(() =>
+      this.groupByRaw(this.normalizeInput(groupByData)),
+    );
+  }
+
+  private groupByRaw(groupByData: GroupByData) {
     if (groupByData.by === undefined) {
       throw new GassmaMissingArgumentError("by");
     }

--- a/src/util/read/cachedSheetReader.ts
+++ b/src/util/read/cachedSheetReader.ts
@@ -1,0 +1,103 @@
+import { isDateValue } from "../other/isDateValue";
+import type { SheetWriter } from "../write/sheetWriter";
+import type { SheetReader } from "./sheetReader";
+
+type Sheet = GoogleAppsScript.Spreadsheet.Sheet;
+
+type SheetCacheEntry = {
+  lastRow: number | null;
+  ranges: Map<string, any[][]>;
+};
+
+const cloneCell = (cell: any): any =>
+  isDateValue(cell) ? new Date(cell.getTime()) : cell;
+
+const copyValues = (values: any[][]): any[][] =>
+  values.map((row) => row.map(cloneCell));
+
+const createSheetReadCache = () => {
+  const entries = new Map<Sheet, SheetCacheEntry>();
+
+  const entryFor = (sheet: Sheet): SheetCacheEntry => {
+    const existing = entries.get(sheet);
+    if (existing) return existing;
+    const created: SheetCacheEntry = { lastRow: null, ranges: new Map() };
+    entries.set(sheet, created);
+    return created;
+  };
+
+  const clear = () => {
+    entries.clear();
+  };
+
+  const wrapReader = (base: SheetReader): SheetReader => ({
+    getLastRow: (sheet) => {
+      const entry = entryFor(sheet);
+      if (entry.lastRow === null) entry.lastRow = base.getLastRow(sheet);
+      return entry.lastRow;
+    },
+    getRangeValues: (
+      sheet,
+      rowNumber,
+      columnNumber,
+      rowLength,
+      columnLength,
+    ) => {
+      const entry = entryFor(sheet);
+      const key = `${rowNumber},${columnNumber},${rowLength},${columnLength}`;
+      const cached = entry.ranges.get(key);
+      if (cached) return copyValues(cached);
+      const values = base.getRangeValues(
+        sheet,
+        rowNumber,
+        columnNumber,
+        rowLength,
+        columnLength,
+      );
+      entry.ranges.set(key, copyValues(values));
+      return values;
+    },
+  });
+
+  const wrapWriter = (base: SheetWriter): SheetWriter => ({
+    appendRows: (sheet, startColumnNumber, columnLength, rows) => {
+      clear();
+      base.appendRows(sheet, startColumnNumber, columnLength, rows);
+    },
+    updateRow: (sheet, rowNumber, startColumnNumber, columnLength, row) => {
+      clear();
+      base.updateRow(sheet, rowNumber, startColumnNumber, columnLength, row);
+    },
+    updateRows: (
+      sheet,
+      startRowNumber,
+      startColumnNumber,
+      columnLength,
+      rows,
+    ) => {
+      clear();
+      base.updateRows(
+        sheet,
+        startRowNumber,
+        startColumnNumber,
+        columnLength,
+        rows,
+      );
+    },
+    deleteRow: (sheet, rowNumber) => {
+      clear();
+      base.deleteRow(sheet, rowNumber);
+    },
+    deleteRows: (sheet, rowPosition, howMany) => {
+      clear();
+      base.deleteRows(sheet, rowPosition, howMany);
+    },
+  });
+
+  return { wrapReader, wrapWriter, clear };
+};
+
+type SheetReadCache = ReturnType<typeof createSheetReadCache>;
+
+export { createSheetReadCache };
+export type { SheetReadCache };

--- a/src/util/read/readCacheContext.ts
+++ b/src/util/read/readCacheContext.ts
@@ -1,0 +1,39 @@
+import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
+import { resolveWriter } from "../write/sheetWriter";
+import type { SheetReadCache } from "./cachedSheetReader";
+import { createSheetReadCache } from "./cachedSheetReader";
+import { resolveReader } from "./sheetReader";
+
+let activeCache: SheetReadCache | null = null;
+let writeDepth = 0;
+
+const runWithReadCache = <T>(fn: () => T): T => {
+  if (writeDepth > 0 || activeCache) return fn();
+  activeCache = createSheetReadCache();
+  try {
+    return fn();
+  } finally {
+    activeCache = null;
+  }
+};
+
+const runWithoutReadCache = <T>(fn: () => T): T => {
+  if (activeCache) activeCache.clear();
+  writeDepth += 1;
+  try {
+    return fn();
+  } finally {
+    writeDepth -= 1;
+  }
+};
+
+const applyReadCache = (util: GassmaControllerUtil): GassmaControllerUtil => {
+  if (!activeCache || writeDepth > 0) return util;
+  return {
+    ...util,
+    reader: activeCache.wrapReader(resolveReader(util.reader)),
+    writer: activeCache.wrapWriter(resolveWriter(util.writer)),
+  };
+};
+
+export { applyReadCache, runWithoutReadCache, runWithReadCache };


### PR DESCRIPTION
## 概要

N+1 調査の**発見3**(最後の1件)。**外から見える挙動は一切変わりません。**純粋な内部最適化です。

リレーションの解決は `findManyOnSheet` → `controller.findMany` そのもの(`injectRelations.ts:21-29`)なので、「子を取る」は**フルのクエリをもう一度実行する**ことになり、**相手が同じシートでも区別していませんでした**。加えて `findMany` は毎回**見出し行を2回**読んでいました(絞り込み用と結果組み立て用)。

## 往復回数(実測)

| クエリ | before | after |
|---|---|---|
| `findMany({})` | 4 | **3** |
| `include` 1つ・別シート | 8 | **6** |
| `include` 1つ・自己参照 | 8 | **3** |
| **`include` 2つ・自己参照** | **12** | **3** |

`findFirst` / `count` / `aggregate` / `groupBy` も各 4 → 3。

## 使い回すのは「シートの中身」であって「クエリの結果」ではありません

`parent` と `children` では探すものが違います(`id in [...]` と `parentId in [...]`)。**絞り込み・並び替えは毎回そのまま実行**し、材料の行データだけ使い回します。

## 読み取り専用に限定・書き込みは完全遮断

**書き込み系9メソッドはバリアで囲み、その内側ではキャッシュが一切発生しません。**

理由は、書き込み処理が**自分の書き込みを読み直すことに依存**しているためです。#174 の Cascade 循環処理は「①持ち主1の行を一時値にする → ②持ち主2の行を1にする → **③持ち主が一時値の行を2にする**」と動き、③は①の結果を探します。ここを固定すると `__gassma_cascade_tmp_0` がシートに残ります。

バリアは **Cascade や whereRelation が内部で呼ぶ `controller.findMany`(公開メソッド)にも効きます**。「Cascade update の読み往復数 = 18」が実装前の実測と完全一致することをテストで固定しています。

さらに安全網として、**writer デコレータが書き込み前に全キャッシュを破棄**します。

## 寿命は「1回のトップレベル呼び出し」

`$transaction` 全体では持ちません。tx 内で `findMany` → `update` → `findMany` としたとき、**2回目は新しい値を返します**。Prisma も同じ(`["SELECT","UPDATE","SELECT"]` を実測)で、現状の gassma とも一致します。

「呼び出しを2回すると往復も倍になる」ことをテストで固定しています。

## 実装

- `src/util/read/cachedSheetReader.ts` — `SheetReader` のデコレータ。`$transaction` の buffered reader と同じ流儀で、**読み経路(`getAllData` / `getTitle` の2箇所)には一切手を触れていません**
- `src/util/read/readCacheContext.ts` — 寿命管理。リレーション解決が**別コントローラ**の `findMany` に飛ぶため構築時注入では伝搬できず、モジュールレベルの一時スロットを使用(`runTransaction.ts:21` の `transactionInProgress` に同じ前例)。GAS は単一スレッド同期実行
- `gassmaController.ts` — 読み5メソッドに窓、書き込み9メソッドにバリア、`getGassmaControllerUtil()` に適用の3種のみ。**各メソッドの本体は private に移しただけで1文字も変えていません**

## ⚠️ 厳密には観測しうる変化

- **クエリ実行中に別ユーザーが手編集した場合**、従来は途中から新しい値が混ざりえましたが(ティアリング)、今後は1呼び出し内で一貫した断面になります。より一貫した方向ですが「同一」ではありません
- **Date インスタンスの同一性**: キャッシュヒット時は clone するため、実 GAS の「読むたび新インスタンス」の意味論に統一されます(従来モックでは同一インスタンスが返るズレが既にありました)

## 検証

- `npx jest`: **1937 passed / 155 suites**(既存 1893 は**1件も書き換えず**全通過、新規44件)
- `npx tsc --noEmit` clean / `npm run build` 成功 / **`verify:bundle` OK(52、増減なし)**
- `biome`: **新規2ファイルは診断ゼロ**。`gassmaController.ts` の警告7件は**origin/main 時点と同数**(実ファイルで測定して確認)
- **追跡ファイルの変更は `gassmaController.ts` の1つだけ**
- `as` / `for ... of` 不使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)