### PR TITLE
perf: batch junction writes for many-to-many set and create

### DIFF
--- a/src/__test__/util/create/nestedWrite/processManyToManyCreateBatching.test.ts
+++ b/src/__test__/util/create/nestedWrite/processManyToManyCreateBatching.test.ts
@@ -1,0 +1,282 @@
+import type { AnyUse, WhereUse } from "../../../../types/coreTypes";
+import type { NestedWriteOperation } from "../../../../types/nestedWriteTypes";
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../../types/relationTypes";
+import { processManyToMany } from "../../../../util/create/nestedWrite/processManyToMany";
+
+type Row = Record<string, unknown>;
+
+const matchesPlain = (record: Row, where: Record<string, unknown>): boolean =>
+  Object.entries(where).every(([key, value]) => {
+    if (!(key in record)) return true;
+    if (value !== null && typeof value === "object") return false;
+    const wanted = value === "" ? null : value;
+    return record[key] === wanted;
+  });
+
+const makeTagSheets = (initialTags: Row[]) => {
+  const tags: Row[] = initialTags.map((row) => ({ ...row }));
+  const junctions: Row[] = [];
+  const calls: string[] = [];
+  let nextId = 10;
+
+  const findManyOnSheet = jest.fn(
+    (sheet: string, findData: { where?: WhereUse }) => {
+      calls.push(`find:${sheet}`);
+      const where = findData.where ?? {};
+      if (Object.keys(where).length === 0) return tags.map((r) => ({ ...r }));
+      return tags
+        .filter((row) => matchesPlain(row, where))
+        .map((r) => ({ ...r }));
+    },
+  );
+
+  const createOnSheet = jest.fn((sheet: string, createData: { data: Row }) => {
+    calls.push(`create:${sheet}`);
+    if (sheet === "PostTags") {
+      const record = { ...createData.data };
+      junctions.push(record);
+      return { ...record };
+    }
+    const record = { id: nextId, ...createData.data };
+    nextId += 1;
+    tags.push(record);
+    return { ...record };
+  });
+
+  const createManyOnSheet = jest.fn(
+    (sheet: string, createManyData: { data: AnyUse[] }) => {
+      calls.push(`createMany:${sheet}`);
+      createManyData.data.forEach((row) => {
+        const record = { ...row };
+        if (sheet === "PostTags") junctions.push(record);
+        else tags.push(record);
+      });
+      return { count: createManyData.data.length };
+    },
+  );
+
+  const createManyAndReturnOnSheet = jest.fn(
+    (sheet: string, createManyData: { data: AnyUse[] }) => {
+      calls.push(`createManyAndReturn:${sheet}`);
+      return createManyData.data.map((row) => {
+        const record = { id: nextId, ...row };
+        nextId += 1;
+        if (sheet === "PostTags") junctions.push({ ...record });
+        else tags.push({ ...record });
+        return { ...record };
+      });
+    },
+  );
+
+  return {
+    tags,
+    junctions,
+    calls,
+    findManyOnSheet,
+    createOnSheet,
+    createManyOnSheet,
+    createManyAndReturnOnSheet,
+  };
+};
+
+const tagsRelation: RelationDefinition = {
+  type: "manyToMany",
+  to: "Tags",
+  field: "id",
+  reference: "id",
+  through: {
+    sheet: "PostTags",
+    field: "postId",
+    reference: "tagId",
+  },
+};
+
+type RunOptions = {
+  relation?: RelationDefinition;
+  withCreateManyAndReturn?: boolean;
+  parent?: Row;
+};
+
+const runOps = (
+  sheets: ReturnType<typeof makeTagSheets>,
+  ops: NestedWriteOperation,
+  options: RunOptions = {},
+) => {
+  const relation = options.relation ?? tagsRelation;
+  const relationOps = new Map<string, NestedWriteOperation>();
+  relationOps.set("tags", ops);
+  const context: RelationContext = {
+    relations: { tags: relation },
+    findManyOnSheet: sheets.findManyOnSheet,
+    createOnSheet: sheets.createOnSheet,
+    createManyOnSheet: sheets.createManyOnSheet,
+  };
+  if (options.withCreateManyAndReturn !== false) {
+    context.createManyAndReturnOnSheet = sheets.createManyAndReturnOnSheet;
+  }
+  processManyToMany(
+    options.parent ?? { id: 1, title: "記事A" },
+    relationOps,
+    context,
+  );
+};
+
+describe("processManyToMany create のバッチ化", () => {
+  it("複数 create はターゲット 1 回・junction 1 回のまとめ書きで items 順に作られる", () => {
+    const sheets = makeTagSheets([]);
+
+    runOps(sheets, { create: [{ name: "TS" }, { name: "JS" }] });
+
+    expect(sheets.createOnSheet).not.toHaveBeenCalled();
+    expect(sheets.createManyAndReturnOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheets.createManyAndReturnOnSheet).toHaveBeenCalledWith("Tags", {
+      data: [{ name: "TS" }, { name: "JS" }],
+    });
+    expect(sheets.calls).toEqual([
+      "createManyAndReturn:Tags",
+      "createMany:PostTags",
+    ]);
+    expect(sheets.tags).toEqual([
+      { id: 10, name: "TS" },
+      { id: 11, name: "JS" },
+    ]);
+    expect(sheets.junctions).toEqual([
+      { postId: 1, tagId: 10 },
+      { postId: 1, tagId: 11 },
+    ]);
+  });
+
+  it("create が 1 件のときは従来どおり createOnSheet でターゲットと junction を作る", () => {
+    const sheets = makeTagSheets([]);
+
+    runOps(sheets, { create: { name: "TS" } });
+
+    expect(sheets.createManyAndReturnOnSheet).not.toHaveBeenCalled();
+    expect(sheets.calls).toEqual(["create:Tags", "create:PostTags"]);
+    expect(sheets.junctions).toEqual([{ postId: 1, tagId: 10 }]);
+  });
+
+  it("createManyAndReturnOnSheet が無いコンテキストでは従来どおり 1 件ずつ作られる", () => {
+    const sheets = makeTagSheets([]);
+
+    runOps(
+      sheets,
+      { create: [{ name: "TS" }, { name: "JS" }] },
+      { withCreateManyAndReturn: false },
+    );
+
+    expect(sheets.createManyOnSheet).not.toHaveBeenCalled();
+    expect(sheets.calls).toEqual([
+      "create:Tags",
+      "create:PostTags",
+      "create:Tags",
+      "create:PostTags",
+    ]);
+    expect(sheets.junctions).toEqual([
+      { postId: 1, tagId: 10 },
+      { postId: 1, tagId: 11 },
+    ]);
+  });
+
+  it("自己 junction は従来どおり 1 件ずつ作られる", () => {
+    const selfJunction: RelationDefinition = {
+      type: "manyToMany",
+      to: "Tags",
+      field: "id",
+      reference: "id",
+      through: { sheet: "Tags", field: "postId", reference: "tagId" },
+    };
+    const sheets = makeTagSheets([]);
+
+    runOps(
+      sheets,
+      { create: [{ name: "TS" }, { name: "JS" }] },
+      { relation: selfJunction },
+    );
+
+    expect(sheets.createManyAndReturnOnSheet).not.toHaveBeenCalled();
+    expect(sheets.createOnSheet).toHaveBeenCalledTimes(4);
+  });
+
+  it("item が nested write を含む場合はリレーション全体を従来どおり 1 件ずつに戻す", () => {
+    const sheets = makeTagSheets([]);
+
+    runOps(sheets, {
+      create: [{ name: "TS", posts: { connect: { id: 5 } } }, { name: "JS" }],
+    });
+
+    expect(sheets.createManyAndReturnOnSheet).not.toHaveBeenCalled();
+    expect(sheets.calls).toEqual([
+      "create:Tags",
+      "create:PostTags",
+      "create:Tags",
+      "create:PostTags",
+    ]);
+  });
+
+  it("item にセル値でない値を含む場合は従来どおり 1 件ずつ作られる", () => {
+    const sheets = makeTagSheets([]);
+
+    runOps(sheets, {
+      create: [{ name: "TS", meta: { color: "blue" } }, { name: "JS" }],
+    });
+
+    expect(sheets.createManyAndReturnOnSheet).not.toHaveBeenCalled();
+    expect(sheets.createOnSheet).toHaveBeenCalledTimes(4);
+  });
+
+  it("null を含む item はまとめ書きされる", () => {
+    const sheets = makeTagSheets([]);
+
+    runOps(sheets, { create: [{ name: null }, { name: "JS" }] });
+
+    expect(sheets.createManyAndReturnOnSheet).toHaveBeenCalledWith("Tags", {
+      data: [{ name: null }, { name: "JS" }],
+    });
+  });
+
+  it("親の値がセル値でない場合もターゲットはまとめ、junction は 1 件ずつ追記される", () => {
+    const sheets = makeTagSheets([]);
+
+    runOps(
+      sheets,
+      { create: [{ name: "TS" }, { name: "JS" }] },
+      { parent: { title: "記事A" } },
+    );
+
+    expect(sheets.createManyAndReturnOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheets.createManyOnSheet).not.toHaveBeenCalled();
+    expect(sheets.junctions).toEqual([
+      { postId: undefined, tagId: 10 },
+      { postId: undefined, tagId: 11 },
+    ]);
+  });
+
+  it("create と connect の併用でもシート跨ぎの書き込み順が従来と同じになる", () => {
+    const sheets = makeTagSheets([
+      { id: 1, name: "GAS" },
+      { id: 2, name: "JS2" },
+    ]);
+
+    runOps(sheets, {
+      create: [{ name: "TS" }, { name: "JS" }],
+      connect: [{ id: 1 }, { id: 2 }],
+    });
+
+    expect(sheets.calls).toEqual([
+      "createManyAndReturn:Tags",
+      "createMany:PostTags",
+      "find:Tags",
+      "createMany:PostTags",
+    ]);
+    expect(sheets.junctions).toEqual([
+      { postId: 1, tagId: 10 },
+      { postId: 1, tagId: 11 },
+      { postId: 1, tagId: 1 },
+      { postId: 1, tagId: 2 },
+    ]);
+  });
+});

--- a/src/__test__/util/relation/manyToManyWriteRoundTrips.test.ts
+++ b/src/__test__/util/relation/manyToManyWriteRoundTrips.test.ts
@@ -1,0 +1,292 @@
+import { GassmaClient } from "../../../gassma";
+import { GassmaController } from "../../../gassmaController";
+import {
+  clearGasGlobals,
+  makeLoggedSheet,
+} from "../transaction/transactionTestClient";
+
+type CountingSheet = {
+  sheet: any;
+  trips: () => number;
+  reset: () => void;
+  snapshot: () => unknown[][];
+};
+
+const makeCountingSheet = (
+  name: string,
+  initial: unknown[][],
+): CountingSheet => {
+  const logged = makeLoggedSheet(name, initial);
+  const base: any = logged.sheet;
+  let trips = 0;
+  const sheet: any = {
+    ...base,
+    getLastRow: () => {
+      trips += 1;
+      return base.getLastRow();
+    },
+    getRange: (row: number, col: number, numRows: number, numCols: number) => {
+      const range = base.getRange(row, col, numRows, numCols);
+      return {
+        ...range,
+        getValues: () => {
+          trips += 1;
+          return range.getValues();
+        },
+        setValues: (values: unknown[][]) => {
+          trips += 1;
+          range.setValues(values);
+        },
+      };
+    },
+    deleteRow: (rowIndex: number) => {
+      trips += 1;
+      base.deleteRow(rowIndex);
+    },
+    deleteRows: (rowPosition: number, howMany: number) => {
+      trips += 1;
+      base.deleteRows(rowPosition, howMany);
+    },
+  };
+  return {
+    sheet,
+    trips: () => trips,
+    reset: () => {
+      trips = 0;
+    },
+    snapshot: logged.snapshot,
+  };
+};
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!(controller instanceof GassmaController)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+type M2mEnv = {
+  client: GassmaClient;
+  posts: CountingSheet;
+  tags: CountingSheet;
+  postTags: CountingSheet;
+  propsStore: Record<string, string>;
+  totalTrips: () => number;
+  resetTrips: () => void;
+};
+
+type M2mEnvConfig = {
+  tagRows?: unknown[][];
+  junctionRows?: unknown[][];
+  autoincrementSeed?: number;
+};
+
+const buildM2mEnv = (config: M2mEnvConfig = {}): M2mEnv => {
+  const posts = makeCountingSheet("Posts", [
+    ["id", "title"],
+    [1, "A"],
+  ]);
+  const tags = makeCountingSheet("Tags", [
+    ["id", "name"],
+    ...(config.tagRows ?? []),
+  ]);
+  const postTags = makeCountingSheet("PostTags", [
+    ["postId", "tagId"],
+    ...(config.junctionRows ?? []),
+  ]);
+  const sheets = [posts.sheet, tags.sheet, postTags.sheet];
+  const spreadsheet: any = {
+    getId: () => "m2m-test",
+    getSheets: () => sheets,
+    getSheetByName: (n: string) =>
+      sheets.find((s: any) => s.getName() === n) ?? null,
+  };
+  const propsStore: Record<string, string> = {};
+  if (config.autoincrementSeed !== undefined) {
+    propsStore["gassma_autoincrement_m2m-test_Tags_id"] = String(
+      config.autoincrementSeed,
+    );
+  }
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => spreadsheet },
+    LockService: {
+      getScriptLock: () => ({ waitLock: () => {}, releaseLock: () => {} }),
+    },
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getProperty: (key: string) => propsStore[key] ?? null,
+        setProperty: (key: string, value: string) => {
+          propsStore[key] = value;
+        },
+        deleteProperty: (key: string) => {
+          delete propsStore[key];
+        },
+        getKeys: () => Object.keys(propsStore),
+      }),
+    },
+  });
+  const client = new GassmaClient({
+    relations: {
+      Posts: {
+        tags: {
+          type: "manyToMany",
+          to: "Tags",
+          field: "id",
+          reference: "id",
+          through: { sheet: "PostTags", field: "postId", reference: "tagId" },
+        },
+      },
+    },
+    autoincrement: { Tags: "id" },
+  });
+  const all = [posts, tags, postTags];
+  return {
+    client,
+    posts,
+    tags,
+    postTags,
+    propsStore,
+    totalTrips: () => all.reduce((sum, s) => sum + s.trips(), 0),
+    resetTrips: () => {
+      all.forEach((s) => {
+        s.reset();
+      });
+    },
+  };
+};
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const tagRows = (count: number): unknown[][] =>
+  Array.from({ length: count }, (_, i) => [i + 1, `t${i + 1}`]);
+
+const setWheres = (count: number): { id: number }[] =>
+  Array.from({ length: count }, (_, i) => ({ id: i + 1 }));
+
+const runSetScenario = (k: number): { env: M2mEnv; trips: number } => {
+  const env = buildM2mEnv({
+    tagRows: tagRows(20),
+    junctionRows: [
+      [1, 5],
+      [2, 7],
+    ],
+  });
+  env.resetTrips();
+  const posts: any = sheetOf(env.client, "Posts");
+  posts.update({
+    where: { id: 1 },
+    data: { tags: { set: setWheres(k) } },
+  });
+  return { env, trips: env.totalTrips() };
+};
+
+const createItems = (count: number): { name: string }[] =>
+  Array.from({ length: count }, (_, i) => ({ name: `n${i + 1}` }));
+
+const runCreateScenario = (k: number): { env: M2mEnv; trips: number } => {
+  const env = buildM2mEnv({ autoincrementSeed: 5 });
+  env.resetTrips();
+  const posts: any = sheetOf(env.client, "Posts");
+  posts.create({
+    data: { id: 2, title: "B", tags: { create: createItems(k) } },
+  });
+  return { env, trips: env.totalTrips() };
+};
+
+describe("manyToMany set のシート往復回数", () => {
+  it("set の junction row 追記後のシート状態が正しい", () => {
+    const { env } = runSetScenario(3);
+
+    expect(env.postTags.snapshot()).toEqual([
+      ["postId", "tagId"],
+      [2, 7],
+      [1, 1],
+      [1, 2],
+      [1, 3],
+    ]);
+    expect(env.tags.snapshot()).toEqual([["id", "name"], ...tagRows(20)]);
+  });
+
+  it("set 1 件でもシート状態が正しい", () => {
+    const { env } = runSetScenario(1);
+
+    expect(env.postTags.snapshot()).toEqual([
+      ["postId", "tagId"],
+      [2, 7],
+      [1, 1],
+    ]);
+  });
+
+  it("junction row の追記が 1 回にまとまり往復回数が削減されている", () => {
+    const twenty = runSetScenario(20);
+
+    expect(twenty.env.postTags.snapshot()).toEqual([
+      ["postId", "tagId"],
+      [2, 7],
+      ...setWheres(20).map((w) => [1, w.id]),
+    ]);
+    expect([1, 3, 5, 20].map((k) => runSetScenario(k).trips)).toEqual([
+      22, 24, 26, 41,
+    ]);
+  });
+});
+
+describe("manyToMany create のシート往復回数", () => {
+  it("create のターゲットと junction row のシート状態・採番順が正しい", () => {
+    const { env } = runCreateScenario(3);
+
+    expect(env.tags.snapshot()).toEqual([
+      ["id", "name"],
+      [6, "n1"],
+      [7, "n2"],
+      [8, "n3"],
+    ]);
+    expect(env.postTags.snapshot()).toEqual([
+      ["postId", "tagId"],
+      [2, 6],
+      [2, 7],
+      [2, 8],
+    ]);
+    expect(env.propsStore["gassma_autoincrement_m2m-test_Tags_id"]).toBe("8");
+  });
+
+  it("create 1 件でもシート状態・採番が正しい", () => {
+    const { env } = runCreateScenario(1);
+
+    expect(env.tags.snapshot()).toEqual([
+      ["id", "name"],
+      [6, "n1"],
+    ]);
+    expect(env.postTags.snapshot()).toEqual([
+      ["postId", "tagId"],
+      [2, 6],
+    ]);
+    expect(env.propsStore["gassma_autoincrement_m2m-test_Tags_id"]).toBe("6");
+  });
+
+  it("ターゲットと junction の追記が 1 回ずつにまとまり往復回数が削減されている", () => {
+    const twenty = runCreateScenario(20);
+
+    expect(twenty.env.tags.snapshot()).toEqual([
+      ["id", "name"],
+      ...Array.from({ length: 20 }, (_, i) => [i + 6, `n${i + 1}`]),
+    ]);
+    expect(twenty.env.postTags.snapshot()).toEqual([
+      ["postId", "tagId"],
+      ...Array.from({ length: 20 }, (_, i) => [2, i + 6]),
+    ]);
+    expect(twenty.env.propsStore["gassma_autoincrement_m2m-test_Tags_id"]).toBe(
+      "25",
+    );
+    expect([1, 3, 5, 20].map((k) => runCreateScenario(k).trips)).toEqual([
+      12, 16, 20, 50,
+    ]);
+  });
+});

