### PR TITLE
docs: lead with a cross-sheet relation example in the README (en/ja)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,18 @@ generator client {
   output   = "./generated/gassma"
 }
 
-model User {
-  id    Int     @id
+model Author {
+  id    Int    @id
   name  String
-  email String?
-  age   Int
+  books Book[]
+}
+
+model Book {
+  id        Int     @id
+  title     String
+  published Boolean
+  authorId  Int
+  author    Author  @relation(fields: [authorId], references: [id])
 }
 ```
 
@@ -50,18 +57,24 @@ import { GassmaClient } from "./generated/gassma/schemaClient";
 
 const gassma = new GassmaClient();
 
-// Getting data from the SpreadSheet
-function myFunction(){
-    const result = gassma.User.findMany({
-        where: {
-            age: { gte: 25 }
-        },
-        orderBy: { name: "asc" }
-    });
+// Getting authors who have published at least one book
+function myFunction() {
+  const result = gassma.Author.findMany({
+    where: {
+      books: {
+        some: { published: true },
+      },
+    },
+    select: {
+      name: true,
+    },
+  });
 
-    console.log(result);
+  console.log(result);
 }
 ```
+
+Sheets are just sheets — GASsma resolves the relation across them for you, with full type safety.
 
 When using script editor in GAS...
 
@@ -69,15 +82,15 @@ When using script editor in GAS...
 const gassma = new Gassma.GassmaClient();
 
 // Getting data from the SpreadSheet
-function myFunction(){
-    const result = gassma.YOUR_SHEET_NAME.findMany({
-        where: {
-            city: "Tokyo",
-            age: 22
-        }
-    });
+function myFunction() {
+  const result = gassma.YOUR_SHEET_NAME.findMany({
+    where: {
+      city: "Tokyo",
+      age: 22,
+    },
+  });
 
-    console.log(result);
+  console.log(result);
 }
 ```
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -33,11 +33,18 @@ generator client {
   output   = "./generated/gassma"
 }
 
-model User {
-  id    Int     @id
+model Author {
+  id    Int    @id
   name  String
-  email String?
-  age   Int
+  books Book[]
+}
+
+model Book {
+  id        Int     @id
+  title     String
+  published Boolean
+  authorId  Int
+  author    Author  @relation(fields: [authorId], references: [id])
 }
 ```
 
@@ -50,18 +57,24 @@ import { GassmaClient } from "./generated/gassma/schemaClient";
 
 const gassma = new GassmaClient();
 
-// スプレッドシートからデータを取得
-function myFunction(){
-    const result = gassma.User.findMany({
-        where: {
-            age: { gte: 25 }
-        },
-        orderBy: { name: "asc" }
-    });
+// 一冊でも本を出版したことのある著者を取得
+function myFunction() {
+  const result = gassma.Author.findMany({
+    where: {
+      books: {
+        some: { published: true },
+      },
+    },
+    select: {
+      name: true,
+    },
+  });
 
-    console.log(result);
+  console.log(result);
 }
 ```
+
+シートはあくまでシートのまま。GASsma がシートをまたいだリレーションを型安全に解決します。
 
 GASのスクリプトエディタを使用する場合...
 
@@ -69,15 +82,15 @@ GASのスクリプトエディタを使用する場合...
 const gassma = new Gassma.GassmaClient();
 
 // スプレッドシートからデータを取得
-function myFunction(){
-    const result = gassma.YOUR_SHEET_NAME.findMany({
-        where: {
-            city: "Tokyo",
-            age: 22
-        }
-    });
+function myFunction() {
+  const result = gassma.YOUR_SHEET_NAME.findMany({
+    where: {
+      city: "Tokyo",
+      age: 22,
+    },
+  });
 
-    console.log(result);
+  console.log(result);
 }
 ```
 


### PR DESCRIPTION
## 概要

README の使用例を**リレーション**に差し替えます(ユーザー指示)。単一シートの `findMany` は GASsma の一番の強み — シートをまたいだリレーション解決 — を見せられていなかったため。

```ts
// Getting authors who have published at least one book
const result = gassma.Author.findMany({
  where: {
    books: {
      some: { published: true },
    },
  },
  select: {
    name: true,
  },
});
```

## 変更点

- **スキーマ例も Author / Book に差し替え**(コード例だけ変えるとスキーマと食い違うため。`books Book[]` と `@relation(fields: [authorId], references: [id])`)
- 「シートはあくまでシートのまま。GASsma がシートをまたいだリレーションを型安全に解決します」の1行を添えて、何がインパクトなのかを明示
- **インデントを4スペース→2スペースに**(GAS スクリプトエディタ側の例も含む)。関数宣言も `function myFunction() {` に統一

## 検証

- スキーマ例を**実 CLI の `gassma validate` にかけて valid を確認**
- さらに `gassma generate` して生成クライアントに対し、README のコード例そのものを **TypeScript で型チェック(エラーゼロ)**

en / ja 対で同内容です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtxX