### PR TITLE
feat: add acceptDataLoss option to migrateSheets

### DIFF
--- a/src/__test__/util/migrate/migrateSheets.test.ts
+++ b/src/__test__/util/migrate/migrateSheets.test.ts
@@ -31,6 +31,7 @@ type MockSheet = {
     numCols: number,
   ) => MockRange;
   insertColumnsAfter: (afterPosition: number, howMany: number) => void;
+  deleteColumn: (columnPosition: number) => void;
 };
 
 type SheetHandle = {
@@ -38,6 +39,7 @@ type SheetHandle = {
   snapshot: () => unknown[][];
   writes: SetValuesCall[];
   columnInsertions: InsertColumnsAfterCall[];
+  deletedColumns: number[];
 };
 
 const DEFAULT_MAX_COLUMNS = 26;
@@ -50,6 +52,7 @@ const makeSheet = (
   const data = initial.map((row) => [...row]);
   const writes: SetValuesCall[] = [];
   const columnInsertions: InsertColumnsAfterCall[] = [];
+  const deletedColumns: number[] = [];
   let maxColumns = initialMaxColumns;
   const width = () => (data[0] ? data[0].length : 0);
   const sheet: MockSheet = {
@@ -65,9 +68,12 @@ const makeSheet = (
       }
       return {
         getValues: () =>
-          data
-            .slice(row - 1, row - 1 + numRows)
-            .map((r) => r.slice(col - 1, col - 1 + numCols)),
+          Array.from({ length: numRows }, (_, i) =>
+            Array.from({ length: numCols }, (_, j) => {
+              const value = data[row - 1 + i]?.[col - 1 + j];
+              return value === undefined ? "" : value;
+            }),
+          ),
         setValues: (values) => {
           writes.push({ row, col, numRows, numCols, values });
           values.forEach((rowValues, i) => {
@@ -91,12 +97,27 @@ const makeSheet = (
       });
       maxColumns += howMany;
     },
+    deleteColumn: (columnPosition) => {
+      if (columnPosition < 1 || columnPosition > maxColumns) {
+        throw new Error("Those columns are out of bounds.");
+      }
+      if (maxColumns <= 1) {
+        throw new Error("You can't delete all the columns in the sheet.");
+      }
+      deletedColumns.push(columnPosition);
+      data.forEach((row) => {
+        if (row.length < columnPosition) return;
+        row.splice(columnPosition - 1, 1);
+      });
+      maxColumns -= 1;
+    },
   };
   return {
     sheet,
     snapshot: () => data.map((row) => [...row]),
     writes,
     columnInsertions,
+    deletedColumns,
   };
 };
 
@@ -428,6 +449,148 @@ describe("migrateSheets 非破壊", () => {
       ),
     ).toBe(true);
     expect(warns.some((warn) => warn.includes('"Old"'))).toBe(true);
+    expect(warns.some((warn) => warn.includes('""'))).toBe(false);
+  });
+});
+
+describe("migrateSheets acceptDataLoss 無効時", () => {
+  test("acceptDataLoss: false では schema に無い列もシートも削除しない", () => {
+    const users = makeSheet("User", [
+      ["id", "legacy"],
+      [1, "x"],
+    ]);
+    const old = makeSheet("Old", [["a"], [1]]);
+    const env = makeSpreadsheet("active", [users, old]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id"] }],
+      acceptDataLoss: false,
+    });
+
+    expect(users.snapshot()).toEqual([
+      ["id", "legacy"],
+      [1, "x"],
+    ]);
+    expect(users.deletedColumns).toEqual([]);
+    expect(env.sheetNames()).toEqual(["User", "Old"]);
+    const warns = messagesOf(warnSpy);
+    expect(warns.some((warn) => warn.includes('"legacy"'))).toBe(true);
+    expect(warns.some((warn) => warn.includes('"Old"'))).toBe(true);
+  });
+});
+
+describe("migrateSheets acceptDataLoss 列削除", () => {
+  test("schema に無い列を削除し非空セル数を警告する", () => {
+    const users = makeSheet("User", [
+      ["id", "memo"],
+      [1, "a"],
+      [2, ""],
+      [3, "b"],
+    ]);
+    const env = makeSpreadsheet("active", [users]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id"] }],
+      acceptDataLoss: true,
+    });
+
+    expect(users.snapshot()).toEqual([["id"], [1], [2], [3]]);
+    expect(users.deletedColumns).toEqual([2]);
+    expect(users.writes).toEqual([]);
+    expect(env.sheetNames()).toEqual(["User"]);
+    expect(messagesOf(warnSpy)).toContain(
+      'Gassma.migrateSheets: You are about to drop the column "memo" on the sheet "User", which still contains 2 non-empty values.',
+    );
+  });
+
+  test("複数の余分な列を削除しても位置がずれない", () => {
+    const users = makeSheet("User", [
+      ["id", "legacy1", "name", "legacy2", "email"],
+      [1, "a", "Alice", "b", "alice@example.com"],
+    ]);
+    const env = makeSpreadsheet("active", [users]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id", "name", "email"] }],
+      acceptDataLoss: true,
+    });
+
+    expect(users.snapshot()).toEqual([
+      ["id", "name", "email"],
+      [1, "Alice", "alice@example.com"],
+    ]);
+    const warns = messagesOf(warnSpy);
+    expect(warns.some((warn) => warn.includes('"legacy1"'))).toBe(true);
+    expect(warns.some((warn) => warn.includes('"legacy2"'))).toBe(true);
+  });
+
+  test("足りない列の追加を先に行ってから余分な列を削除する", () => {
+    const users = makeSheet("User", [
+      ["id", "legacy", "name"],
+      [1, "L", "Alice"],
+    ]);
+    const env = makeSpreadsheet("active", [users]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id", "name", "flag"] }],
+      acceptDataLoss: true,
+    });
+
+    expect(users.snapshot()).toEqual([
+      ["id", "name", "flag"],
+      [1, "Alice"],
+    ]);
+    expect(users.writes.length).toBe(1);
+    users.writes.forEach((write) => {
+      expect(write.row).toBe(1);
+      expect(write.numRows).toBe(1);
+    });
+  });
+
+  test("データセルがすべて空の列も削除し 0 件として警告する", () => {
+    const users = makeSheet("User", [
+      ["id", "empty"],
+      [1, ""],
+      [2, ""],
+    ]);
+    const env = makeSpreadsheet("active", [users]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id"] }],
+      acceptDataLoss: true,
+    });
+
+    expect(users.snapshot()).toEqual([["id"], [1], [2]]);
+    expect(users.deletedColumns).toEqual([2]);
+    expect(messagesOf(warnSpy)).toContain(
+      'Gassma.migrateSheets: You are about to drop the column "empty" on the sheet "User", which still contains 0 non-empty values.',
+    );
+  });
+
+  test("ヘッダーが空文字の列は削除しない", () => {
+    const users = makeSheet("User", [
+      ["id", "", "legacy"],
+      [1, "", "x"],
+    ]);
+    const env = makeSpreadsheet("active", [users]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id"] }],
+      acceptDataLoss: true,
+    });
+
+    expect(users.snapshot()).toEqual([
+      ["id", ""],
+      [1, ""],
+    ]);
+    expect(users.deletedColumns).toEqual([3]);
+    const warns = messagesOf(warnSpy);
     expect(warns.some((warn) => warn.includes('""'))).toBe(false);
   });
 });

