### PR TITLE
feat: add Gassma.raw to write cell values without formula escaping

### DIFF
--- a/src/__test__/util/raw/raw.test.ts
+++ b/src/__test__/util/raw/raw.test.ts
@@ -1,0 +1,138 @@
+import * as publicApi from "../../../publicApi";
+import {
+  escapeFormulaInjection,
+  escapeFormulaInjectionRow,
+} from "../../../util/core/escapeFormulaInjection";
+import { isDict } from "../../../util/other/isDict";
+import {
+  RawValue,
+  isRawValue,
+  raw,
+  rawBrand,
+  unwrapRawValue,
+} from "../../../util/raw/raw";
+import { normalizeQueryInput } from "../../../util/skip/normalizeQueryInput";
+import { isUpdateNestedWriteOperation } from "../../../util/update/nestedWrite/extractRelationDataForUpdate";
+import { isNumberOperation } from "../../../util/update/resolveNumberOperation";
+import { createCrossRealmValue } from "../../consts/crossRealm";
+
+describe("raw ラッパの生成と判定", () => {
+  it("raw は isRawValue が真になる値を生成する", () => {
+    expect(isRawValue(raw("=SUM(A1:A10)"))).toBe(true);
+  });
+
+  it("unwrapRawValue は元の文字列をそのまま返す", () => {
+    const value = "=SUM(A1:A10)";
+    expect(unwrapRawValue(raw(value))).toBe(value);
+  });
+
+  it("raw 以外の値は isRawValue が偽", () => {
+    expect(isRawValue("=SUM(A1:A10)")).toBe(false);
+    expect(isRawValue(null)).toBe(false);
+    expect(isRawValue(undefined)).toBe(false);
+    expect(isRawValue(42)).toBe(false);
+    expect(isRawValue(true)).toBe(false);
+    expect(isRawValue(new Date("2025-01-01"))).toBe(false);
+    expect(isRawValue({})).toBe(false);
+    expect(isRawValue({ value: "=SUM(A1:A10)" })).toBe(false);
+    expect(isRawValue([])).toBe(false);
+  });
+
+  it("d.ts のブランドキー名を真似た平オブジェクトは RawValue 扱いしない", () => {
+    expect(isRawValue({ __gassmaRawValueBrand: "Gassma.raw" })).toBe(false);
+  });
+
+  it("publicApi.raw は本体の関数と同一", () => {
+    expect(publicApi.raw).toBe(raw);
+  });
+});
+
+describe("escapeFormulaInjection との連携", () => {
+  it("raw された = 始まり文字列はエスケープされない", () => {
+    expect(escapeFormulaInjection(raw("=SUM(A1:A10)"))).toBe("=SUM(A1:A10)");
+  });
+
+  it("raw された + - @ 始まり文字列もエスケープされない", () => {
+    expect(escapeFormulaInjection(raw("+1+1"))).toBe("+1+1");
+    expect(escapeFormulaInjection(raw("-1+1"))).toBe("-1+1");
+    expect(escapeFormulaInjection(raw("@SUM"))).toBe("@SUM");
+  });
+
+  it("raw された通常の文字列はそのまま返る", () => {
+    expect(escapeFormulaInjection(raw("hello"))).toBe("hello");
+  });
+
+  it("escapeFormulaInjectionRow はセル単位で raw だけ素通しする", () => {
+    expect(
+      escapeFormulaInjectionRow([raw("=1+1"), "=1+1", "normal", 42, null]),
+    ).toEqual(["=1+1", "'=1+1", "normal", 42, null]);
+  });
+
+  it("配列の再帰サニタイズ中でも raw は素通しされる", () => {
+    expect(escapeFormulaInjection([raw("=A1"), "=B1"])).toEqual([
+      "=A1",
+      "'=B1",
+    ]);
+  });
+});
+
+describe("realm 安全性", () => {
+  it("別 realm で構築されたブランド付きオブジェクトも RawValue と判定する", () => {
+    const makeForeignRawValue = createCrossRealmValue<
+      (brand: symbol, value: string) => unknown
+    >(
+      "(brand, value) => { class RawValue { constructor(v) { this[brand] = v; } } return new RawValue(value); }",
+    );
+    const foreign = makeForeignRawValue(rawBrand, "=SUM(A1:A2)");
+
+    expect(isRawValue(foreign)).toBe(true);
+    expect(escapeFormulaInjection(foreign)).toBe("=SUM(A1:A2)");
+    expect(isDict(foreign)).toBe(false);
+  });
+
+  it("raw 値は別 realm の関数を往復しても判定できる", () => {
+    const identity = createCrossRealmValue<(v: unknown) => unknown>("(v) => v");
+    const roundTripped = identity(raw("=NOW()"));
+
+    expect(isRawValue(roundTripped)).toBe(true);
+    expect(escapeFormulaInjection(roundTripped)).toBe("=NOW()");
+  });
+
+  it("別 realm の平オブジェクトは RawValue 扱いしない", () => {
+    expect(isRawValue(createCrossRealmValue("({})"))).toBe(false);
+  });
+});
+
+describe("他の値判定と衝突しない", () => {
+  it("isDict は RawValue を辞書扱いしない", () => {
+    expect(isDict(raw("=SUM(A1)"))).toBe(false);
+  });
+
+  it("isNumberOperation は RawValue を数値演算扱いしない", () => {
+    expect(isNumberOperation(raw("=SUM(A1)"))).toBe(false);
+  });
+
+  it("isUpdateNestedWriteOperation は RawValue を nested write 扱いしない", () => {
+    expect(isUpdateNestedWriteOperation(raw("=SUM(A1)"))).toBe(false);
+  });
+
+  it("normalizeQueryInput(strict) は RawValue を同一参照のまま素通しする", () => {
+    const wrapped = raw("=SUM(A1)");
+    const normalized = normalizeQueryInput({ data: { total: wrapped } }, true);
+
+    expect(normalized.data.total).toBe(wrapped);
+  });
+});
+
+describe("非文字列の扱い", () => {
+  it("型上は string 専用だがランタイムの非文字列は素通しする", () => {
+    // @ts-expect-error raw は string 専用
+    const wrapped = raw(42);
+
+    expect(escapeFormulaInjection(wrapped)).toBe(42);
+  });
+
+  it("内部コンストラクタ経由の非文字列も素通しする", () => {
+    expect(escapeFormulaInjection(new RawValue(42))).toBe(42);
+  });
+});

--- a/src/__test__/util/raw/rawReturnRecords.test.ts
+++ b/src/__test__/util/raw/rawReturnRecords.test.ts
@@ -1,0 +1,169 @@
+import { raw } from "../../../util/raw/raw";
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "../extends/extendsTestClient";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "../transaction/transactionTestClient";
+
+afterEach(() => {
+  clearSpreadsheetApp();
+  clearGasGlobals();
+  jest.restoreAllMocks();
+});
+
+describe("create の戻り値", () => {
+  it("raw カラムは数式文字列でアンラップされ非 raw カラムは従来どおり入力エコー", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    const created = users.create({
+      data: { id: 4, name: raw("=SUM(A1:A2)"), age: "=danger" },
+    });
+
+    expect(created).toEqual({ id: 4, name: "=SUM(A1:A2)", age: "=danger" });
+  });
+
+  it("数値カラムへの raw も戻り値は数式文字列(エコーであり計算結果ではない)", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    const created = users.create({
+      data: { id: 5, name: "x", age: raw("=SUM(A1:A2)") },
+    });
+
+    expect(created).toEqual({ id: 5, name: "x", age: "=SUM(A1:A2)" });
+  });
+});
+
+describe("createManyAndReturn の戻り値", () => {
+  it("raw カラムはアンラップされ他の行・カラムは従来どおり", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    const created = users.createManyAndReturn({
+      data: [
+        { id: 6, name: raw("=A1"), age: 1 },
+        { id: 7, name: "=A1", age: 2 },
+      ],
+    });
+
+    expect(created).toEqual([
+      { id: 6, name: "=A1", age: 1 },
+      { id: 7, name: "=A1", age: 2 },
+    ]);
+  });
+});
+
+describe("update / updateManyAndReturn の戻り値", () => {
+  it("update の戻り値の raw カラムはアンラップされる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    const updated = users.update({
+      where: { id: 1 },
+      data: { name: raw("=NOW()") },
+    });
+
+    expect(updated).toEqual({ id: 1, name: "=NOW()", age: 20 });
+  });
+
+  it("updateManyAndReturn の戻り値の raw カラムは全行アンラップされる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    const updated = users.updateManyAndReturn({
+      where: {},
+      data: { name: raw("=RAND()") },
+    });
+
+    expect(updated).toHaveLength(3);
+    updated.forEach((record) => {
+      expect(record).toMatchObject({ name: "=RAND()" });
+    });
+  });
+});
+
+describe("upsert の戻り値", () => {
+  it("update 分岐の戻り値の raw カラムはアンラップされる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    const upserted = users.upsert({
+      where: { id: 2 },
+      create: { id: 2, name: "none", age: 0 },
+      update: { name: raw("=U1") },
+    });
+
+    expect(upserted).toEqual({ id: 2, name: "=U1", age: 30 });
+  });
+
+  it("create 分岐の戻り値の raw カラムはアンラップされる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    const upserted = users.upsert({
+      where: { id: 99 },
+      create: { id: 99, name: raw("=C1"), age: 0 },
+      update: {},
+    });
+
+    expect(upserted).toEqual({ id: 99, name: "=C1", age: 0 });
+  });
+});
+
+describe("nested write の戻り値", () => {
+  it("nested create を伴う create の戻り値でも親の raw カラムはアンラップされる", () => {
+    const client = buildTestClient({ relations: true });
+    const users: any = sheetOf(client, "Users");
+
+    const created = users.create({
+      data: {
+        id: 8,
+        name: raw("=P1"),
+        age: 1,
+        posts: { create: { id: 103, title: "t" } },
+      },
+    });
+
+    expect(created).toMatchObject({ id: 8, name: "=P1" });
+  });
+
+  it("nested create を伴う update の戻り値でも親の raw カラムはアンラップされる", () => {
+    const client = buildTestClient({ relations: true });
+    const posts: any = sheetOf(client, "Posts");
+
+    const updated = posts.update({
+      where: { id: 101 },
+      data: {
+        title: raw("=SUM(B:B)"),
+        comments: { create: { id: 1004, body: "c" } },
+      },
+    });
+
+    expect(updated).toMatchObject({ id: 101, title: "=SUM(B:B)" });
+  });
+});
+
+describe("$transaction 内の戻り値", () => {
+  test("tx 内 create の戻り値も raw は数式文字列(シート側は数式として評価)", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      const created = tx.Users.create({
+        data: { id: 3, name: raw("=SUM(A1:A2)"), age: 40 },
+      });
+      expect(created).toEqual({ id: 3, name: "=SUM(A1:A2)", age: 40 });
+    });
+
+    expect(env.users.snapshot()[3]).toEqual([3, "#MOCK(=SUM(A1:A2))", 40]);
+  });
+
+  test("tx 内 update の戻り値も raw は数式文字列", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      const updated = tx.Users.update({
+        where: { id: 1 },
+        data: { name: raw("=NOW()") },
+      });
+      expect(updated).toEqual({ id: 1, name: "=NOW()", age: 20 });
+    });
+  });
+});