--- a/src/__test__/util/update/nestedWrite/processManyToManyUpdateBatching.test.ts
+++ b/src/__test__/util/update/nestedWrite/processManyToManyUpdateBatching.test.ts
@@ -1,0 +1,338 @@
+import type { AnyUse, WhereUse } from "../../../../types/coreTypes";
+import type { NestedWriteOperation } from "../../../../types/nestedWriteTypes";
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../../types/relationTypes";
+import { processManyToManyUpdate } from "../../../../util/update/nestedWrite/processManyToManyUpdate";
+
+type Row = Record<string, unknown>;
+
+const matchesPlain = (record: Row, where: Record<string, unknown>): boolean =>
+  Object.entries(where).every(([key, value]) => {
+    if (!(key in record)) return true;
+    if (value !== null && typeof value === "object") return false;
+    const wanted = value === "" ? null : value;
+    return record[key] === wanted;
+  });
+
+const makeTagSheets = (initialTags: Row[], initialJunctions: Row[] = []) => {
+  const tags: Row[] = initialTags.map((row) => ({ ...row }));
+  const junctions: Row[] = initialJunctions.map((row) => ({ ...row }));
+  const calls: string[] = [];
+
+  const findManyOnSheet = jest.fn(
+    (sheet: string, findData: { where?: WhereUse }) => {
+      calls.push(`find:${sheet}`);
+      const where = findData.where ?? {};
+      if (Object.keys(where).length === 0) return tags.map((r) => ({ ...r }));
+      return tags
+        .filter((row) => matchesPlain(row, where))
+        .map((r) => ({ ...r }));
+    },
+  );
+
+  const createOnSheet = jest.fn((sheet: string, createData: { data: Row }) => {
+    calls.push(`create:${sheet}`);
+    const record = { ...createData.data };
+    if (sheet === "PostTags") junctions.push(record);
+    else tags.push(record);
+    return { ...record };
+  });
+
+  const createManyOnSheet = jest.fn(
+    (sheet: string, createManyData: { data: AnyUse[] }) => {
+      calls.push(`createMany:${sheet}`);
+      createManyData.data.forEach((row) => {
+        const record = { ...row };
+        if (sheet === "PostTags") junctions.push(record);
+        else tags.push(record);
+      });
+      return { count: createManyData.data.length };
+    },
+  );
+
+  const deleteManyOnSheet = jest.fn(
+    (sheet: string, deleteData: { where: WhereUse }) => {
+      calls.push(`deleteMany:${sheet}`);
+      const before = junctions.length;
+      const remaining = junctions.filter(
+        (row) => !matchesPlain(row, deleteData.where),
+      );
+      junctions.splice(0, junctions.length);
+      remaining.forEach((row) => {
+        junctions.push(row);
+      });
+      return { count: before - junctions.length };
+    },
+  );
+
+  return {
+    tags,
+    junctions,
+    calls,
+    findManyOnSheet,
+    createOnSheet,
+    createManyOnSheet,
+    deleteManyOnSheet,
+  };
+};
+
+const tagsRelation: RelationDefinition = {
+  type: "manyToMany",
+  to: "Tags",
+  field: "id",
+  reference: "id",
+  through: {
+    sheet: "PostTags",
+    field: "postId",
+    reference: "tagId",
+  },
+};
+
+type RunOptions = {
+  relation?: RelationDefinition;
+  withCreateMany?: boolean;
+  relationNames?: string[];
+  parent?: Row;
+};
+
+const runSet = (
+  sheets: ReturnType<typeof makeTagSheets>,
+  set: WhereUse[],
+  options: RunOptions = {},
+) => {
+  const relation = options.relation ?? tagsRelation;
+  const relationOps = new Map<string, NestedWriteOperation>();
+  relationOps.set("tags", { set });
+  const context: RelationContext = {
+    relations: { tags: relation },
+    findManyOnSheet: sheets.findManyOnSheet,
+    createOnSheet: sheets.createOnSheet,
+    deleteManyOnSheet: sheets.deleteManyOnSheet,
+  };
+  if (options.withCreateMany !== false) {
+    context.createManyOnSheet = sheets.createManyOnSheet;
+  }
+  if (options.relationNames) {
+    const names = options.relationNames;
+    context.relationNamesOnSheet = () => names;
+  }
+  processManyToManyUpdate(
+    options.parent ?? { id: 1, title: "記事A" },
+    relationOps,
+    context,
+  );
+};
+
+describe("processManyToManyUpdate set のバッチ化", () => {
+  it("複数 set は読み 1 回・junction row は 1 回の createManyOnSheet で items 順に追記される", () => {
+    const sheets = makeTagSheets([
+      { id: 1, name: "TS" },
+      { id: 2, name: "JS" },
+      { id: 3, name: "GAS" },
+    ]);
+
+    runSet(sheets, [{ id: 3 }, { id: 1 }, { id: 2 }]);
+
+    expect(sheets.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheets.findManyOnSheet).toHaveBeenCalledWith("Tags", {});
+    expect(sheets.createOnSheet).not.toHaveBeenCalled();
+    expect(sheets.createManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheets.createManyOnSheet).toHaveBeenCalledWith("PostTags", {
+      data: [
+        { postId: 1, tagId: 3 },
+        { postId: 1, tagId: 1 },
+        { postId: 1, tagId: 2 },
+      ],
+    });
+  });
+
+  it("既存 junction row の全削除はスナップショット読みより前に行われる", () => {
+    const sheets = makeTagSheets(
+      [
+        { id: 1, name: "TS" },
+        { id: 2, name: "JS" },
+      ],
+      [
+        { postId: 1, tagId: 9 },
+        { postId: 2, tagId: 1 },
+      ],
+    );
+
+    runSet(sheets, [{ id: 2 }, { id: 1 }]);
+
+    expect(sheets.calls).toEqual([
+      "deleteMany:PostTags",
+      "find:Tags",
+      "createMany:PostTags",
+    ]);
+    expect(sheets.junctions).toEqual([
+      { postId: 2, tagId: 1 },
+      { postId: 1, tagId: 2 },
+      { postId: 1, tagId: 1 },
+    ]);
+  });
+
+  it("見つからない項目はバッチでもスキップされ残りが items 順に追記される", () => {
+    const sheets = makeTagSheets([
+      { id: 1, name: "TS" },
+      { id: 2, name: "JS" },
+    ]);
+
+    runSet(sheets, [{ id: 1 }, { id: 999 }, { id: 2 }]);
+
+    expect(sheets.createManyOnSheet).toHaveBeenCalledWith("PostTags", {
+      data: [
+        { postId: 1, tagId: 1 },
+        { postId: 1, tagId: 2 },
+      ],
+    });
+  });
+
+  it("全項目が見つからない場合は junction row を 1 行も追記しない", () => {
+    const sheets = makeTagSheets([{ id: 1, name: "TS" }]);
+
+    runSet(sheets, [{ id: 998 }, { id: 999 }]);
+
+    expect(sheets.createOnSheet).not.toHaveBeenCalled();
+    expect(sheets.createManyOnSheet).not.toHaveBeenCalled();
+    expect(sheets.junctions).toEqual([]);
+  });
+
+  it("複数行にマッチする where は先頭行が使われる", () => {
+    const sheets = makeTagSheets([
+      { id: 1, group: "a" },
+      { id: 2, group: "a" },
+      { id: 3, group: "b" },
+    ]);
+
+    runSet(sheets, [{ group: "a" }, { id: 3 }]);
+
+    expect(sheets.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheets.junctions).toEqual([
+      { postId: 1, tagId: 1 },
+      { postId: 1, tagId: 3 },
+    ]);
+  });
+
+  it("set が 1 件のときは従来どおり個別読みと createOnSheet で追記される", () => {
+    const sheets = makeTagSheets([{ id: 1, name: "TS" }]);
+
+    runSet(sheets, [{ id: 1 }]);
+
+    expect(sheets.findManyOnSheet).toHaveBeenCalledTimes(1);
+    expect(sheets.findManyOnSheet).toHaveBeenCalledWith("Tags", {
+      where: { id: 1 },
+    });
+    expect(sheets.createManyOnSheet).not.toHaveBeenCalled();
+    expect(sheets.createOnSheet).toHaveBeenCalledWith("PostTags", {
+      data: { postId: 1, tagId: 1 },
+    });
+  });
+
+  it("自己 junction は従来どおり個別読みで追記される", () => {
+    const selfJunction: RelationDefinition = {
+      type: "manyToMany",
+      to: "Tags",
+      field: "id",
+      reference: "id",
+      through: { sheet: "Tags", field: "postId", reference: "tagId" },
+    };
+    const sheets = makeTagSheets([
+      { id: 1, name: "TS" },
+      { id: 2, name: "JS" },
+    ]);
+
+    runSet(sheets, [{ id: 1 }, { id: 2 }], { relation: selfJunction });
+
+    expect(sheets.createManyOnSheet).not.toHaveBeenCalled();
+    expect(sheets.findManyOnSheet).toHaveBeenCalledWith("Tags", {
+      where: { id: 1 },
+    });
+    expect(sheets.findManyOnSheet).toHaveBeenCalledWith("Tags", {
+      where: { id: 2 },
+    });
+  });
+
+  it("createManyOnSheet が無いコンテキストでは従来どおり個別読みで追記される", () => {
+    const sheets = makeTagSheets([
+      { id: 1, name: "TS" },
+      { id: 2, name: "JS" },
+    ]);
+
+    runSet(sheets, [{ id: 2 }, { id: 1 }], { withCreateMany: false });
+
+    expect(sheets.findManyOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheets.findManyOnSheet).toHaveBeenCalledWith("Tags", {
+      where: { id: 2 },
+    });
+    expect(sheets.createOnSheet).toHaveBeenNthCalledWith(1, "PostTags", {
+      data: { postId: 1, tagId: 2 },
+    });
+    expect(sheets.createOnSheet).toHaveBeenNthCalledWith(2, "PostTags", {
+      data: { postId: 1, tagId: 1 },
+    });
+  });
+
+  it("スナップショットで判定できない where はその項目だけ個別読みに戻す", () => {
+    const sheets = makeTagSheets([
+      { id: 1, name: "TS" },
+      { id: 2, name: "JS" },
+    ]);
+
+    runSet(sheets, [{ id: 1 }, { unknown: 9 }, { id: 2 }]);
+
+    expect(sheets.calls).toEqual([
+      "deleteMany:PostTags",
+      "find:Tags",
+      "find:Tags",
+      "createMany:PostTags",
+    ]);
+    expect(sheets.findManyOnSheet).toHaveBeenCalledWith("Tags", {
+      where: { unknown: 9 },
+    });
+    expect(sheets.junctions).toEqual([
+      { postId: 1, tagId: 1 },
+      { postId: 1, tagId: 1 },
+      { postId: 1, tagId: 2 },
+    ]);
+  });
+
+  it("関係名のキーを含む where はその項目だけ個別読みに戻す", () => {
+    const sheets = makeTagSheets([
+      { id: 1, name: "TS" },
+      { id: 2, name: "JS" },
+    ]);
+
+    runSet(sheets, [{ id: 1 }, { posts: { some: { id: 5 } } }], {
+      relationNames: ["posts"],
+    });
+
+    expect(sheets.findManyOnSheet).toHaveBeenCalledWith("Tags", {
+      where: { posts: { some: { id: 5 } } },
+    });
+    expect(sheets.calls).toEqual([
+      "deleteMany:PostTags",
+      "find:Tags",
+      "find:Tags",
+      "createMany:PostTags",
+    ]);
+  });
+
+  it("親の値がセル値でない場合は junction row が従来どおり 1 件ずつ追記される", () => {
+    const sheets = makeTagSheets([
+      { id: 1, name: "TS" },
+      { id: 2, name: "JS" },
+    ]);
+
+    runSet(sheets, [{ id: 1 }, { id: 2 }], { parent: { title: "記事A" } });
+
+    expect(sheets.createManyOnSheet).not.toHaveBeenCalled();
+    expect(sheets.createOnSheet).toHaveBeenCalledTimes(2);
+    expect(sheets.junctions).toEqual([
+      { postId: undefined, tagId: 1 },
+      { postId: undefined, tagId: 2 },
+    ]);
+  });
+});

