### PR TITLE
perf: stop re-reading the header row on every write

### DIFF
--- a/src/__test__/util/read/perCallReadCache.test.ts
+++ b/src/__test__/util/read/perCallReadCache.test.ts
@@ -307,10 +307,10 @@ describe("書き込み経路の鮮度(キャッシュを持ち込まない)", ()
     );
   });
 
-  test("Cascade update の読み往復数は従来から変わらない", () => {
+  test("Cascade update の読み往復数はキャッシュが効いた値まで下がらない", () => {
     const env = buildEnv(cascadeRelations);
     sheetOf(env.client, "Users").update({ where: { id: 1 }, data: { id: 10 } });
-    expect(env.totalTrips()).toBe(18);
+    expect(env.totalTrips()).toBe(14);
   });
 
   test("$transaction 内の findMany → update → findMany で2回目は新しい値を返す", () => {

--- a/src/__test__/util/relation/manyToManyWriteRoundTrips.test.ts
+++ b/src/__test__/util/relation/manyToManyWriteRoundTrips.test.ts
@@ -233,7 +233,7 @@ describe("manyToMany set のシート往復回数", () => {
       ...setWheres(20).map((w) => [1, w.id]),
     ]);
     expect([1, 3, 5, 20].map((k) => runSetScenario(k).trips)).toEqual([
-      22, 24, 26, 41,
+      19, 19, 19, 19,
     ]);
   });
 });
@@ -286,7 +286,7 @@ describe("manyToMany create のシート往復回数", () => {
       "25",
     );
     expect([1, 3, 5, 20].map((k) => runCreateScenario(k).trips)).toEqual([
-      12, 16, 20, 50,
+      9, 9, 9, 9,
     ]);
   });
 });

--- a/src/__test__/util/write/titleRowReadTrips.test.ts
+++ b/src/__test__/util/write/titleRowReadTrips.test.ts
@@ -1,0 +1,161 @@
+import { GassmaClient } from "../../../gassma";
+import { GassmaController } from "../../../gassmaController";
+import {
+  clearGasGlobals,
+  makeLoggedSheet,
+} from "../transaction/transactionTestClient";
+
+type TitleCountingSheet = {
+  sheet: any;
+  titleReads: () => number;
+  resetTitleReads: () => void;
+  snapshot: () => unknown[][];
+};
+
+const makeTitleCountingSheet = (
+  name: string,
+  initial: unknown[][],
+): TitleCountingSheet => {
+  const logged = makeLoggedSheet(name, initial);
+  const base: any = logged.sheet;
+  let titleReadCount = 0;
+  const sheet: any = {
+    ...base,
+    getRange: (row: number, col: number, numRows: number, numCols: number) => {
+      const range = base.getRange(row, col, numRows, numCols);
+      return {
+        ...range,
+        getValues: () => {
+          if (row === 1 && numRows === 1) titleReadCount += 1;
+          return range.getValues();
+        },
+      };
+    },
+  };
+  return {
+    sheet,
+    titleReads: () => titleReadCount,
+    resetTitleReads: () => {
+      titleReadCount = 0;
+    },
+    snapshot: logged.snapshot,
+  };
+};
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!(controller instanceof GassmaController)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+const buildEnv = () => {
+  const users = makeTitleCountingSheet("Users", [
+    ["id", "name", "age"],
+    [1, "Alice", 20],
+    [2, "Bob", 30],
+  ]);
+  const sheets = [users.sheet];
+  const spreadsheet: any = {
+    getId: () => "title-read-trips-test",
+    getSheets: () => sheets,
+    getSheetByName: (n: string) =>
+      sheets.find((s: any) => s.getName() === n) ?? null,
+  };
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => spreadsheet },
+  });
+  const client = new GassmaClient();
+  users.resetTitleReads();
+  return { client, users };
+};
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+describe("書き込み系の見出し行読み取り回数", () => {
+  test("create 1件は見出し行を1回だけ読む", () => {
+    const env = buildEnv();
+    const result = sheetOf(env.client, "Users").create({
+      data: { id: 3, name: "Carol", age: 40 },
+    });
+    expect(result).toEqual({ id: 3, name: "Carol", age: 40 });
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+      [3, "Carol", 40],
+    ]);
+    expect(env.users.titleReads()).toBe(1);
+  });
+
+  test("createMany 3件でも見出し行は1回だけ読む", () => {
+    const env = buildEnv();
+    const result = sheetOf(env.client, "Users").createMany({
+      data: [
+        { id: 3, name: "Carol", age: 40 },
+        { id: 4, name: "Dave", age: 50 },
+        { id: 5, name: "Eve", age: 60 },
+      ],
+    });
+    expect(result).toEqual({ count: 3 });
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+      [3, "Carol", 40],
+      [4, "Dave", 50],
+      [5, "Eve", 60],
+    ]);
+    expect(env.users.titleReads()).toBe(1);
+  });
+
+  test("createMany 10件でも見出し行は1回だけ読む", () => {
+    const env = buildEnv();
+    const rows = Array.from({ length: 10 }, (_, index) => ({
+      id: 10 + index,
+      name: `User${index}`,
+      age: 20 + index,
+    }));
+    const result = sheetOf(env.client, "Users").createMany({ data: rows });
+    expect(result).toEqual({ count: 10 });
+    expect(env.users.snapshot()).toHaveLength(13);
+    expect(env.users.titleReads()).toBe(1);
+  });
+
+  test("update 1件は見出し行を1回だけ読む", () => {
+    const env = buildEnv();
+    const result = sheetOf(env.client, "Users").update({
+      where: { id: 1 },
+      data: { age: 21 },
+    });
+    expect(result).toEqual({ id: 1, name: "Alice", age: 21 });
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 21],
+      [2, "Bob", 30],
+    ]);
+    expect(env.users.titleReads()).toBe(1);
+  });
+
+  test("updateMany は見出し行を1回だけ読む", () => {
+    const env = buildEnv();
+    const result = sheetOf(env.client, "Users").updateMany({
+      where: { age: 20 },
+      data: { age: 21 },
+    });
+    expect(result).toEqual({ count: 1 });
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 21],
+      [2, "Bob", 30],
+    ]);
+    expect(env.users.titleReads()).toBe(1);
+  });
+});