--- a/src/__test__/util/raw/rawTransaction.test.ts
+++ b/src/__test__/util/raw/rawTransaction.test.ts
@@ -1,0 +1,74 @@
+import { raw } from "../../../util/raw/raw";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "../transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+  jest.restoreAllMocks();
+});
+
+describe("$transaction と raw", () => {
+  test("tx 内の raw create は flush 後に生のまま書かれる", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.create({
+        data: { id: 3, name: raw("=SUM(A1:A2)"), age: "=danger" },
+      });
+      expect(env.users.writes).toEqual([]);
+    });
+
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+      [3, "#MOCK(=SUM(A1:A2))", "'=danger"],
+    ]);
+    expect(env.users.formulaSnapshot()[3]).toEqual(["", "=SUM(A1:A2)", ""]);
+  });
+
+  test("tx 内の raw update は flush 後に生のまま書かれる", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.update({ where: { id: 1 }, data: { name: raw("=NOW()") } });
+    });
+
+    expect(env.users.snapshot()[1]).toEqual([1, "#MOCK(=NOW())", 20]);
+    expect(env.users.formulaSnapshot()[1]).toEqual(["", "=NOW()", ""]);
+  });
+
+  test("read-your-writes では raw 値は文字列のまま見える", () => {
+    const env = buildTxTestEnv();
+
+    env.client.$transaction((tx) => {
+      tx.Users.create({
+        data: { id: 3, name: raw("=SUM(A1:A2)"), age: "=danger" },
+      });
+
+      expect(tx.Users.findFirst({ where: { id: 3 } })).toMatchObject({
+        name: "=SUM(A1:A2)",
+        age: "'=danger",
+      });
+    });
+  });
+
+  test("rollback 時は raw を含む書き込みもシートに反映されない", () => {
+    const env = buildTxTestEnv();
+
+    expect(() =>
+      env.client.$transaction((tx) => {
+        tx.Users.create({ data: { id: 3, name: raw("=SUM(A1:A2)"), age: 0 } });
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+    ]);
+  });
+});

--- a/src/__test__/util/raw/rawWritePaths.test.ts
+++ b/src/__test__/util/raw/rawWritePaths.test.ts
@@ -1,0 +1,189 @@
+import { raw } from "../../../util/raw/raw";
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "../extends/extendsTestClient";
+
+afterEach(() => {
+  clearSpreadsheetApp();
+});
+
+describe("create 経路の raw", () => {
+  it("raw されたセルは素通しされ同じ行の他セルはエスケープされる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    users.create({
+      data: { id: 4, name: raw("=SUM(A1:A2)"), age: "=danger" },
+    });
+
+    expect(users.findFirst({ where: { id: 4 } })).toMatchObject({
+      name: "=SUM(A1:A2)",
+      age: "'=danger",
+    });
+  });
+});
+
+describe("createMany 経路の raw", () => {
+  it("raw された行だけ素通しされ他の行は従来どおりエスケープされる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    users.createMany({
+      data: [
+        { id: 5, name: raw("=A1"), age: 1 },
+        { id: 6, name: "=A1", age: 2 },
+      ],
+    });
+
+    expect(users.findFirst({ where: { id: 5 } })).toMatchObject({
+      name: "=A1",
+    });
+    expect(users.findFirst({ where: { id: 6 } })).toMatchObject({
+      name: "'=A1",
+    });
+  });
+
+  it("createManyAndReturn 経由でも raw は素通しされる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    users.createManyAndReturn({
+      data: [{ id: 7, name: raw("=B1"), age: 3 }],
+    });
+
+    expect(users.findFirst({ where: { id: 7 } })).toMatchObject({
+      name: "=B1",
+    });
+  });
+});
+
+describe("update / updateMany 経路の raw", () => {
+  it("update で raw されたセルは素通しされ他セルはエスケープされる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    users.update({
+      where: { id: 1 },
+      data: { name: raw("=NOW()"), age: "=cmd" },
+    });
+
+    expect(users.findFirst({ where: { id: 1 } })).toMatchObject({
+      name: "=NOW()",
+      age: "'=cmd",
+    });
+  });
+
+  it("updateMany で raw されたセルは全行素通しされる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    users.updateMany({
+      where: {},
+      data: { name: raw("=RAND()"), age: "=cmd" },
+    });
+
+    const found = users.findMany({});
+    expect(found).toHaveLength(3);
+    found.forEach((record) => {
+      expect(record).toMatchObject({ name: "=RAND()", age: "'=cmd" });
+    });
+  });
+});
+
+describe("upsert 経路の raw", () => {
+  it("update 分岐で raw は素通しされる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    users.upsert({
+      where: { id: 2 },
+      create: { id: 2, name: "none", age: 0 },
+      update: { name: raw("=U1") },
+    });
+
+    expect(users.findFirst({ where: { id: 2 } })).toMatchObject({
+      name: "=U1",
+    });
+  });
+
+  it("create 分岐で raw は素通しされる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+
+    users.upsert({
+      where: { id: 99 },
+      create: { id: 99, name: raw("=C1"), age: 0 },
+      update: {},
+    });
+
+    expect(users.findFirst({ where: { id: 99 } })).toMatchObject({
+      name: "=C1",
+    });
+  });
+});
+
+describe("nested write 経路の raw", () => {
+  it("create の nested create でも raw は素通しされる", () => {
+    const client = buildTestClient({ relations: true });
+    const users: any = sheetOf(client, "Users");
+
+    users.create({
+      data: {
+        id: 8,
+        name: "Dave",
+        age: 1,
+        posts: { create: { id: 103, title: raw("=IMPORTRANGE(1)") } },
+      },
+    });
+
+    const posts = sheetOf(client, "Posts");
+    expect(posts.findFirst({ where: { id: 103 } })).toMatchObject({
+      title: "=IMPORTRANGE(1)",
+      authorId: 8,
+    });
+  });
+
+  it("update の nested create でも親子ともに raw は素通しされる", () => {
+    const client = buildTestClient({ relations: true });
+    const posts: any = sheetOf(client, "Posts");
+
+    posts.update({
+      where: { id: 101 },
+      data: {
+        title: raw("=SUM(B:B)"),
+        comments: { create: { id: 1004, body: raw("=cmd2") } },
+      },
+    });
+
+    expect(posts.findFirst({ where: { id: 101 } })).toMatchObject({
+      title: "=SUM(B:B)",
+    });
+
+    const comments = sheetOf(client, "Comments");
+    expect(comments.findFirst({ where: { id: 1004 } })).toMatchObject({
+      body: "=cmd2",
+      postId: 101,
+    });
+  });
+});
+
+describe("@default / @updatedAt との併用", () => {
+  it("defaults が適用されても raw は壊れない", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    users._setDefaults({ age: 99 });
+
+    users.create({ data: { id: 10, name: raw("=X1") } });
+
+    expect(users.findFirst({ where: { id: 10 } })).toMatchObject({
+      name: "=X1",
+      age: 99,
+    });
+  });
+
+  it("updatedAt が適用されても raw は壊れない", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    users._setUpdatedAt(["age"]);
+
+    users.create({ data: { id: 11, name: raw("=Y1") } });
+
+    expect(users.findFirst({ where: { id: 11 } })).toMatchObject({
+      name: "=Y1",
+      age: expect.any(Date),
+    });
+  });
+});

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,25 @@ declare namespace Gassma {
 
   type SkipValue = typeof skip;
 
+  type RawValue = {
+    readonly __gassmaRawValueBrand: "Gassma.raw";
+  };
+
+  /**
+   * Writes the value to the cell as-is, skipping formula-injection escaping.
+   * A string starting with `=` therefore becomes a live spreadsheet formula.
+   *
+   * Susceptible to formula injection: never pass unsanitized user input.
+   *
+   * @example
+   * ```
+   * gassma.Report.create({
+   *   data: { title: userInput, total: Gassma.raw("=SUM(B2:B10)") },
+   * });
+   * ```
+   */
+  function raw(value: string): RawValue;
+
   class FieldRef {
     readonly modelName: string;
     readonly name: string;
@@ -149,11 +168,11 @@ declare namespace Gassma {
   };
 
   type AnyUse = {
-    [key: string]: GassmaAny | SkipValue;
+    [key: string]: GassmaAny | RawValue | SkipValue;
   };
 
   type UpdateAnyUse = {
-    [key: string]: GassmaAny | NumberOperation | SkipValue;
+    [key: string]: GassmaAny | NumberOperation | RawValue | SkipValue;
   };
 
   type WhereUse = {

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -13,6 +13,7 @@ import { GassmaClient as GassmaClientClass } from "./gassma";
 import { GassmaController as GassmaControllerClass } from "./gassmaController";
 import { FieldRef as FieldRefClass } from "./util/filterConditions/fieldRef";
 import { migrateSheets as migrateSheetsFunc } from "./util/migrate/migrateSheets";
+import { raw as rawFunc } from "./util/raw/raw";
 import { skip as skipSymbol } from "./util/skip/skip";
 
 // GAS ライブラリとして公開する実体。src/index.d.ts の namespace Gassma と 1:1 に保つ。
@@ -22,6 +23,7 @@ export const GassmaClient = GassmaClientClass;
 export const GassmaController = GassmaControllerClass;
 export const FieldRef = FieldRefClass;
 export const skip = skipSymbol;
+export const raw = rawFunc;
 export const migrateSheets = migrateSheetsFunc;
 
 export const GassmaSkipNegativeError = findErrors.GassmaSkipNegativeError;

--- a/src/types/coreTypes.ts
+++ b/src/types/coreTypes.ts
@@ -1,3 +1,5 @@
+import type { RawValue } from "../util/raw/raw";
+
 type GassmaAny = string | number | boolean | Date | null;
 
 type SortOrderInput = {
@@ -33,11 +35,11 @@ type NumberOperation = {
 };
 
 type AnyUse = {
-  [key: string]: GassmaAny;
+  [key: string]: GassmaAny | RawValue;
 };
 
 type UpdateAnyUse = {
-  [key: string]: GassmaAny | NumberOperation;
+  [key: string]: GassmaAny | NumberOperation | RawValue;
 };
 
 type WhereUse = {
@@ -143,9 +145,13 @@ type TranspositionHavingAggregateWithIndex = {
   index: number;
 };
 
+type RowRecord = {
+  [key: string]: GassmaAny;
+};
+
 type HitByClassificationedRowData = {
   rowNumber: number;
-  row: AnyUse[];
+  row: RowRecord[];
 };
 
 type TranspositionHavingConditionKeys = {
@@ -167,6 +173,7 @@ export type {
   NumberOperation,
   AnyUse,
   UpdateAnyUse,
+  RowRecord,
   FilterConditions,
   NumberFilterConditions,
   WhereUse,

--- a/src/util/core/escapeFormulaInjection.ts
+++ b/src/util/core/escapeFormulaInjection.ts
@@ -1,6 +1,9 @@
+import { isRawValue, unwrapRawValue } from "../raw/raw";
+
 const FORMULA_PREFIXES = ["=", "+", "-", "@"];
 
 const escapeFormulaInjection = (value: unknown): unknown => {
+  if (isRawValue(value)) return unwrapRawValue(value);
   if (Array.isArray(value)) return value.map(escapeFormulaInjection);
   if (typeof value !== "string") return value;
   if (value.length === 0) return value;

--- a/src/util/create/create.ts
+++ b/src/util/create/create.ts
@@ -1,9 +1,9 @@
-import type { AnyUse } from "../../types/coreTypes";
 import type { CreateData } from "../../types/createTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import { getTitle } from "../core/getTitle";
 import { getWantUpdateIndexFromTitles } from "../core/getWantUpdateIndex";
 import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
+import { unwrapRawCell } from "../raw/raw";
 import { resolveWriter } from "../write/sheetWriter";
 
 const createFunc = (
@@ -17,7 +17,7 @@ const createFunc = (
 
   const wantCreateIndex = getWantUpdateIndexFromTitles(titles, data);
 
-  const createReturn: AnyUse = {};
+  const createReturn: Record<string, unknown> = {};
 
   const newData = titles.map((_, index) => {
     if (!wantCreateIndex.includes(index)) {
@@ -25,7 +25,7 @@ const createFunc = (
       return "";
     }
 
-    createReturn[titles[index]] = data[titles[index]];
+    createReturn[titles[index]] = unwrapRawCell(data[titles[index]]);
     return data[titles[index]];
   });
 

--- a/src/util/create/createManyFunc.ts
+++ b/src/util/create/createManyFunc.ts
@@ -3,6 +3,7 @@ import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType"
 import { getTitle } from "../core/getTitle";
 import { getWantUpdateIndexFromTitles } from "../core/getWantUpdateIndex";
 import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
+import { unwrapRawCell } from "../raw/raw";
 import { resolveWriter } from "../write/sheetWriter";
 
 function createManyFunc(
@@ -50,7 +51,7 @@ function createManyFunc(
   if (withReturn) {
     return data.map((row) =>
       titles.reduce<Record<string, unknown>>((record, title) => {
-        record[title] = title in row ? row[title] : null;
+        record[title] = title in row ? unwrapRawCell(row[title]) : null;
         return record;
       }, {}),
     );

--- a/src/util/groupby/groubyUtil/getAggregate.ts
+++ b/src/util/groupby/groubyUtil/getAggregate.ts
@@ -1,7 +1,7 @@
 import type {
-  AnyUse,
   HavingAggregate,
   MatchKeys,
+  RowRecord,
 } from "../../../types/coreTypes";
 import { getAvg } from "../../aggregate/aggregateUtil/avg";
 import { getCount } from "../../aggregate/aggregateUtil/count";
@@ -10,7 +10,7 @@ import { getMin } from "../../aggregate/aggregateUtil/min";
 import { getSum } from "../../aggregate/aggregateUtil/sum";
 
 const getAggregate = (
-  byClassificationedRow: AnyUse[],
+  byClassificationedRow: RowRecord[],
   matchKeys: MatchKeys,
 ): HavingAggregate => {
   const aggregateResult = {

--- a/src/util/groupby/groubyUtil/having.ts
+++ b/src/util/groupby/groubyUtil/having.ts
@@ -1,7 +1,7 @@
 import type {
-  AnyUse,
   HavingUse,
   HitByClassificationedRowData,
+  RowRecord,
 } from "../../../types/coreTypes";
 import { isLogicMatchHaving } from "./andOrNot/entry";
 import { normalHaving } from "./having/normalHavingFilter";
@@ -15,7 +15,7 @@ const removeIndex = (
 };
 
 const havingFilter = (
-  byClassificationedRow: AnyUse[][],
+  byClassificationedRow: RowRecord[][],
   havingData: HavingUse,
   by: string[],
 ) => {

--- a/src/util/groupby/groupby.ts
+++ b/src/util/groupby/groupby.ts
@@ -1,4 +1,4 @@
-import type { AnyUse } from "../../types/coreTypes";
+import type { RowRecord } from "../../types/coreTypes";
 import type { FindData } from "../../types/findTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import type { GroupByData } from "../../types/groupByType";
@@ -37,7 +37,7 @@ const groupByFunc = (
 
   const findedRows = findManyFunc(gassmaControllerUtil, findData);
 
-  let byClassificationed = byClassification(findedRows, by) as AnyUse[][];
+  let byClassificationed = byClassification(findedRows, by) as RowRecord[][];
 
   if (having) byClassificationed = havingFilter(byClassificationed, having, by);
 

--- a/src/util/raw/raw.ts
+++ b/src/util/raw/raw.ts
@@ -1,0 +1,21 @@
+const rawBrand: unique symbol = Symbol("Gassma.raw");
+
+class RawValue {
+  readonly [rawBrand]: unknown;
+
+  constructor(value: unknown) {
+    this[rawBrand] = value;
+  }
+}
+
+const raw = (value: string): RawValue => new RawValue(value);
+
+const isRawValue = (value: unknown): value is RawValue =>
+  typeof value === "object" && value !== null && rawBrand in value;
+
+const unwrapRawValue = (value: RawValue): unknown => value[rawBrand];
+
+const unwrapRawCell = (value: unknown): unknown =>
+  isRawValue(value) ? unwrapRawValue(value) : value;
+
+export { RawValue, raw, isRawValue, unwrapRawValue, unwrapRawCell, rawBrand };

--- a/src/util/update/nestedWrite/resolveNestedUpdate.ts
+++ b/src/util/update/nestedWrite/resolveNestedUpdate.ts
@@ -22,6 +22,7 @@ import {
   resolveNumberOperation,
 } from "../resolveNumberOperation";
 import { escapeFormulaInjectionRow } from "../../core/escapeFormulaInjection";
+import { unwrapRawCell } from "../../raw/raw";
 import { resolveWriter } from "../../write/sheetWriter";
 
 type UpdateInput = {
@@ -93,7 +94,7 @@ const resolveNestedUpdate = (
     );
 
     return titles.reduce<Record<string, unknown>>((record, title, index) => {
-      record[title] = updatedRow[index];
+      record[title] = unwrapRawCell(updatedRow[index]);
       return record;
     }, {});
   }
@@ -137,7 +138,7 @@ const resolveNestedUpdate = (
 
   const updatedRecord = titles.reduce<Record<string, unknown>>(
     (record, title, index) => {
-      record[title] = updatedRow[index];
+      record[title] = unwrapRawCell(updatedRow[index]);
       return record;
     },
     {},

--- a/src/util/update/updateMany.ts
+++ b/src/util/update/updateMany.ts
@@ -5,6 +5,7 @@ import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
 import { getTitle } from "../core/getTitle";
 import { getWantUpdateIndexFromTitles } from "../core/getWantUpdateIndex";
 import { whereFilter } from "../core/whereFilter";
+import { unwrapRawCell } from "../raw/raw";
 import { groupUpdateRuns } from "../write/rowRuns";
 import { resolveWriter } from "../write/sheetWriter";
 import {
@@ -92,7 +93,7 @@ function updateManyFunc(
 
   const records = updates.map(({ updatedRow }) =>
     titles.reduce<Record<string, unknown>>((record, title, index) => {
-      record[title] = updatedRow[index];
+      record[title] = unwrapRawCell(updatedRow[index]);
       return record;
     }, {}),
   );


### PR DESCRIPTION
## 概要

数式インジェクション対策のエスケープ(`= + - @` 始まりの文字列に `'` を付与)を**セル単位で**バイパスする `Gassma.raw(value)` を追加します。これまで `=SUM(B2:B10)` のような**意図的な数式を書き込めなかった**問題への対応です(ユーザーと設計を詰めて確定)。

```ts
gassma.Report.create({
  data: {
    title: userInput,                  // 従来どおりエスケープされる
    total: Gassma.raw("=SUM(B2:B10)"), // このセルだけ生で書く
  },
});
```

## なぜ「値ラッパ」なのか(Prisma パリティ)

Prisma には `$queryRawUnsafe`(生成 d.ts の JSDoc に "Susceptible to SQL injections, see documentation.")と、値単位ラッパの `Prisma.raw` があります。gassma で危険なのは**セルに書く値**なので `Prisma.raw` の写像が正解と判断しました。クエリ単位・クライアント単位のフラグにしなかったのは、**同じ書き込みの他カラム(ユーザー入力)まで丸腰になる**のを避けるためです。危険が call site に見えるという副次効果もあります。宣言には Prisma と同種の警告 JSDoc を入れてあります。

## 実装

- ブランドは **unique symbol を持つ class**。判定は `rawBrand in value` で **instanceof 不使用 = realm 安全**(`Gassma.skip` と同じ考え方。vm 製の別 realm 値でもテスト)
  - **class にした理由**: 平オブジェクトだと `isDict` が辞書と判定し、`normalizeQueryInput` の Object.keys コピーで symbol ブランドが落ちる(この衝突もテストで pin)
- **アンラップは2系統**:
  1. `escapeFormulaInjection` 先頭 — **書き込み側5箇所は無変更**
  2. **レコード組み立て5箇所** — 戻り値にラッパが残ると「宣言型は string なのに実行時は `{}`」という型/実装乖離になるため(初版では残っていたのを差し戻して修正)
- `RowRecord` を新設して読み側の行レコード型を `AnyUse` から分離(RawValue 追加が groupBy の having 型に波及するのを防ぐ。型レベルのみ)

## 仕様として固定した点(テストで pin)

- **戻り値は「書き込んだ内容のエコー」であり計算結果ではない**(gassma は書き込み後に再読しない既存設計)。数値カラムに数式を書くと戻り値は数式**文字列**になります。計算結果が要る場合は後から読み直す
- **raw 性は伝播しない**: raw を使ったセルを FK アンカーにした場合、子行へ渡る値は通常どおりエスケープされる
- `$transaction`: バッファを素通しして flush で数式として書かれる / read-your-writes では数式文字列のまま見える / rollback 時は1セルも書かれない
- 型は `raw(value: string)` に限定。ランタイムでは非文字列も素通し(coerce も throw もしない)

## テスト

1998 → **2043**(+45)。Red は2段階(ラッパ+書き込み経路で23件、戻り値で11件)を実測。**既存テストは1文字も変更せず green**。verify:bundle は Red 実測 → Green(公開実体 **53→54**)。実バンドルの 2 realm ハーネスで、raw セルが `'` 無しで書かれ・同行の通常セルはエスケープされ・戻り値が数式文字列になることを確認。

## 次(別 PR)

cli 追随(生成データ型に `| Gassma.RawValue`)→ gassma-test → reference(API 定義 + **インジェクション対策の節に危険例**、Prisma のドキュメント構成に倣う)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CBDJwN2kT86U6pukiUtxX