--- a/src/types/relationTypes.ts
+++ b/src/types/relationTypes.ts
@@ -125,6 +125,10 @@ type RelationContext = {
     sheetName: string,
     createManyData: { data: AnyUse[] },
   ) => { count: number } | undefined;
+  createManyAndReturnOnSheet?: (
+    sheetName: string,
+    createManyData: { data: AnyUse[] },
+  ) => Record<string, unknown>[];
 };
 
 type RelationListFilter = {

--- a/src/util/create/nestedWrite/connectBatch/manyToManyItems.ts
+++ b/src/util/create/nestedWrite/connectBatch/manyToManyItems.ts
@@ -1,12 +1,62 @@
 import { NestedWriteConnectNotFoundError } from "../../../../errors/relation/nestedWriteError";
-import type { WhereUse } from "../../../../types/coreTypes";
+import type { AnyUse, WhereUse } from "../../../../types/coreTypes";
 import type { ConnectOrCreateInput } from "../../../../types/nestedWriteTypes";
 import type {
   RelationContext,
   RelationDefinition,
 } from "../../../../types/relationTypes";
+import { isCellValue } from "../cellValue";
+import { hasNestedWrite, isRow } from "../createItems";
 import type { JunctionWriter } from "./junctionWriter";
 import { createTargetTable } from "./targetTable";
+
+const buildTargetRow = (item: Record<string, unknown>): AnyUse | null => {
+  const row: AnyUse = {};
+  let complete = true;
+  Object.keys(item).forEach((key) => {
+    const value = item[key];
+    if (!isCellValue(value)) {
+      complete = false;
+      return;
+    }
+    row[key] = value;
+  });
+  return complete ? row : null;
+};
+
+const batchManyToManyCreate = (
+  relation: RelationDefinition,
+  items: Record<string, unknown>[],
+  context: RelationContext,
+  junction: JunctionWriter,
+): void => {
+  const oneByOne = () => {
+    items.forEach((item) => {
+      const created = context.createOnSheet(relation.to, { data: item });
+      junction.add(created[relation.reference]);
+      junction.flush();
+    });
+  };
+
+  if (!context.createManyAndReturnOnSheet || items.some(hasNestedWrite)) {
+    oneByOne();
+    return;
+  }
+
+  const rows = items.map(buildTargetRow);
+  if (!rows.every(isRow)) {
+    oneByOne();
+    return;
+  }
+
+  const created = context.createManyAndReturnOnSheet(relation.to, {
+    data: rows,
+  });
+  created.forEach((record) => {
+    junction.add(record[relation.reference]);
+  });
+  junction.flush();
+};
 
 const batchManyToManyConnect = (
   relation: RelationDefinition,
@@ -85,4 +135,8 @@ const batchManyToManyConnectOrCreate = (
   junction.flush();
 };
 
-export { batchManyToManyConnect, batchManyToManyConnectOrCreate };
+export {
+  batchManyToManyConnect,
+  batchManyToManyConnectOrCreate,
+  batchManyToManyCreate,
+};

--- a/src/util/create/nestedWrite/createItems.ts
+++ b/src/util/create/nestedWrite/createItems.ts
@@ -59,4 +59,4 @@ const batchNestedCreate = (
   context.createManyOnSheet(relation.to, { data: rows });
 };
 
-export { batchNestedCreate };
+export { batchNestedCreate, hasNestedWrite, isRow };

--- a/src/util/create/nestedWrite/processManyToMany.ts
+++ b/src/util/create/nestedWrite/processManyToMany.ts
@@ -5,6 +5,7 @@ import { createJunctionWriter } from "./connectBatch/junctionWriter";
 import {
   batchManyToManyConnect,
   batchManyToManyConnectOrCreate,
+  batchManyToManyCreate,
 } from "./connectBatch/manyToManyItems";
 
 const processManyToMany = (
@@ -30,15 +31,19 @@ const processManyToMany = (
       });
     };
 
+    const junction = createJunctionWriter(context, through, parentValue);
+
     if (ops.create) {
       const items = Array.isArray(ops.create) ? ops.create : [ops.create];
-      items.forEach((item) => {
-        const created = context.createOnSheet(relation.to, { data: item });
-        createJunctionRow(created[relation.reference]);
-      });
+      if (items.length > 1 && !selfJunction) {
+        batchManyToManyCreate(relation, items, context, junction);
+      } else {
+        items.forEach((item) => {
+          const created = context.createOnSheet(relation.to, { data: item });
+          createJunctionRow(created[relation.reference]);
+        });
+      }
     }
-
-    const junction = createJunctionWriter(context, through, parentValue);
 
     if (ops.connect) {
       const items = Array.isArray(ops.connect) ? ops.connect : [ops.connect];

--- a/src/util/relation/injectRelations.ts
+++ b/src/util/relation/injectRelations.ts
@@ -81,6 +81,17 @@ const injectRelations = (
     return controller.createMany(createManyData);
   };
 
+  const createManyAndReturnOnSheet = (
+    sheetName: string,
+    createManyData: { data: AnyUse[] },
+  ): Record<string, unknown>[] => {
+    const controller = controllers[sheetName];
+    if (!controller) {
+      throw new Error(`Target sheet "${sheetName}" is not accessible`);
+    }
+    return controller.createManyAndReturn(createManyData);
+  };
+
   const relationNamesOnSheet = (sheetName: string): string[] =>
     Object.keys(relations[sheetName] ?? {});
 
@@ -96,6 +107,7 @@ const injectRelations = (
       updateManyOnSheet,
       createOnSheet,
       createManyOnSheet,
+      createManyAndReturnOnSheet,
     });
   });
 };

--- a/src/util/update/nestedWrite/processManyToManyUpdate.ts
+++ b/src/util/update/nestedWrite/processManyToManyUpdate.ts
@@ -1,5 +1,7 @@
-import type { RelationContext } from "../../../types/relationTypes";
 import type { NestedWriteOperation } from "../../../types/nestedWriteTypes";
+import type { RelationContext } from "../../../types/relationTypes";
+import { createJunctionWriter } from "../../create/nestedWrite/connectBatch/junctionWriter";
+import { batchManyToManySet } from "./setItems";
 
 const processManyToManyUpdate = (
   updatedRecord: Record<string, unknown>,
@@ -35,17 +37,12 @@ const processManyToManyUpdate = (
       context.deleteManyOnSheet!(through.sheet, {
         where: { [through.field]: parentValue },
       });
-      ops.set.forEach((where) => {
-        const found = context.findManyOnSheet(relation.to, { where });
-        if (found.length > 0) {
-          context.createOnSheet!(through.sheet, {
-            data: {
-              [through.field]: parentValue,
-              [through.reference]: found[0][relation.reference],
-            },
-          });
-        }
-      });
+      batchManyToManySet(
+        relation,
+        ops.set,
+        context,
+        createJunctionWriter(context, through, parentValue),
+      );
     }
   });
 };

--- a/src/util/update/nestedWrite/setItems.ts
+++ b/src/util/update/nestedWrite/setItems.ts
@@ -1,0 +1,46 @@
+import type { WhereUse } from "../../../types/coreTypes";
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../types/relationTypes";
+import type { JunctionWriter } from "../../create/nestedWrite/connectBatch/junctionWriter";
+import { createTargetTable } from "../../create/nestedWrite/connectBatch/targetTable";
+
+const batchManyToManySet = (
+  relation: RelationDefinition,
+  items: WhereUse[],
+  context: RelationContext,
+  junction: JunctionWriter,
+): void => {
+  const oneByOne = () => {
+    items.forEach((where) => {
+      const found = context.findManyOnSheet(relation.to, { where });
+      if (found.length > 0) {
+        junction.add(found[0][relation.reference]);
+        junction.flush();
+      }
+    });
+  };
+
+  const selfJunction = relation.through?.sheet === relation.to;
+  if (items.length < 2 || selfJunction || !context.createManyOnSheet) {
+    oneByOne();
+    return;
+  }
+
+  const table = createTargetTable(context, relation.to);
+  const foundRecords = items.map((where) =>
+    table.canEvaluate(where)
+      ? table.matchRecords(where)
+      : context.findManyOnSheet(relation.to, { where }),
+  );
+
+  foundRecords.forEach((found) => {
+    if (found.length > 0) {
+      junction.add(found[0][relation.reference]);
+    }
+  });
+  junction.flush();
+};
+
+export { batchManyToManySet };