--- a/src/__test__/util/migrate/migrateSheets.test.ts
+++ b/src/__test__/util/migrate/migrateSheets.test.ts
@@ -585,6 +585,28 @@ describe("migrateSheets acceptDataLoss 列削除", () => {
     expect(messagesOf(warnSpy)).toEqual([]);
   });
 
+  test("0 や false のセルも非空としてカウントする", () => {
+    const users = makeSheet("User", [
+      ["id", "legacy"],
+      [1, 0],
+      [2, false],
+      [3, ""],
+    ]);
+    const env = makeSpreadsheet("active", [users]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id"] }],
+      acceptDataLoss: true,
+    });
+
+    expect(users.snapshot()).toEqual([["id"], [1], [2], [3]]);
+    expect(users.deletedColumns).toEqual([2]);
+    expect(messagesOf(warnSpy)).toContain(
+      'Gassma.migrateSheets: You are about to drop the column "legacy" on the sheet "User", which still contains 2 non-empty values.',
+    );
+  });
+
   test("ヘッダーが空文字の列は削除しない", () => {
     const users = makeSheet("User", [
       ["id", "", "legacy"],
@@ -641,6 +663,24 @@ describe("migrateSheets acceptDataLoss シート削除", () => {
     expect(env.sheetNames()).toEqual(["User"]);
     expect(env.deletedNames).toEqual(["Empty"]);
     expect(messagesOf(warnSpy)).toEqual([]);
+  });
+
+  test("0 や false だけの行もデータ行としてカウントする", () => {
+    const users = makeSheet("User", [["id"]]);
+    const flags = makeSheet("Flags", [["flag"], [0], [false]]);
+    const env = makeSpreadsheet("active", [users, flags]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id"] }],
+      acceptDataLoss: true,
+    });
+
+    expect(env.sheetNames()).toEqual(["User"]);
+    expect(env.deletedNames).toEqual(["Flags"]);
+    expect(messagesOf(warnSpy)).toContain(
+      'Gassma.migrateSheets: You are about to drop the sheet "Flags", which still contains 2 rows.',
+    );
   });
 
   test("最後の1枚になるシートは削除せず警告して残す", () => {

--- a/src/__test__/util/migrate/migrateSheets.test.ts
+++ b/src/__test__/util/migrate/migrateSheets.test.ts
@@ -566,7 +566,7 @@ describe("migrateSheets acceptDataLoss 列削除", () => {
     });
   });
 
-  test("データセルがすべて空の列も削除し 0 件として警告する", () => {
+  test("データセルがすべて空の列は警告なしで削除する", () => {
     const users = makeSheet("User", [
       ["id", "empty"],
       [1, ""],
@@ -582,9 +582,7 @@ describe("migrateSheets acceptDataLoss 列削除", () => {
 
     expect(users.snapshot()).toEqual([["id"], [1], [2]]);
     expect(users.deletedColumns).toEqual([2]);
-    expect(messagesOf(warnSpy)).toContain(
-      'Gassma.migrateSheets: You are about to drop the column "empty" on the sheet "User", which still contains 0 non-empty values.',
-    );
+    expect(messagesOf(warnSpy)).toEqual([]);
   });
 
   test("ヘッダーが空文字の列は削除しない", () => {
@@ -629,7 +627,7 @@ describe("migrateSheets acceptDataLoss シート削除", () => {
     );
   });
 
-  test("データが空のシートも削除し 0 行として警告する", () => {
+  test("データが空のシートは警告なしで削除する", () => {
     const users = makeSheet("User", [["id"]]);
     const empty = makeSheet("Empty", [["a"]]);
     const env = makeSpreadsheet("active", [users, empty]);
@@ -642,9 +640,7 @@ describe("migrateSheets acceptDataLoss シート削除", () => {
 
     expect(env.sheetNames()).toEqual(["User"]);
     expect(env.deletedNames).toEqual(["Empty"]);
-    expect(messagesOf(warnSpy)).toContain(
-      'Gassma.migrateSheets: You are about to drop the sheet "Empty", which still contains 0 rows.',
-    );
+    expect(messagesOf(warnSpy)).toEqual([]);
   });
 
   test("最後の1枚になるシートは削除せず警告して残す", () => {

--- a/src/__test__/util/migrate/migrateSheets.test.ts
+++ b/src/__test__/util/migrate/migrateSheets.test.ts
@@ -126,12 +126,14 @@ type MockSpreadsheet = {
   getSheets: () => MockSheet[];
   getSheetByName: (name: string) => MockSheet | null;
   insertSheet: (name: string) => MockSheet;
+  deleteSheet: (sheet: MockSheet) => void;
 };
 
 type SpreadsheetHandle = {
   spreadsheet: MockSpreadsheet;
   handleOf: (name: string) => SheetHandle;
   insertedNames: string[];
+  deletedNames: string[];
   sheetNames: () => string[];
 };
 
@@ -141,6 +143,7 @@ const makeSpreadsheet = (
 ): SpreadsheetHandle => {
   const all = [...handles];
   const insertedNames: string[] = [];
+  const deletedNames: string[] = [];
   const spreadsheet: MockSpreadsheet = {
     getId: () => id,
     getSheets: () => all.map((handle) => handle.sheet),
@@ -155,6 +158,17 @@ const makeSpreadsheet = (
       insertedNames.push(name);
       return handle.sheet;
     },
+    deleteSheet: (sheet) => {
+      if (all.length <= 1) {
+        throw new Error("You can't remove all the sheets in a document.");
+      }
+      const index = all.findIndex((handle) => handle.sheet === sheet);
+      if (index === -1) {
+        throw new Error(`mock sheet not found: ${sheet.getName()}`);
+      }
+      deletedNames.push(sheet.getName());
+      all.splice(index, 1);
+    },
   };
   const handleOf = (name: string): SheetHandle => {
     const found = all.find((handle) => handle.sheet.getName() === name);
@@ -165,6 +179,7 @@ const makeSpreadsheet = (
     spreadsheet,
     handleOf,
     insertedNames,
+    deletedNames,
     sheetNames: () => all.map((handle) => handle.sheet.getName()),
   };
 };
@@ -592,6 +607,94 @@ describe("migrateSheets acceptDataLoss 列削除", () => {
     expect(users.deletedColumns).toEqual([3]);
     const warns = messagesOf(warnSpy);
     expect(warns.some((warn) => warn.includes('""'))).toBe(false);
+  });
+});
+
+describe("migrateSheets acceptDataLoss シート削除", () => {
+  test("schema に無いシートを削除しデータ行数を警告する", () => {
+    const users = makeSheet("User", [["id"], [1]]);
+    const old = makeSheet("Old", [["a"], [1], [2]]);
+    const env = makeSpreadsheet("active", [users, old]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id"] }],
+      acceptDataLoss: true,
+    });
+
+    expect(env.sheetNames()).toEqual(["User"]);
+    expect(env.deletedNames).toEqual(["Old"]);
+    expect(messagesOf(warnSpy)).toContain(
+      'Gassma.migrateSheets: You are about to drop the sheet "Old", which still contains 2 rows.',
+    );
+  });
+
+  test("データが空のシートも削除し 0 行として警告する", () => {
+    const users = makeSheet("User", [["id"]]);
+    const empty = makeSheet("Empty", [["a"]]);
+    const env = makeSpreadsheet("active", [users, empty]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "User", columns: ["id"] }],
+      acceptDataLoss: true,
+    });
+
+    expect(env.sheetNames()).toEqual(["User"]);
+    expect(env.deletedNames).toEqual(["Empty"]);
+    expect(messagesOf(warnSpy)).toContain(
+      'Gassma.migrateSheets: You are about to drop the sheet "Empty", which still contains 0 rows.',
+    );
+  });
+
+  test("最後の1枚になるシートは削除せず警告して残す", () => {
+    const old1 = makeSheet("Old1", [["a"], [1]]);
+    const old2 = makeSheet("Old2", [["b"]]);
+    const env = makeSpreadsheet("active", [old1, old2]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({ models: [], acceptDataLoss: true });
+
+    expect(env.deletedNames).toEqual(["Old1"]);
+    expect(env.sheetNames()).toEqual(["Old2"]);
+    const warns = messagesOf(warnSpy);
+    expect(
+      warns.some(
+        (warn) => warn.includes('"Old2"') && warn.includes("at least one"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("migrateSheets acceptDataLoss 冪等性", () => {
+  test("削除後に再実行しても変更が発生しない", () => {
+    const users = makeSheet("User", [
+      ["id", "legacy"],
+      [1, "x"],
+    ]);
+    const old = makeSheet("Old", [["a"], [1]]);
+    const env = makeSpreadsheet("active", [users, old]);
+    installSpreadsheetApp(env);
+    const options = {
+      models: [{ name: "User", columns: ["id"] }],
+      acceptDataLoss: true,
+    };
+
+    migrateSheets(options);
+    const snapshotAfterFirst = users.snapshot();
+    const writeCountAfterFirst = users.writes.length;
+    const deletedColumnsAfterFirst = [...users.deletedColumns];
+    const deletedNamesAfterFirst = [...env.deletedNames];
+    const warnCountAfterFirst = warnSpy.mock.calls.length;
+
+    migrateSheets(options);
+
+    expect(users.snapshot()).toEqual(snapshotAfterFirst);
+    expect(users.writes.length).toBe(writeCountAfterFirst);
+    expect(users.deletedColumns).toEqual(deletedColumnsAfterFirst);
+    expect(env.deletedNames).toEqual(deletedNamesAfterFirst);
+    expect(env.sheetNames()).toEqual(["User"]);
+    expect(warnSpy.mock.calls.length).toBe(warnCountAfterFirst);
   });
 });
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -316,6 +316,7 @@ declare namespace Gassma {
   type MigrateSheetsOptions = {
     spreadsheetId?: string;
     models: MigrateModel[];
+    acceptDataLoss?: boolean;
   };
 
   /**
@@ -323,7 +324,10 @@ declare namespace Gassma {
    * missing sheets are created and missing columns are appended, idempotently.
    * Assumes the header row is row 1 starting at column A on every sheet
    * (header positions moved via changeSettings are not supported).
-   * Never deletes or reorders existing sheets/columns, never touches data rows.
+   * Columns not in the schema are only warned about by default; with
+   * `acceptDataLoss: true` they are dropped after a warning that reports how
+   * much data they still contain. Sheets not in the schema are never deleted.
+   * Never reorders existing columns, never writes to data rows.
    */
   function migrateSheets(options: MigrateSheetsOptions): void;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -326,9 +326,9 @@ declare namespace Gassma {
    * (header positions moved via changeSettings are not supported).
    * Columns and sheets not in the schema are only warned about by default;
    * with `acceptDataLoss: true` they are dropped after a warning that reports
-   * how much data they still contain (the last remaining sheet is kept, since
-   * a spreadsheet must contain at least one sheet).
-   * Never reorders existing columns, never writes to data rows.
+   * how much data they still contain (silently when they are empty; the last
+   * remaining sheet is kept, since a spreadsheet must contain at least one
+   * sheet). Never reorders existing columns, never writes to data rows.
    */
   function migrateSheets(options: MigrateSheetsOptions): void;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -324,9 +324,10 @@ declare namespace Gassma {
    * missing sheets are created and missing columns are appended, idempotently.
    * Assumes the header row is row 1 starting at column A on every sheet
    * (header positions moved via changeSettings are not supported).
-   * Columns not in the schema are only warned about by default; with
-   * `acceptDataLoss: true` they are dropped after a warning that reports how
-   * much data they still contain. Sheets not in the schema are never deleted.
+   * Columns and sheets not in the schema are only warned about by default;
+   * with `acceptDataLoss: true` they are dropped after a warning that reports
+   * how much data they still contain (the last remaining sheet is kept, since
+   * a spreadsheet must contain at least one sheet).
    * Never reorders existing columns, never writes to data rows.
    */
   function migrateSheets(options: MigrateSheetsOptions): void;

--- a/src/types/migrateTypes.ts
+++ b/src/types/migrateTypes.ts
@@ -6,6 +6,7 @@ type MigrateModel = {
 type MigrateSheetsOptions = {
   spreadsheetId?: string;
   models: MigrateModel[];
+  acceptDataLoss?: boolean;
 };
 
 export type { MigrateModel, MigrateSheetsOptions };

--- a/src/util/migrate/migrateSheets.ts
+++ b/src/util/migrate/migrateSheets.ts
@@ -45,21 +45,66 @@ const warnExtraColumns = (headers: string[], model: MigrateModel) => {
   });
 };
 
-const appendMissingColumns = (sheet: Sheet, model: MigrateModel) => {
-  const headers = readHeaders(sheet);
+const appendMissingColumns = (
+  sheet: Sheet,
+  model: MigrateModel,
+  headers: string[],
+) => {
   const missingColumns = model.columns.filter(
     (column) => !headers.includes(column),
   );
   if (missingColumns.length === 0) {
     console.log(`${LOG_PREFIX} sheet "${model.name}" is up to date`);
-  } else {
-    ensureColumnCapacity(sheet, headers.length + missingColumns.length);
-    sheet
-      .getRange(1, headers.length + 1, 1, missingColumns.length)
-      .setValues([missingColumns]);
-    console.log(
-      `${LOG_PREFIX} added columns [${missingColumns.join(", ")}] to sheet "${model.name}"`,
+    return;
+  }
+  ensureColumnCapacity(sheet, headers.length + missingColumns.length);
+  sheet
+    .getRange(1, headers.length + 1, 1, missingColumns.length)
+    .setValues([missingColumns]);
+  console.log(
+    `${LOG_PREFIX} added columns [${missingColumns.join(", ")}] to sheet "${model.name}"`,
+  );
+};
+
+const listExtraColumns = (headers: string[], model: MigrateModel) =>
+  headers
+    .map((header, index) => ({ header, position: index + 1 }))
+    .filter(({ header }) => header !== "" && !model.columns.includes(header));
+
+const countNonEmptyDataCells = (sheet: Sheet, columnPosition: number) => {
+  const lastRow = sheet.getLastRow();
+  if (lastRow < 2) return 0;
+  const values = sheet.getRange(2, columnPosition, lastRow - 1, 1).getValues();
+  return values.filter((row) => row[0] !== "").length;
+};
+
+const dropExtraColumns = (
+  sheet: Sheet,
+  model: MigrateModel,
+  headers: string[],
+) => {
+  const extraColumns = listExtraColumns(headers, model);
+  extraColumns.forEach(({ header, position }) => {
+    const count = countNonEmptyDataCells(sheet, position);
+    console.warn(
+      `${LOG_PREFIX} You are about to drop the column "${header}" on the sheet "${model.name}", which still contains ${count} non-empty values.`,
     );
+  });
+  [...extraColumns].reverse().forEach(({ position }) => {
+    sheet.deleteColumn(position);
+  });
+};
+
+const syncExistingSheet = (
+  sheet: Sheet,
+  model: MigrateModel,
+  acceptDataLoss: boolean,
+) => {
+  const headers = readHeaders(sheet);
+  appendMissingColumns(sheet, model, headers);
+  if (acceptDataLoss) {
+    dropExtraColumns(sheet, model, headers);
+    return;
   }
   warnExtraColumns(headers, model);
 };
@@ -80,12 +125,16 @@ const warnExtraSheets = (spreadsheet: Spreadsheet, models: MigrateModel[]) => {
  * missing sheets are created and missing columns are appended, idempotently.
  * Assumes the header row is row 1 starting at column A on every sheet
  * (header positions moved via changeSettings are not supported).
- * Never deletes or reorders existing sheets/columns, never touches data rows.
+ * Columns not in the schema are only warned about by default; with
+ * `acceptDataLoss: true` they are dropped after a warning that reports how
+ * much data they still contain. Sheets not in the schema are never deleted.
+ * Never reorders existing columns, never writes to data rows.
  */
 const migrateSheets = (options: MigrateSheetsOptions): void => {
   if (!options || !options.models) {
     throw new GassmaMissingArgumentError("models");
   }
+  const acceptDataLoss = options.acceptDataLoss === true;
   const spreadsheet = options.spreadsheetId
     ? SpreadsheetApp.openById(options.spreadsheetId)
     : SpreadsheetApp.getActiveSpreadsheet();
@@ -96,7 +145,7 @@ const migrateSheets = (options: MigrateSheetsOptions): void => {
       createSheetWithHeaders(spreadsheet, model);
       return;
     }
-    appendMissingColumns(sheet, model);
+    syncExistingSheet(sheet, model, acceptDataLoss);
   });
 
   warnExtraSheets(spreadsheet, options.models);

--- a/src/util/migrate/migrateSheets.ts
+++ b/src/util/migrate/migrateSheets.ts
@@ -86,6 +86,7 @@ const dropExtraColumns = (
   const extraColumns = listExtraColumns(headers, model);
   extraColumns.forEach(({ header, position }) => {
     const count = countNonEmptyDataCells(sheet, position);
+    if (count < 1) return;
     console.warn(
       `${LOG_PREFIX} You are about to drop the column "${header}" on the sheet "${model.name}", which still contains ${count} non-empty values.`,
     );
@@ -134,9 +135,11 @@ const dropExtraSheets = (spreadsheet: Spreadsheet, models: MigrateModel[]) => {
       return;
     }
     const dataRows = Math.max(sheet.getLastRow() - 1, 0);
-    console.warn(
-      `${LOG_PREFIX} You are about to drop the sheet "${sheetName}", which still contains ${dataRows} rows.`,
-    );
+    if (dataRows >= 1) {
+      console.warn(
+        `${LOG_PREFIX} You are about to drop the sheet "${sheetName}", which still contains ${dataRows} rows.`,
+      );
+    }
     spreadsheet.deleteSheet(sheet);
   });
 };
@@ -148,9 +151,9 @@ const dropExtraSheets = (spreadsheet: Spreadsheet, models: MigrateModel[]) => {
  * (header positions moved via changeSettings are not supported).
  * Columns and sheets not in the schema are only warned about by default;
  * with `acceptDataLoss: true` they are dropped after a warning that reports
- * how much data they still contain (the last remaining sheet is kept, since
- * a spreadsheet must contain at least one sheet).
- * Never reorders existing columns, never writes to data rows.
+ * how much data they still contain (silently when they are empty; the last
+ * remaining sheet is kept, since a spreadsheet must contain at least one
+ * sheet). Never reorders existing columns, never writes to data rows.
  */
 const migrateSheets = (options: MigrateSheetsOptions): void => {
   if (!options || !options.models) {

--- a/src/util/migrate/migrateSheets.ts
+++ b/src/util/migrate/migrateSheets.ts
@@ -120,14 +120,36 @@ const warnExtraSheets = (spreadsheet: Spreadsheet, models: MigrateModel[]) => {
   });
 };
 
+const dropExtraSheets = (spreadsheet: Spreadsheet, models: MigrateModel[]) => {
+  const modelNames = models.map((model) => model.name);
+  const extraSheets = spreadsheet
+    .getSheets()
+    .filter((sheet) => !modelNames.includes(sheet.getName()));
+  extraSheets.forEach((sheet) => {
+    const sheetName = sheet.getName();
+    if (spreadsheet.getSheets().length <= 1) {
+      console.warn(
+        `${LOG_PREFIX} sheet "${sheetName}" is not in the schema but cannot be deleted because a spreadsheet must contain at least one sheet. It is left untouched.`,
+      );
+      return;
+    }
+    const dataRows = Math.max(sheet.getLastRow() - 1, 0);
+    console.warn(
+      `${LOG_PREFIX} You are about to drop the sheet "${sheetName}", which still contains ${dataRows} rows.`,
+    );
+    spreadsheet.deleteSheet(sheet);
+  });
+};
+
 /**
  * Synchronizes the spreadsheet with the given models like `prisma db push`:
  * missing sheets are created and missing columns are appended, idempotently.
  * Assumes the header row is row 1 starting at column A on every sheet
  * (header positions moved via changeSettings are not supported).
- * Columns not in the schema are only warned about by default; with
- * `acceptDataLoss: true` they are dropped after a warning that reports how
- * much data they still contain. Sheets not in the schema are never deleted.
+ * Columns and sheets not in the schema are only warned about by default;
+ * with `acceptDataLoss: true` they are dropped after a warning that reports
+ * how much data they still contain (the last remaining sheet is kept, since
+ * a spreadsheet must contain at least one sheet).
  * Never reorders existing columns, never writes to data rows.
  */
 const migrateSheets = (options: MigrateSheetsOptions): void => {
@@ -148,6 +170,10 @@ const migrateSheets = (options: MigrateSheetsOptions): void => {
     syncExistingSheet(sheet, model, acceptDataLoss);
   });
 
+  if (acceptDataLoss) {
+    dropExtraSheets(spreadsheet, options.models);
+    return;
+  }
   warnExtraSheets(spreadsheet, options.models);
 };
 


### PR DESCRIPTION
## 概要

`Gassma.migrateSheets` に **`acceptDataLoss` オプション**を追加します。schema から列やモデルを削除しても、これまではシート側に残り続けて**スキーマと実体が永久に乖離**していました。

```js
Gassma.migrateSheets({
  spreadsheetId: "...",
  models: [...],
  acceptDataLoss: true,   // ← 追加
});
```

| | `acceptDataLoss` なし(既定) | `acceptDataLoss: true` |
|---|---|---|
| schema に無い列 | 警告のみ・残る(**従来どおり**) | **削除する** |
| schema に無いシート | 警告のみ・残る(**従来どおり**) | **削除する** |

**既定の挙動は一切変わりません。** 削除は明示的にオプトインしたときだけ起きます。

## Prisma との対応

prisma 7.4.1 の実挙動を実測して設計しました:

- データが入った列を消そうとすると **件数を明示して警告し、非対話環境では停止**する
  ```
  ⚠️  Warnings for the current datasource:
    • You are about to drop the column `memo` on the `User` table, which still contains 1 non-null values.
  Error: Prisma Migrate has detected that the environment is non-interactive, which is not supported.
  ```
- `prisma db push --accept-data-loss` で警告を無視して実行できる(フラグ名の由来)
- **空の列・空のテーブルはフラグ無しでも黙って DROP される**

最後の点だけ gassma では採用していません。**Prisma の DB は Prisma が専有しますが、スプレッドシートはユーザーが手でも使う文書**だからです。空の作業用タブや自分で足した列が黙って消えると困るので、**削除は常に `acceptDataLoss` が必要**という一段安全側の仕様にしています。

## 警告

削除対象にデータがあるときだけ、Prisma に倣った文言で警告します(空なら警告なしで削除 = Prisma と同じ):

```
Gassma.migrateSheets: You are about to drop the column "memo" on the sheet "User", which still contains 2 non-empty values.
Gassma.migrateSheets: You are about to drop the sheet "Old", which still contains 2 rows.
```

スプレッドシートは最低1枚シートが必要なため、最後の1枚は削除せず警告に切り替えます:

```
Gassma.migrateSheets: sheet "Old2" is not in the schema but cannot be deleted because a spreadsheet must contain at least one sheet. It is left untouched.
```

## 実装上の要点

- **列の削除は右から左へ** — 左から消すと後続の列位置が繰り上がり、意図しない列を消してしまいます
- **追記 → 削除の順序** — 逆にすると位置計算が壊れます
- **最後の1枚の判定はループ内で毎回** — 削除を進める途中で残り枚数が変わるためです
- **非空の判定は `!== ""`** — `0` や `false` や `Date` は**有効なデータとして数えます**(falsy 判定にすると `0` が消えても警告が出ない)

## テスト

t-wada 流 TDD。migrate スイート **27件**(新規12件)、**全体1949件パス**。lint / format:check / verify:bundle すべて clean。

独立した検証エージェントによる敵対的レビューを実施しました。特に**後方互換の検証**が徹底しています:

- **origin/main の旧テストファイル(旧モックのまま)を新実装に対して実行 → 15/15 パス**。旧モックには `deleteColumn`/`deleteSheet` が存在しないため、フラグ無しで削除パスに入れば TypeError で即死します。落ちなかったことが「フラグ無しでは削除 API を一切呼ばない」ことの**実行時証明**になります
- 変異テスト5系統で Red を確認(左→右削除への変更、削除→追記への順序入れ替え、空ヘッダーガード除去、最後の1枚チェックのループ外固定化、`Boolean()` による falsy 判定)

テストモックには `deleteColumn`/`deleteSheet` を実機忠実に実装しています(splice による位置繰り上げ、最後の1枚での例外、`getValues` の矩形パディング)。忠実でなければ位置ずれのバグを検出できないためです。

## 既知の制限

`getSheets()` は非表示シートも数えるため、「非表示シート1枚 + 可視の余分シート1枚」という状況では可視シートが全滅する形になり、実機の `deleteSheet` がエラーを投げ得ます。モックでは検出できない領域です。

## 残作業

CLI 側の `npx gassma migrate --accept-data-loss` フラグは別 PR で対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja