### PR TITLE
fix: reject relations that run on ignored columns

### DIFF
--- a/src/__test__/util/relation/validation/ignoredColumnIntegration.test.ts
+++ b/src/__test__/util/relation/validation/ignoredColumnIntegration.test.ts
@@ -1,0 +1,145 @@
+import { RelationIgnoredColumnError } from "../../../../errors/relation/relationValidationError";
+import { GassmaClient } from "../../../../gassma";
+import type { GassmaController } from "../../../../gassmaController";
+import type { RelationsConfig } from "../../../../types/relationTypes";
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => { getValues: () => unknown[][] };
+  getDataRange: () => { getValues: () => unknown[][] };
+};
+
+const makeSheet = (name: string, data: unknown[][]): MockSheet => ({
+  getName: () => name,
+  getLastRow: () => data.length,
+  getLastColumn: () => data[0].length,
+  getRange: (row, col, numRows, numCols) => ({
+    getValues: () =>
+      data
+        .slice(row - 1, row - 1 + numRows)
+        .map((r) => r.slice(col - 1, col - 1 + numCols)),
+  }),
+  getDataRange: () => ({ getValues: () => data }),
+});
+
+const sheets = [
+  makeSheet("Users", [
+    ["id", "name"],
+    [1, "Alice"],
+  ]),
+  makeSheet("Posts", [
+    ["id", "authorId", "title"],
+    [101, 1, "Alice post"],
+  ]),
+  makeSheet("Categories", [
+    ["id", "name"],
+    [201, "tech"],
+  ]),
+  makeSheet("PostCategories", [
+    ["postId", "categoryId"],
+    [101, 201],
+  ]),
+];
+
+const mockSpreadsheet = {
+  getId: () => "test-spreadsheet",
+  getSheets: () => sheets,
+  getSheetByName: (name: string) =>
+    sheets.find((sheet) => sheet.getName() === name) ?? null,
+};
+
+const relations: RelationsConfig = {
+  Users: {
+    posts: {
+      type: "oneToMany",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+      onDelete: "SetNull",
+    },
+  },
+  Posts: {
+    categories: {
+      type: "manyToMany",
+      to: "Categories",
+      field: "id",
+      reference: "id",
+      through: {
+        sheet: "PostCategories",
+        field: "postId",
+        reference: "categoryId",
+      },
+    },
+  },
+};
+
+const isGassmaController = (value: unknown): value is GassmaController =>
+  typeof value === "object" &&
+  value !== null &&
+  "findMany" in value &&
+  typeof value.findMany === "function";
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!isGassmaController(controller)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+describe("無視列を使うリレーション定義の起動時拒否（統合）", () => {
+  beforeAll(() => {
+    Object.assign(globalThis, {
+      SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+    });
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, { SpreadsheetApp: undefined });
+  });
+
+  it("reference が相手シートで無視されているとクライアント構築時にエラーを投げる", () => {
+    expect(
+      () => new GassmaClient({ relations, ignore: { Posts: "authorId" } }),
+    ).toThrow(RelationIgnoredColumnError);
+  });
+
+  it("field が自シートで無視されているとクライアント構築時にエラーを投げる", () => {
+    expect(
+      () => new GassmaClient({ relations, ignore: { Users: ["id"] } }),
+    ).toThrow(RelationIgnoredColumnError);
+  });
+
+  it("through.field が中間シートで無視されているとクライアント構築時にエラーを投げる", () => {
+    expect(
+      () =>
+        new GassmaClient({ relations, ignore: { PostCategories: "postId" } }),
+    ).toThrow(RelationIgnoredColumnError);
+  });
+
+  it("リレーションに関係ない列の無視ならクライアントを構築できる", () => {
+    const client = new GassmaClient({
+      relations,
+      ignore: { Users: "name", Posts: ["title"] },
+    });
+
+    const posts = sheetOf(client, "Posts").findMany({});
+
+    expect(posts).toEqual([{ id: 101, authorId: 1 }]);
+  });
+
+  it("無視設定がなければクライアントを構築できる", () => {
+    expect(() => new GassmaClient({ relations })).not.toThrow();
+  });
+});

--- a/src/__test__/util/relation/validation/validateIgnoredColumns.test.ts
+++ b/src/__test__/util/relation/validation/validateIgnoredColumns.test.ts
@@ -1,0 +1,210 @@
+import { RelationIgnoredColumnError } from "../../../../errors/relation/relationValidationError";
+import { validateIgnoredColumns } from "../../../../util/relation/validation/validateIgnoredColumns";
+import { validateRelationsConfig } from "../../../../util/relation/validation/validateRelationsConfig";
+
+const buildGetIgnoredFields =
+  (ignored: Record<string, string[]>) =>
+  (sheetName: string): string[] =>
+    ignored[sheetName] ?? [];
+
+describe("validateIgnoredColumns", () => {
+  const oneToMany = {
+    type: "oneToMany",
+    to: "Posts",
+    field: "id",
+    reference: "authorId",
+  };
+
+  const manyToMany = {
+    type: "manyToMany",
+    to: "Categories",
+    field: "id",
+    reference: "id",
+    through: {
+      sheet: "PostCategories",
+      field: "postId",
+      reference: "categoryId",
+    },
+  };
+
+  it("field が自シートで無視されている場合エラーを投げる", () => {
+    expect(() =>
+      validateIgnoredColumns(
+        "Users",
+        "posts",
+        oneToMany,
+        buildGetIgnoredFields({ Users: ["id"] }),
+      ),
+    ).toThrow(RelationIgnoredColumnError);
+  });
+
+  it("reference が相手シートで無視されている場合エラーを投げる", () => {
+    expect(() =>
+      validateIgnoredColumns(
+        "Users",
+        "posts",
+        oneToMany,
+        buildGetIgnoredFields({ Posts: ["authorId"] }),
+      ),
+    ).toThrow(RelationIgnoredColumnError);
+  });
+
+  it("エラーメッセージにシート・リレーション・列名と危険性が含まれる", () => {
+    expect(() =>
+      validateIgnoredColumns(
+        "Users",
+        "posts",
+        oneToMany,
+        buildGetIgnoredFields({ Posts: ["authorId"] }),
+      ),
+    ).toThrow(
+      'Relation "posts" on sheet "Users": column "authorId" is ignored on sheet "Posts". Ignored columns are stripped from where conditions, so relation processing (onDelete/onUpdate/nested writes) could modify all rows in sheet "Posts". Remove "authorId" from the ignore option or remove this relation',
+    );
+  });
+
+  it("through.field が中間シートで無視されている場合エラーを投げる", () => {
+    expect(() =>
+      validateIgnoredColumns(
+        "Posts",
+        "categories",
+        manyToMany,
+        buildGetIgnoredFields({ PostCategories: ["postId"] }),
+      ),
+    ).toThrow(RelationIgnoredColumnError);
+  });
+
+  it("through.reference が中間シートで無視されている場合エラーを投げる", () => {
+    expect(() =>
+      validateIgnoredColumns(
+        "Posts",
+        "categories",
+        manyToMany,
+        buildGetIgnoredFields({ PostCategories: ["categoryId"] }),
+      ),
+    ).toThrow(RelationIgnoredColumnError);
+  });
+
+  it("manyToMany の reference が相手シートで無視されている場合エラーを投げる", () => {
+    expect(() =>
+      validateIgnoredColumns(
+        "Posts",
+        "categories",
+        manyToMany,
+        buildGetIgnoredFields({ Categories: ["id"] }),
+      ),
+    ).toThrow(RelationIgnoredColumnError);
+  });
+
+  it("リレーションと無関係な列の無視ではエラーを投げない", () => {
+    expect(() =>
+      validateIgnoredColumns(
+        "Users",
+        "posts",
+        oneToMany,
+        buildGetIgnoredFields({ Users: ["name"], Posts: ["title"] }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("同名の列でも別シートでの無視ならエラーを投げない", () => {
+    expect(() =>
+      validateIgnoredColumns(
+        "Users",
+        "posts",
+        oneToMany,
+        buildGetIgnoredFields({ Users: ["authorId"], Posts: ["id"] }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("through の列名を中間シート以外で無視してもエラーを投げない", () => {
+    expect(() =>
+      validateIgnoredColumns(
+        "Posts",
+        "categories",
+        manyToMany,
+        buildGetIgnoredFields({
+          Posts: ["postId"],
+          Categories: ["categoryId"],
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("無視設定が空ならエラーを投げない", () => {
+    expect(() =>
+      validateIgnoredColumns(
+        "Users",
+        "posts",
+        oneToMany,
+        buildGetIgnoredFields({}),
+      ),
+    ).not.toThrow();
+  });
+
+  it("manyToMany 以外では through の検査を行わない", () => {
+    const withoutThrough = {
+      type: "oneToMany",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+    };
+
+    expect(() =>
+      validateIgnoredColumns(
+        "Users",
+        "posts",
+        withoutThrough,
+        buildGetIgnoredFields({ PostCategories: ["postId", "categoryId"] }),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("validateRelationsConfig の無視列チェック連携", () => {
+  const mockSheets: Record<string, unknown> = {
+    Users: {},
+    Posts: {},
+  };
+
+  const getColumnHeaders = (sheetName: string): string[] => {
+    const headers: Record<string, string[]> = {
+      Users: ["id", "name"],
+      Posts: ["id", "authorId", "title"],
+    };
+    return headers[sheetName] ?? [];
+  };
+
+  const relations = {
+    Users: {
+      posts: {
+        type: "oneToMany",
+        to: "Posts",
+        field: "id",
+        reference: "authorId",
+      },
+    },
+  };
+
+  it("getIgnoredFields 付きで無視列を使うリレーションを弾く", () => {
+    expect(() =>
+      validateRelationsConfig(
+        relations,
+        mockSheets,
+        getColumnHeaders,
+        buildGetIgnoredFields({ Posts: ["authorId"] }),
+      ),
+    ).toThrow(RelationIgnoredColumnError);
+  });
+
+  it("getIgnoredFields 付きでも無関係な列の無視なら通る", () => {
+    expect(() =>
+      validateRelationsConfig(
+        relations,
+        mockSheets,
+        getColumnHeaders,
+        buildGetIgnoredFields({ Posts: ["title"], Users: ["name"] }),
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/errors/relation/relationValidationError.ts
+++ b/src/errors/relation/relationValidationError.ts
@@ -96,6 +96,20 @@ class RelationInvalidOnUpdateError extends Error {
   }
 }
 
+class RelationIgnoredColumnError extends Error {
+  constructor(
+    sheetName: string,
+    relationName: string,
+    columnName: string,
+    ignoredSheetName: string,
+  ) {
+    super(
+      `Relation "${relationName}" on sheet "${sheetName}": column "${columnName}" is ignored on sheet "${ignoredSheetName}". Ignored columns are stripped from where conditions, so relation processing (onDelete/onUpdate/nested writes) could modify all rows in sheet "${ignoredSheetName}". Remove "${columnName}" from the ignore option or remove this relation`,
+    );
+    this.name = "RelationIgnoredColumnError";
+  }
+}
+
 export {
   RelationSheetNotFoundError,
   RelationMissingPropertyError,
@@ -108,4 +122,5 @@ export {
   IncludeSelectIncludeConflictError,
   RelationInvalidOnDeleteError,
   RelationInvalidOnUpdateError,
+  RelationIgnoredColumnError,
 };

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -154,6 +154,10 @@ class GassmaController {
     this.ignoredFields = fields;
   }
 
+  public _getIgnoredFields(): string[] {
+    return this.ignoredFields ?? [];
+  }
+
   public _setMap(mapping: FieldMapping) {
     this.fieldMapping = mapping;
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -567,6 +567,14 @@ declare namespace Gassma {
   class RelationInvalidOnUpdateError extends Error {
     constructor(sheetName: string, relationName: string, value: string);
   }
+  class RelationIgnoredColumnError extends Error {
+    constructor(
+      sheetName: string,
+      relationName: string,
+      columnName: string,
+      ignoredSheetName: string,
+    );
+  }
   class NestedWriteConnectNotFoundError extends Error {
     constructor(sheetName: string);
   }

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -55,6 +55,8 @@ export const RelationInvalidOnDeleteError =
   relationValidationErrors.RelationInvalidOnDeleteError;
 export const RelationInvalidOnUpdateError =
   relationValidationErrors.RelationInvalidOnUpdateError;
+export const RelationIgnoredColumnError =
+  relationValidationErrors.RelationIgnoredColumnError;
 
 export const WhereRelationInvalidFilterError =
   whereRelationErrors.WhereRelationInvalidFilterError;

--- a/src/util/relation/injectRelations.ts
+++ b/src/util/relation/injectRelations.ts
@@ -16,7 +16,15 @@ const injectRelations = (
     return headers;
   };
 
-  validateRelationsConfig(relations, controllers, getColumnHeaders);
+  const getIgnoredFields = (sheetName: string): string[] =>
+    controllers[sheetName]._getIgnoredFields();
+
+  validateRelationsConfig(
+    relations,
+    controllers,
+    getColumnHeaders,
+    getIgnoredFields,
+  );
 
   const findManyOnSheet = (
     sheetName: string,

--- a/src/util/relation/validation/validateIgnoredColumns.ts
+++ b/src/util/relation/validation/validateIgnoredColumns.ts
@@ -1,0 +1,77 @@
+import { RelationIgnoredColumnError } from "../../../errors/relation/relationValidationError";
+
+type GetIgnoredFields = (sheetName: string) => string[];
+
+interface ThroughConfig {
+  sheet: string;
+  field: string;
+  reference: string;
+}
+
+interface RelationForIgnoreCheck {
+  type: string;
+  to: string;
+  field: string;
+  reference: string;
+  through?: ThroughConfig;
+}
+
+const assertColumnNotIgnored = (
+  sourceSheetName: string,
+  relationName: string,
+  sheetName: string,
+  columnName: string,
+  getIgnoredFields: GetIgnoredFields,
+): void => {
+  if (getIgnoredFields(sheetName).includes(columnName)) {
+    throw new RelationIgnoredColumnError(
+      sourceSheetName,
+      relationName,
+      columnName,
+      sheetName,
+    );
+  }
+};
+
+const validateIgnoredColumns = (
+  sourceSheetName: string,
+  relationName: string,
+  definition: RelationForIgnoreCheck,
+  getIgnoredFields: GetIgnoredFields,
+): void => {
+  assertColumnNotIgnored(
+    sourceSheetName,
+    relationName,
+    sourceSheetName,
+    definition.field,
+    getIgnoredFields,
+  );
+
+  assertColumnNotIgnored(
+    sourceSheetName,
+    relationName,
+    definition.to,
+    definition.reference,
+    getIgnoredFields,
+  );
+
+  if (definition.type === "manyToMany" && definition.through) {
+    assertColumnNotIgnored(
+      sourceSheetName,
+      relationName,
+      definition.through.sheet,
+      definition.through.field,
+      getIgnoredFields,
+    );
+    assertColumnNotIgnored(
+      sourceSheetName,
+      relationName,
+      definition.through.sheet,
+      definition.through.reference,
+      getIgnoredFields,
+    );
+  }
+};
+
+export { validateIgnoredColumns };
+export type { GetIgnoredFields };

--- a/src/util/relation/validation/validateRelationsConfig.ts
+++ b/src/util/relation/validation/validateRelationsConfig.ts
@@ -1,14 +1,19 @@
 import { RelationSheetNotFoundError } from "../../../errors/relation/relationValidationError";
-import { validateRelationDefinition } from "./validateRelationDefinition";
 import {
-  validateColumnExistence,
   type GetColumnHeaders,
+  validateColumnExistence,
 } from "./validateColumnExistence";
+import {
+  type GetIgnoredFields,
+  validateIgnoredColumns,
+} from "./validateIgnoredColumns";
+import { validateRelationDefinition } from "./validateRelationDefinition";
 
 const validateRelationsConfig = (
   relations: Record<string, Record<string, Record<string, unknown>>>,
   sheets: Record<string, unknown>,
   getColumnHeaders: GetColumnHeaders,
+  getIgnoredFields?: GetIgnoredFields,
 ): void => {
   const allSheetNames = Object.keys(sheets);
 
@@ -29,18 +34,29 @@ const validateRelationsConfig = (
         allSheetNames,
       );
 
+      const checkedDefinition = definition as {
+        type: string;
+        to: string;
+        field: string;
+        reference: string;
+        through?: { sheet: string; field: string; reference: string };
+      };
+
       validateColumnExistence(
         sheetName,
         relationName,
-        definition as {
-          type: string;
-          to: string;
-          field: string;
-          reference: string;
-          through?: { sheet: string; field: string; reference: string };
-        },
+        checkedDefinition,
         getColumnHeaders,
       );
+
+      if (getIgnoredFields) {
+        validateIgnoredColumns(
+          sheetName,
+          relationName,
+          checkedDefinition,
+          getIgnoredFields,
+        );
+      }
     });
   });
 };


### PR DESCRIPTION
## 直す問題

#174 の作業中に見つけた既存バグです。**エラーも警告も出ずに子シートの全行が壊れます。**

`resolveWhere`([`gassmaController.ts:277-283`](https://github.com/akahoshi1421/gassma/blob/main/src/gassmaController.ts#L277-L283))は `where` から**無視指定された列を落とします**。リレーションの追従処理はその列で絞り込むので、**条件が消えて `where` が `{}` になり、全行に一致**します。

| 経路 | 起きること |
|---|---|
| onDelete: Cascade | **子シートの全行が削除** |
| onDelete/onUpdate: SetNull | **全行が null になる** |
| Restrict | 常にヒットして誤発動 |
| nested write の `delete: true` | **親シートの全行が削除** |
| nested write の `disconnect` | その親の全リンクが解除 |

## Prisma はどうしているか(実測)

FK 列に `@ignore` を付けると、Prisma は**リレーションごと生成 API から消します**。

```ts
export type PostInclude = {}   // include できるものが何もない
export type PostCreateInput = { title: string; updatedAt?: Date | string }
```

`include: { author: true }` は型が `never`、`author: { connect: ... }` も使えません。**FK が使えないならリレーションも使わせない**という設計で、データの整合性は DB の外部キー制約が守ります。

**gassma にはリレーションを消す仕組みも、下支えする制約もありません。**そこで**明示的に拒否**します(黙って消えるより設定ミスを教える方が親切、というユーザー判断)。

## やること

危険な設定ならクライアント構築時に例外を投げます。

```
Relation "posts" on sheet "Users": column "authorId" is ignored on sheet "Posts".
Ignored columns are stripped from where conditions, so relation processing
(onDelete/onUpdate/nested writes) could modify all rows in sheet "Posts".
Remove "authorId" from the ignore option or remove this relation
```

**どのシートの無視設定がどの列に効くか**は、`where` を評価する側のシートで判定します(`field`→自シート / `reference`→`to` / `through.*`→`through.sheet`)。これは既存の列存在チェックと同じ対応関係です。

## 保有側(`field`)も拒否します

こちらは `where` を潰しません(親の値収集は無視適用前に読むため)。ただし**リレーションとしては壊れています** — include が常に空、nested write は黙って何もしません。加えて**両側宣言のリレーションでは同じ列が逆側の `reference`** になり、全行破壊の経路に乗ります。Prisma もこの場合リレーションごと消すので、揃えて拒否します。

## 検証

- `npx jest`: **1955 passed**(既存 1937 は**1件も書き換えず**全通過、新規18件)
- 新規テストは4列すべてのエラー系・メッセージ・**正常系**(無関係な列の無視 / 同名別シート / `through` 列を別シートで無視)をカバー。加えて `new GassmaClient({relations, ignore})` を実際に構築する統合テスト5件
- `tsc` clean / `build` 成功 / **`verify:bundle` OK(公開シンボル 52 → **53**、増分は新エラー1件のみ)**
- `biome`: 新規・変更部分は指摘ゼロ。`publicApi.ts` の organizeImports は **origin/main でも同じく出る既存分**(実ファイルで測定して確認)。`npm run lint` は通過

## 補足

`validateRelationsConfig` の第4引数(無視列の取得)は**省略可能**にしています。既存テストが3引数で呼んでおり、必須化すると書き換えが必要になるためです。実運用の経路(`injectRelations`)では必ず渡り、上記の統合テスト5件が実クライアント構築で守っています。

**CLI 側(型生成時に弾く)は別 PR です。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)