### PR DESCRIPTION
## 概要

#173 で見送った箇所です。多対多の `set` と `create` は、**紐付け行(中間シートの行)を1件ずつ**書いていました。

原因は、1項目ごとに「**別シートを触る処理 → 紐付け1行**」が交互に来ることです。#173 の紐付けライターは「他のシートを触る直前に必ず書き出す」という約束(失敗時のシートの状態と順序を従来と一致させるため)を持つので、**溜まるのが常に1件**でまとめる相手が隣に来ませんでした。

## 実測していた損失

| 項目数 | connect(対応済み) | set | create |
|---|---|---|---|
| 3 | 20 | 37 | 34 |
| **20** | **37** | **173** | — |

**1件増えるごとに connect は +1 往復、set / create は +8 往復。** 20件で約4.7倍でした。

## やったこと — 紐付け行を「連続させる」

**約束は緩めていません。** 相手シートの用事を先に済ませることで、紐付けの書き込みが自然に隣り合うようにしました。

- **`set`**: 相手シートを**1回だけ読み**、全項目をそのスナップショットで判定(#172 の `connect` と同じ手)
- **`create`**: **`createManyAndReturn` でまとめて作り、採番済みの id を受け取る**

`createManyAndReturn` は**既にある公開メソッド**で、リレーション処理から呼ぶ口がなかっただけでした(`RelationContext` の `createManyOnSheet` は件数しか返さない方に繋がっていた)。`createManyAndReturnOnSheet` を追加して繋いでいます。

どちらも**全ての読み/作成が終わってから**紐付けを積むので、既存のライターがそのまま効きます。

## 往復回数

| 項目数 | set | create |
|---|---|---|
| 3 | 37 → **23** | 34 → **16** |
| 5 | 53 → **26** | 44 → **20** |
| **20** | **173 → 40** | **164 → 50** |

傾きが **+8/項目 → +1〜2/項目**に。残る +1〜2 は `createMany` が行ごとに見出し行を読み直す**既存のコスト**で、`connect` の傾きと同じです。ここを平らにするには全書き込み経路に影響する変更が要るため触っていません。

## id の採番順は従来と同一

カウンタは `C+1 … C+K` を順に予約し、行の並び順に割り当てます。**実測**: カウンタ5 の状態でタグ3件を作ると `6, 7, 8` が A→B→C の順に付き、紐付け行も同じ順序、カウンタは 8 で終わります。

## フォールバック(結果が変わりうるものは従来経路)

- 項目が1件
- **自己 junction**(相手行と紐付け行が同じシートに交互に並ぶ順序を保つため)
- **項目が自分の nested write を持つ**(`createManyAndReturn` は入れ子を解決しないため**必須**)
- 非セル値が混じる
- スナップショットで忠実に判定できない `where`(リレーション名キー・未知キー)

## ⚠️ 変わること — 失敗した時の途中経過

いずれも #172 / #173 で既に受け入れた変化と同じ性質です。

- **バッチが失敗すると、そのバッチ分は1行も書かれません**(従来は失敗より前の項目が書かれていた)
- **`create` は id を先にまとめて予約する**ため、途中で失敗したときのカウンタの進み方が変わります(従来は成功した件数分)
- 関数のデフォルト値(`() => new Date()` 等)は、評価回数・順序は同じですが**書き込み直前にまとめて評価**されるため値が近接します

最終的なシートの状態・行順・id・エラーの型とメッセージ・戻り値は**すべて従来と同一**です。

## 検証

- `npx jest`: **1993 passed**(既存 1967 は**1件も書き換えず**全通過、新規26件)
  - 新規テストは往復数・最終シート状態・採番・全フォールバックを固定。統合テストの期待値は**実装前の従来コードで緑**であることを確認済み(= 期待値が従来挙動そのものである証明)
- `tsc` clean / `build` 成功 / **`verify:bundle` OK(公開シンボル 53、増減なし)**
- `biome`: エラー0。警告は既存の `noNonNullAssertion` が **3件 → 2件に減少**(実ファイルで測定)
- `as` / `for ... of` 不使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)