### PR TITLE
fix: allow omitting the argument where Prisma does

### DIFF
--- a/src/__test__/util/extends/extendsTestClient.ts
+++ b/src/__test__/util/extends/extendsTestClient.ts
@@ -18,6 +18,7 @@ type MockSheet = {
   ) => MockRange;
   getDataRange: () => { getValues: () => unknown[][] };
   deleteRow: (rowIndex: number) => void;
+  deleteRows: (rowPosition: number, howMany: number) => void;
 };
 
 const makeSheet = (name: string, initial: unknown[][]): MockSheet => {
@@ -45,6 +46,9 @@ const makeSheet = (name: string, initial: unknown[][]): MockSheet => {
     getDataRange: () => ({ getValues: () => data }),
     deleteRow: (rowIndex) => {
       data.splice(rowIndex - 1, 1);
+    },
+    deleteRows: (rowPosition, howMany) => {
+      data.splice(rowPosition - 1, howMany);
     },
   };
 };

--- a/src/__test__/util/omittedArguments.test.ts
+++ b/src/__test__/util/omittedArguments.test.ts
@@ -1,0 +1,160 @@
+import { GassmaMissingArgumentError } from "../../errors/argument/argumentError";
+import { NotFoundError } from "../../errors/find/findError";
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "./extends/extendsTestClient";
+
+afterEach(() => {
+  clearSpreadsheetApp();
+});
+
+const usersController = () => sheetOf(buildTestClient(), "Users");
+
+const allUsers = [
+  { id: 1, name: "Alice", age: 20 },
+  { id: 2, name: "Bob", age: 30 },
+  { id: 3, name: "Carol", age: 40 },
+];
+
+const expectMissing = (fn: () => unknown, argumentName: string) => {
+  expect(fn).toThrow(GassmaMissingArgumentError);
+  expect(fn).toThrow(`Argument \`${argumentName}\` is missing.`);
+};
+
+describe("引数なし呼び出し: {} と同じ扱いで正常動作する5操作", () => {
+  test("findMany() は全件を返す", () => {
+    const users = usersController();
+    expect(users.findMany()).toEqual(allUsers);
+  });
+
+  test("findFirst() は先頭行を返す", () => {
+    const users = usersController();
+    expect(users.findFirst()).toEqual(allUsers[0]);
+  });
+
+  test("findFirstOrThrow() は先頭行を返す", () => {
+    const users = usersController();
+    expect(users.findFirstOrThrow()).toEqual(allUsers[0]);
+  });
+
+  test("findFirstOrThrow() は空シートなら NotFoundError", () => {
+    const users = usersController();
+    users.deleteMany();
+    expect(() => users.findFirstOrThrow()).toThrow(NotFoundError);
+  });
+
+  test("count() は全件数を返す", () => {
+    const users = usersController();
+    expect(users.count()).toBe(3);
+  });
+
+  test("deleteMany() は全件削除する", () => {
+    const users = usersController();
+    expect(users.deleteMany()).toEqual({ count: 3 });
+    expect(users.count()).toBe(0);
+  });
+
+  test("undefined を明示的に渡しても {} と同じ扱いになる", () => {
+    const users = usersController();
+    expect(users.findMany(undefined)).toEqual(allUsers);
+    expect(users.findFirst(undefined)).toEqual(allUsers[0]);
+    expect(users.count(undefined)).toBe(3);
+  });
+});
+
+describe("引数なし呼び出し: 必須引数は GassmaMissingArgumentError で報告する", () => {
+  test("groupBy() は by を報告する", () => {
+    const users = usersController();
+    expectMissing(
+      // @ts-expect-error 引数必須のまま
+      () => users.groupBy(),
+      "by",
+    );
+  });
+
+  test("updateMany() は data を報告し、行を更新しない", () => {
+    const users = usersController();
+    expectMissing(
+      // @ts-expect-error 引数必須のまま
+      () => users.updateMany(),
+      "data",
+    );
+    expect(users.findMany()).toEqual(allUsers);
+  });
+
+  test("updateManyAndReturn() は data を報告する", () => {
+    const users = usersController();
+    expectMissing(
+      // @ts-expect-error 引数必須のまま
+      () => users.updateManyAndReturn(),
+      "data",
+    );
+  });
+
+  test("createMany() は data を報告し、行を作らない", () => {
+    const users = usersController();
+    expectMissing(
+      // @ts-expect-error 引数必須のまま
+      () => users.createMany(),
+      "data",
+    );
+    expect(users.count()).toBe(3);
+  });
+
+  test("createManyAndReturn() は data を報告する", () => {
+    const users = usersController();
+    expectMissing(
+      // @ts-expect-error 引数必須のまま
+      () => users.createManyAndReturn(),
+      "data",
+    );
+  });
+
+  test("create() は data を報告し、行を作らない", () => {
+    const users = usersController();
+    expectMissing(
+      // @ts-expect-error 引数必須のまま
+      () => users.create(),
+      "data",
+    );
+    expect(users.count()).toBe(3);
+  });
+
+  test("update() は where を報告する", () => {
+    const users = usersController();
+    expectMissing(
+      // @ts-expect-error 引数必須のまま
+      () => users.update(),
+      "where",
+    );
+  });
+
+  test("upsert() は where を報告する", () => {
+    const users = usersController();
+    expectMissing(
+      // @ts-expect-error 引数必須のまま
+      () => users.upsert(),
+      "where",
+    );
+  });
+
+  test("delete() は where を報告し、行を削除しない", () => {
+    const users = usersController();
+    expectMissing(
+      // @ts-expect-error 引数必須のまま
+      () => users.delete(),
+      "where",
+    );
+    expect(users.count()).toBe(3);
+  });
+});
+
+describe("引数なし呼び出し: aggregate は {} と同じ扱い", () => {
+  test("aggregate() は {} を返す", () => {
+    const users = usersController();
+    // @ts-expect-error 引数必須のまま
+    expect(users.aggregate()).toEqual({});
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -170,8 +170,12 @@ class GassmaController {
     this.strictUndefinedChecks = enabled;
   }
 
-  private normalizeInput<T>(input: T): T {
-    return normalizeQueryInput(input, this.strictUndefinedChecks);
+  private normalizeInput<T>(input: T): T;
+  private normalizeInput(input: unknown): unknown {
+    return normalizeQueryInput(
+      input === undefined ? {} : input,
+      this.strictUndefinedChecks,
+    );
   }
 
   private stripIgnored(data: Record<string, unknown>): Record<string, unknown> {
@@ -458,7 +462,7 @@ class GassmaController {
     return this.applyOmitToResult(mapped, effectiveOmit);
   }
 
-  public findFirst(findData: FindFirstData) {
+  public findFirst(findData: FindFirstData = {}) {
     return runWithReadCache(() =>
       this.findFirstRaw(this.normalizeInput(findData)),
     );
@@ -644,7 +648,7 @@ class GassmaController {
     return resolved[0] ?? null;
   }
 
-  public findFirstOrThrow(findData: FindFirstData) {
+  public findFirstOrThrow(findData: FindFirstData = {}) {
     const result = this.findFirst(findData);
     if (!result) {
       throw new NotFoundError();
@@ -652,7 +656,7 @@ class GassmaController {
     return result;
   }
 
-  public findMany(findData: FindData) {
+  public findMany(findData: FindData = {}) {
     return runWithReadCache(() =>
       this.findManyRaw(this.normalizeInput(findData)),
     );
@@ -1061,7 +1065,7 @@ class GassmaController {
     );
   }
 
-  public deleteMany(deleteData: DeleteData) {
+  public deleteMany(deleteData: DeleteData = {}) {
     return runWithoutReadCache(() => this.deleteManyRaw(deleteData));
   }
 
@@ -1095,7 +1099,7 @@ class GassmaController {
     return aggregateFunc(this.getGassmaControllerUtil(), aggregateData);
   }
 
-  public count(countData: CountData) {
+  public count(countData: CountData = {}) {
     return runWithReadCache(() =>
       this.countRaw(this.normalizeInput(countData)),
     );

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -104,17 +104,17 @@ declare namespace Gassma {
       createdData: CreateManyAndReturnData,
     ): Record<string, unknown>[];
     create(createdData: CreateData): Record<string, unknown>;
-    findFirst(findData: FindFirstData): Record<string, any>;
-    findFirstOrThrow(findData: FindFirstData): Record<string, any>;
-    findMany(findData: FindData): Record<string, any>[];
+    findFirst(findData?: FindFirstData): Record<string, any>;
+    findFirstOrThrow(findData?: FindFirstData): Record<string, any>;
+    findMany(findData?: FindData): Record<string, any>[];
     update(updateData: UpdateSingleData): Record<string, unknown> | null;
     updateMany(updateData: UpdateData): UpdateManyReturn;
     updateManyAndReturn(updateData: UpdateData): Record<string, unknown>[];
     upsert(upsertData: UpsertSingleData): Record<string, unknown>;
     delete(deleteData: DeleteSingleData): Record<string, unknown> | null;
-    deleteMany(deleteData: DeleteData): DeleteManyReturn;
+    deleteMany(deleteData?: DeleteData): DeleteManyReturn;
     aggregate(aggregateData: AggregateData): Record<string, any>;
-    count(countData: CountData): number;
+    count(countData?: CountData): number;
     groupBy(groupByData: GroupByData): Record<string, any>[];
     _setRelationContext(context: RelationContext): void;
     _setGlobalOmit(omit: Omit): void;


### PR DESCRIPTION
## 直す問題

`findMany()` のように**引数を省略して呼ぶと TypeError で落ちます**。Prisma は全件を返します。

```
TypeError: Cannot read properties of undefined (reading 'include')
```

9操作すべて同じでした(`findMany` / `findFirst` / `findFirstOrThrow` / `count` / `aggregate` / `groupBy` / `updateMany` / `createMany` / `deleteMany`)。

**ただし `{}` を渡せば、以前から Prisma と同じ挙動でした。** つまり**入口で引数の欠落に対する防御が無かっただけ**です。

## Prisma の挙動(実測)

引数なしが有効なのは**5つだけ**です。

| 操作 | Prisma |
|---|---|
| `findMany()` `findFirst()` `findFirstOrThrow()` `count()` `deleteMany()` | ✅ 有効(`deleteMany()` は**全件削除**) |
| `aggregate()` `groupBy()` | ❌ `PrismaClientValidationError` |
| `updateMany()` `createMany()` | ❌ `TypeError`(data 必須) |
| `create()` `update()` `upsert()` `delete()` `findUnique()` | ❌ `PrismaClientValidationError` |

## やったこと

**引数が無ければ `{}` として扱う**。これだけです。

| 操作 | before | after |
|---|---|---|
| `findMany()` | TypeError | **全件** |
| `findFirst()` / `findFirstOrThrow()` | TypeError | **先頭行** |
| `count()` | TypeError | **全件数** |
| `deleteMany()` | TypeError | **全件削除** |
| `groupBy()` | TypeError | `GassmaMissingArgumentError`(``by``) |
| `updateMany()` / `createMany()` | TypeError | `GassmaMissingArgumentError`(``data``) |
| `create()` / `update()` / `upsert()` / `delete()` | TypeError | `GassmaMissingArgumentError` |
| `aggregate()` | TypeError | `{}`(`aggregate({})` と同一) |

TypeError しか出なかったところが、**何が足りないか分かるエラー**になります。素の JavaScript から呼ぶ利用者にとっての改善でもあります。

**型を省略可能にしたのは5操作だけ**です。残りは Prisma がエラーにするので必須のままにし、テストで固定しています。

## 補完場所について

`normalizeQueryInput`(util)ではなく **controller の `normalizeInput`** で補いました。

util 側は既存テストが「**入力全体が undefined ならそのまま返す**(引数省略と区別できないため)」を明示的に固定しており、**扱いは呼び出し側が決める設計**だからです。全公開操作が必ず通る唯一の場所でもあります。

## 変わらないもの

- **`{}` を渡した場合・引数を渡した場合はすべて不変**
- **`aggregate({})` は `{}` を返したまま**(Prisma はエラーにしますが、これは既存の差異で今回は対象外。別途判断)
- `null` を渡した場合は従来どおり TypeError

## 検証

- `npx jest`: **2060 passed**(既存 2043 は**1件も書き換えず**全通過、新規17件)
  - 新規テストは9操作すべての引数なし呼び出しに加え、**引数必須のままにした操作が必須であること**も `@ts-expect-error` で固定(将来誰かが省略可にすると TS2578 で落ちる)
- `tsc` clean / `build` 成功 / **`verify:bundle` OK(公開シンボル 54、増減なし)**
- `biome`: エラー0。警告は origin/main と同じ既存分

**CLI 側の生成型は別 PR です**(gassma-cli #143)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)