--- a/src/util/core/getWantFindIndex.ts
+++ b/src/util/core/getWantFindIndex.ts
@@ -1,7 +1,4 @@
 import type { GassmaAny, WhereUse } from "../../types/coreTypes";
-import type { DeleteData, FindData, UpdateData } from "../../types/findTypes";
-import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
-import { getTitle } from "./getTitle";
 
 const getWantFindIndexFromTitles = (
   titles: GassmaAny[],
@@ -24,13 +21,4 @@ const getWantFindIndexFromTitles = (
   return wantFindIndexRemovedMinusOne;
 };
 
-const getWantFindIndex = (
-  gassmaControllerUtil: GassmaControllerUtil,
-  wantData: FindData | DeleteData | UpdateData,
-) => {
-  const titles = getTitle(gassmaControllerUtil);
-
-  return getWantFindIndexFromTitles(titles, wantData.where);
-};
-
-export { getWantFindIndex, getWantFindIndexFromTitles };
+export { getWantFindIndexFromTitles };

--- a/src/util/core/getWantUpdateIndex.ts
+++ b/src/util/core/getWantUpdateIndex.ts
@@ -1,15 +1,7 @@
-import type { CreateData } from "../../types/createTypes";
-import type { UpdateData } from "../../types/findTypes";
-import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
-import { getTitle } from "./getTitle";
-
-const getWantUpdateIndex = (
-  gassmaControllerUtil: GassmaControllerUtil,
-  wantData: CreateData | UpdateData,
+const getWantUpdateIndexFromTitles = (
+  titles: string[],
+  data: Record<string, unknown>,
 ): number[] => {
-  const data = wantData.data;
-  const titles = getTitle(gassmaControllerUtil);
-
   const wantUpdateKeys = Object.entries(data).map((oneData) => {
     return oneData[0];
   });
@@ -25,4 +17,4 @@ const getWantUpdateIndex = (
   return wantUpdateIndexRemoveMinusOne;
 };
 
-export { getWantUpdateIndex };
+export { getWantUpdateIndexFromTitles };

--- a/src/util/core/whereFilter.ts
+++ b/src/util/core/whereFilter.ts
@@ -8,11 +8,12 @@ import { getTitle } from "./getTitle";
 const whereFilter = (
   where: WhereUse,
   gassmaControllerUtil: GassmaControllerUtil,
+  titles?: string[],
 ): HitRowData[] => {
   const allDataList = getAllData(gassmaControllerUtil);
-  const titles = getTitle(gassmaControllerUtil);
+  const resolvedTitles = titles ?? getTitle(gassmaControllerUtil);
 
-  return filterRowsByWhere(allDataList, titles, where);
+  return filterRowsByWhere(allDataList, resolvedTitles, where);
 };
 
 export { whereFilter };

--- a/src/util/create/create.ts
+++ b/src/util/create/create.ts
@@ -2,7 +2,7 @@ import type { AnyUse } from "../../types/coreTypes";
 import type { CreateData } from "../../types/createTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import { getTitle } from "../core/getTitle";
-import { getWantUpdateIndex } from "../core/getWantUpdateIndex";
+import { getWantUpdateIndexFromTitles } from "../core/getWantUpdateIndex";
 import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
 import { resolveWriter } from "../write/sheetWriter";
 
@@ -15,7 +15,7 @@ const createFunc = (
   const data = createdData.data;
   const titles = getTitle(gassmaControllerUtil);
 
-  const wantCreateIndex = getWantUpdateIndex(gassmaControllerUtil, createdData);
+  const wantCreateIndex = getWantUpdateIndexFromTitles(titles, data);
 
   const createReturn: AnyUse = {};
 

--- a/src/util/create/createManyFunc.ts
+++ b/src/util/create/createManyFunc.ts
@@ -1,11 +1,7 @@
-import type {
-  CreateData,
-  CreateManyData,
-  CreateManyReturn,
-} from "../../types/createTypes";
+import type { CreateManyData, CreateManyReturn } from "../../types/createTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import { getTitle } from "../core/getTitle";
-import { getWantUpdateIndex } from "../core/getWantUpdateIndex";
+import { getWantUpdateIndexFromTitles } from "../core/getWantUpdateIndex";
 import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
 import { resolveWriter } from "../write/sheetWriter";
 
@@ -34,11 +30,7 @@ function createManyFunc(
   const titles = getTitle(gassmaControllerUtil);
 
   const newData = data.map((row) => {
-    const createdData: CreateData = { data: row };
-    const wantCreateIndex = getWantUpdateIndex(
-      gassmaControllerUtil,
-      createdData,
-    );
+    const wantCreateIndex = getWantUpdateIndexFromTitles(titles, row);
 
     return titles.map((_, index) => {
       if (!wantCreateIndex.includes(index)) return "";

--- a/src/util/update/nestedWrite/resolveNestedUpdate.ts
+++ b/src/util/update/nestedWrite/resolveNestedUpdate.ts
@@ -1,9 +1,9 @@
-import type { UpdateAnyUse, WhereUse } from "../../../types/coreTypes";
+import type { WhereUse } from "../../../types/coreTypes";
 import type { GassmaControllerUtil } from "../../../types/gassmaControllerUtilType";
 import type { RelationContext } from "../../../types/relationTypes";
 import { NestedWriteWithoutRelationsError } from "../../../errors/relation/nestedWriteError";
 import { getTitle } from "../../core/getTitle";
-import { getWantUpdateIndex } from "../../core/getWantUpdateIndex";
+import { getWantUpdateIndexFromTitles } from "../../core/getWantUpdateIndex";
 import { whereFilter } from "../../core/whereFilter";
 import { processBeforeCreate } from "../../create/nestedWrite/processBeforeCreate";
 import { processAfterCreate } from "../../create/nestedWrite/processAfterCreate";
@@ -46,12 +46,12 @@ const resolveNestedUpdate = (
   relationContext: RelationContext | undefined,
 ): Record<string, unknown> | null => {
   const { sheet, startRowNumber, startColumnNumber, endColumnNumber } = util;
-  const matchedRows = whereFilter(updateInput.where, util);
+  const titles = getTitle(util);
+  const matchedRows = whereFilter(updateInput.where, util, titles);
 
   if (matchedRows.length === 0) return null;
 
   const firstRow = matchedRows[0];
-  const titles = getTitle(util);
   const columnLength = endColumnNumber - startColumnNumber + 1;
 
   const currentRecord = titles.reduce<Record<string, unknown>>(
@@ -70,9 +70,10 @@ const resolveNestedUpdate = (
       throw new NestedWriteWithoutRelationsError();
     }
 
-    const wantUpdateIndex = getWantUpdateIndex(util, {
-      data: updateInput.data as UpdateAnyUse,
-    });
+    const wantUpdateIndex = getWantUpdateIndexFromTitles(
+      titles,
+      updateInput.data,
+    );
     const updatedRow = firstRow.row.map((cell, cellIndex) => {
       if (!wantUpdateIndex.includes(cellIndex)) return cell;
       const value = updateInput.data[String(titles[cellIndex])];
@@ -115,9 +116,7 @@ const resolveNestedUpdate = (
     relationContext!,
   );
 
-  const wantUpdateIndex = getWantUpdateIndex(util, {
-    data: enrichedData as UpdateAnyUse,
-  });
+  const wantUpdateIndex = getWantUpdateIndexFromTitles(titles, enrichedData);
   const updatedRow = firstRow.row.map((cell, cellIndex) => {
     if (!wantUpdateIndex.includes(cellIndex)) return cell;
     const value = enrichedData[String(titles[cellIndex])];

--- a/src/util/update/updateMany.ts
+++ b/src/util/update/updateMany.ts
@@ -3,7 +3,7 @@ import type { UpdateData, UpdateManyReturn } from "../../types/findTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
 import { getTitle } from "../core/getTitle";
-import { getWantUpdateIndex } from "../core/getWantUpdateIndex";
+import { getWantUpdateIndexFromTitles } from "../core/getWantUpdateIndex";
 import { whereFilter } from "../core/whereFilter";
 import { groupUpdateRuns } from "../write/rowRuns";
 import { resolveWriter } from "../write/sheetWriter";
@@ -34,7 +34,8 @@ function updateManyFunc(
   const data = updateData.data;
   const limit = updateData.limit;
 
-  let findedData = whereFilter(where, gassmaControllerUtil);
+  const titles = getTitle(gassmaControllerUtil);
+  let findedData = whereFilter(where, gassmaControllerUtil, titles);
 
   if (limit !== undefined && limit !== null) {
     if (limit < 0) throw new GassmaLimitNegativeError(limit);
@@ -45,8 +46,7 @@ function updateManyFunc(
     return withReturn ? [] : { count: 0 };
   }
 
-  const titles = getTitle(gassmaControllerUtil);
-  const wantUpdateIndex = getWantUpdateIndex(gassmaControllerUtil, updateData);
+  const wantUpdateIndex = getWantUpdateIndexFromTitles(titles, data);
   const ColumnLength = endColumnNumber - startColumnNumber + 1;
 
   const updates = findedData.map((row) => {


### PR DESCRIPTION
## 概要

書き込み処理が**見出し行(シートの1行目)を何度も読み直していました**。とくに `createManyFunc` は `data.map()` の中で読むので、**件数に比例して往復が増えて**いました。

`getWantUpdateIndex`(どの列に書くかを決める処理)が中で `getTitle` を呼びますが、**呼び出し元は既に見出しを読んでいます**。

## 見出し行の読み回数

| 操作 | before | after |
|---|---|---|
| `create` 1件 | 2 | **1** |
| `createMany` 3件 | 4 | **1** |
| **`createMany` 10件** | **11** | **1** |
| `update` 1件 | 3 | **1** |
| `updateMany` | 3 | **1** |

## やったこと

**#172 で読み取り側に入れたのと同じ形**です。`getWantUpdateIndexFromTitles(titles, data)` を用意し、呼び出し元が既に持っている見出しを渡します。

## デッドコードを2つ削除

- **`getWantFindIndex`** — #172 で `getWantFindIndexFromTitles` に置き換わって以降、**どこからも呼ばれていませんでした**(テストからの参照もゼロ)
- **`getWantUpdateIndex`** — 今回の移行で未使用に

正味 **-28行**です。

## 波及した効果が大きい

この修正で、**#179 で対応した多対多の `set` / `create` が完全に平らになりました**。

| 項目数 | set(before → after) | create |
|---|---|---|
| 1 | 22 → **19** | 12 → **9** |
| 3 | 24 → **19** | 16 → **9** |
| 5 | 26 → **19** | 20 → **9** |
| **20** | **41 → 19** | **50 → 9** |

**件数がいくつでも往復が変わりません。** #179 の時点で残っていた「1件あたり+1〜2往復」は、まさにこの見出し読みでした。

Cascade を伴う update も **18 → 14** に減っています。

## 既存テストの期待値を3件更新しました

いずれも**往復回数を固定していたもの**で、**すべて改善方向**です。

| テスト | before | after |
|---|---|---|
| set の往復数 | `[22,24,26,41]` | `[19,19,19,19]` |
| create の往復数 | `[12,16,20,50]` | `[9,9,9,9]` |
| Cascade update の読み往復数 | 18 | 14 |

**同じテスト内のシート状態・結果の検証は、更新前からすべて通っています**(= 挙動は変わっていない)。減少幅も算術と一致します(set は項目数+2、create は 2×項目数+1、Cascade は 4)。

Cascade のテストは名前が「従来から変わらない」で実態と合わなくなったため、**「キャッシュが効いた値まで下がらない」に変更**しました。このテストの目的は「書き込み経路にキャッシュが持ち込まれていないこと」の担保で、基準値が下がっても役目は果たします。

## `whereFilter` は分割せず省略可能な引数にしました

2つの既存テストが `jest.spyOn(whereFilter)` で `updateManyFunc` を通常は到達できない状態に追い込んでおり、**別名の関数に分けるとスパイが素通りして落ちる**ためです(分割案で実装して実際に落ちることを確認してから転換)。省略可能な引数なら既存テストを一切触らずに理想の1回に到達できます。

## 検証

- `npx jest`: **1998 passed**(既存1993、新規5、期待値更新3)
- 新規テストは**5パターンすべてで見出し読みが1回**であることを固定。返り値とシート最終状態も同時に検証
- `tsc` clean / `build` 成功 / **`verify:bundle` OK(公開シンボル 53、増減なし)**
- `biome`: 変更6ファイルは診断ゼロ。`resolveNestedUpdate.ts` の警告は **9件 → 9件で不変**(実ファイルで測定)
- `as` は**新規ゼロ**。むしろ既存の `as UpdateAnyUse` を2箇所削減

🤖 Generated with [Claude Code](https://claude.com/claude-code)