### PR TITLE
fix: require an aggregation in aggregate

### DIFF
--- a/src/__test__/util/aggregate/aggregateSelectionRequired.test.ts
+++ b/src/__test__/util/aggregate/aggregateSelectionRequired.test.ts
@@ -1,0 +1,121 @@
+import { GassmaAggregateSelectionRequiredError } from "../../../errors/aggregate/aggregateError";
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "../extends/extendsTestClient";
+
+afterEach(() => {
+  clearSpreadsheetApp();
+});
+
+const usersController = () => sheetOf(buildTestClient(), "Users");
+
+describe("aggregate: 集計指定が1つも無ければエラー", () => {
+  test("aggregate({}) はエラー", () => {
+    const users = usersController();
+    expect(() => users.aggregate({})).toThrow(
+      GassmaAggregateSelectionRequiredError,
+    );
+  });
+
+  test("aggregate() はエラー", () => {
+    const users = usersController();
+    // @ts-expect-error 引数必須のまま
+    expect(() => users.aggregate()).toThrow(
+      GassmaAggregateSelectionRequiredError,
+    );
+  });
+
+  test("where だけではエラー", () => {
+    const users = usersController();
+    expect(() => users.aggregate({ where: { age: 20 } })).toThrow(
+      GassmaAggregateSelectionRequiredError,
+    );
+  });
+
+  test("orderBy だけではエラー", () => {
+    const users = usersController();
+    expect(() => users.aggregate({ orderBy: { age: "asc" } })).toThrow(
+      GassmaAggregateSelectionRequiredError,
+    );
+  });
+
+  test("take だけではエラー", () => {
+    const users = usersController();
+    expect(() => users.aggregate({ take: 1 })).toThrow(
+      GassmaAggregateSelectionRequiredError,
+    );
+  });
+
+  test("中身が空の集計指定は5キーすべてエラー", () => {
+    const users = usersController();
+    const emptySelections = [
+      { _avg: {} },
+      { _count: {} },
+      { _max: {} },
+      { _min: {} },
+      { _sum: {} },
+    ];
+    emptySelections.forEach((aggregateData) => {
+      expect(() => users.aggregate(aggregateData)).toThrow(
+        GassmaAggregateSelectionRequiredError,
+      );
+    });
+  });
+
+  test("エラーメッセージは必要な指定が分かる内容", () => {
+    const users = usersController();
+    expect(() => users.aggregate({})).toThrow(
+      "At least one aggregation is required: specify `_avg`, `_count`, `_max`, `_min`, or `_sum` with at least one field.",
+    );
+  });
+});
+
+describe("aggregate: 集計指定があれば従来どおり", () => {
+  test("_avg 指定は従来どおり集計する", () => {
+    const users = usersController();
+    expect(users.aggregate({ _avg: { age: true } })).toEqual({
+      _avg: { age: 30 },
+    });
+  });
+
+  test("where + _count 指定は従来どおり集計する", () => {
+    const users = usersController();
+    expect(
+      users.aggregate({ where: { age: 20 }, _count: { id: true } }),
+    ).toEqual({ _count: { id: 1 } });
+  });
+
+  test("空の集計指定が混ざっていても、有効な集計指定があればエラーにしない", () => {
+    const users = usersController();
+    expect(users.aggregate({ _avg: {}, _count: { age: true } })).toEqual({
+      _avg: {},
+      _count: { age: 3 },
+    });
+  });
+});
+
+describe("aggregate: Select 型を通らない値の実行時挙動", () => {
+  test("_count: true は従来どおり { _count: {} } を返しエラーにしない", () => {
+    const users = usersController();
+    // @ts-expect-error Select 型は true を受け付けない
+    expect(users.aggregate({ _count: true })).toEqual({ _count: {} });
+  });
+
+  test("where + _count: true も従来どおりエラーにしない", () => {
+    const users = usersController();
+    // @ts-expect-error Select 型は true を受け付けない
+    expect(users.aggregate({ where: { age: 20 }, _count: true })).toEqual({
+      _count: {},
+    });
+  });
+
+  test("_count: false は集計指定なしと同じ扱いでエラー", () => {
+    const users = usersController();
+    // @ts-expect-error Select 型は false を受け付けない
+    expect(() => users.aggregate({ _count: false })).toThrow(
+      GassmaAggregateSelectionRequiredError,
+    );
+  });
+});

--- a/src/__test__/util/omittedArguments.test.ts
+++ b/src/__test__/util/omittedArguments.test.ts
@@ -1,3 +1,4 @@
+import { GassmaAggregateSelectionRequiredError } from "../../errors/aggregate/aggregateError";
 import { GassmaMissingArgumentError } from "../../errors/argument/argumentError";
 import { NotFoundError } from "../../errors/find/findError";
 import {
@@ -152,9 +153,11 @@ describe("引数なし呼び出し: 必須引数は GassmaMissingArgumentError �
 });
 
 describe("引数なし呼び出し: aggregate は {} と同じ扱い", () => {
-  test("aggregate() は {} を返す", () => {
+  test("aggregate() は集計指定が無いとして throw する", () => {
     const users = usersController();
     // @ts-expect-error 引数必須のまま
-    expect(users.aggregate()).toEqual({});
+    expect(() => users.aggregate()).toThrow(
+      GassmaAggregateSelectionRequiredError,
+    );
   });
 });

--- a/src/errors/aggregate/aggregateError.ts
+++ b/src/errors/aggregate/aggregateError.ts
@@ -49,6 +49,15 @@ class GassmaAggregateAvgTypeError extends GassmaAggregateSumTypeError {
   }
 }
 
+class GassmaAggregateSelectionRequiredError extends Error {
+  constructor() {
+    super(
+      "At least one aggregation is required: specify `_avg`, `_count`, `_max`, `_min`, or `_sum` with at least one field.",
+    );
+    this.name = "GassmaAggregateSelectionRequiredError";
+  }
+}
+
 export {
   GassmaAggregateMaxError,
   GassmaAggregateMinError,
@@ -57,4 +66,5 @@ export {
   GassmaAggregateTypeError,
   GassmaAggregateSumTypeError,
   GassmaAggregateAvgTypeError,
+  GassmaAggregateSelectionRequiredError,
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -659,6 +659,9 @@ declare namespace Gassma {
   class GassmaAggregateAvgTypeError extends GassmaAggregateSumTypeError {
     constructor();
   }
+  class GassmaAggregateSelectionRequiredError extends Error {
+    constructor();
+  }
   class GassmaRelationNotFoundError extends Error {
     constructor(relationName: string, sheetName: string);
   }

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -106,6 +106,8 @@ export const GassmaAggregateSumTypeError =
   aggregateErrors.GassmaAggregateSumTypeError;
 export const GassmaAggregateAvgTypeError =
   aggregateErrors.GassmaAggregateAvgTypeError;
+export const GassmaAggregateSelectionRequiredError =
+  aggregateErrors.GassmaAggregateSelectionRequiredError;
 
 export const GassmaRelationNotFoundError =
   relationErrors.GassmaRelationNotFoundError;

--- a/src/util/aggregate/aggregate.ts
+++ b/src/util/aggregate/aggregate.ts
@@ -7,11 +7,14 @@ import { getCount } from "./aggregateUtil/count";
 import { getMax } from "./aggregateUtil/max";
 import { getMin } from "./aggregateUtil/min";
 import { getSum } from "./aggregateUtil/sum";
+import { ensureAggregateSelection } from "./ensureAggregateSelection";
 
 const aggregateFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
   aggregateData: AggregateData,
 ) => {
+  ensureAggregateSelection(aggregateData);
+
   const where = aggregateData.where ?? {};
   const orderBy = "orderBy" in aggregateData ? aggregateData.orderBy : null;
   const take = "take" in aggregateData ? aggregateData.take : null;

--- a/src/util/aggregate/ensureAggregateSelection.ts
+++ b/src/util/aggregate/ensureAggregateSelection.ts
@@ -1,0 +1,27 @@
+import { GassmaAggregateSelectionRequiredError } from "../../errors/aggregate/aggregateError";
+import type { AggregateData } from "../../types/aggregateType";
+
+const aggregateKeys: (keyof AggregateData)[] = [
+  "_avg",
+  "_count",
+  "_max",
+  "_min",
+  "_sum",
+];
+
+const hasSelectedField = (value: unknown): boolean => {
+  if (value === true) return true;
+  if (typeof value !== "object" || value === null) return false;
+  return Object.keys(value).length > 0;
+};
+
+const ensureAggregateSelection = (aggregateData: AggregateData): void => {
+  const selected = aggregateKeys.some((key) =>
+    hasSelectedField(aggregateData[key]),
+  );
+  if (selected) return;
+
+  throw new GassmaAggregateSelectionRequiredError();
+};
+
+export { ensureAggregateSelection };


### PR DESCRIPTION
## 直す差異

#182 で残した「唯一の既知の差異」です。**`aggregate({})` が `{}` を返していました**が、Prisma はエラーにします。

## Prisma の正確な境界(実測)

| 引数 | Prisma | before | **after** |
|---|---|---|---|
| `{}` | ❌ | `{}` | **throw** |
| `{ where }` だけ | ❌ | `{}` | **throw** |
| `{ orderBy }` だけ | ❌ | `{}` | **throw** |
| `{ take: 1 }` だけ | ❌ | `{}` | **throw** |
| **`{ _count: {} }`**(中身が空) | ❌ | `{"_count":{}}` | **throw** |
| `{ _count: { id: true } }` | ✅ | 集計結果 | **不変** |
| `{ _avg: { age: true } }` | ✅ | 集計結果 | **不変** |
| `{ where, _count }` | ✅ | 集計結果 | **不変** |

**絞り込みだけでは足りず、`_avg` / `_count` / `_max` / `_min` / `_sum` のいずれかがフィールドを指していることが必要**です。中身が空の集計キーも却下されます。

## エラー

```
GassmaAggregateSelectionRequiredError
"At least one aggregation is required: specify `_avg`, `_count`, `_max`, `_min`, or `_sum` with at least one field."
```

`GassmaMissingArgumentError` は「Argument \`X\` is missing.」という**単一の引数名を前提とした形式**で「5つのうちどれか + 中身も必要」を表現できないため、既に存在する aggregate 専用のエラー群に新設しました。

**検証はシートを読む前**に走るので、何も返せない呼び出しに往復コストがかかりません。

## CLI の生成型は変更不要です

**Prisma は型ではなく実行時で強制しています。** 生成型を確認したところ、集計キーはすべて任意でした:

```ts
_count?: true | TestCountAggregateInputType
_avg?: TestAvgAggregateInputType
```

つまり Prisma でも `aggregate({})` は**型を通って実行時に落ちます**。GASsma もそれに揃えました。

## 変わらないもの

- **集計指定がある呼び出しはすべて不変**。空の指定が混ざっていても、有効な指定が1つでもあれば従来どおりです(`{_avg: {}, _count: {age: true}}` → `{"_avg":{},"_count":{"age":3}}`)
- **`groupBy` は別経路**なので影響しません(`aggregateFunc` の呼び出し元はコントローラ1箇所のみで、`groupBy` は `getAggregate` を使うことを確認済み)

## 既存テスト1件を更新しました

`omittedArguments.test.ts` の「`aggregate()` は `{}` を返す」は、**#182 で追加したばかりのもの**で、まさに今回変える挙動を固定していました。`GassmaAggregateSelectionRequiredError` を投げることを期待する形に更新しています(引数が必須である `@ts-expect-error` の部分はそのまま維持)。

## スコープ外(報告のみ)

**`_count: true` は GASsma の型を通りません**(`Type 'boolean' is not assignable to type 'Select'`)。Prisma は受け付けます。サポート追加は仕様追加になるため触っていません。実行時は従来どおり有効な指定として扱うので、**Prisma が受け付けるものを新たに拒否することはありません**。

## 検証

- `npx jest`: **2073 passed**(既存2059は無変更、新規13、更新1)
- 上の8ケースすべてを私自身でも実行して Prisma と一致することを確認
- `tsc` clean / `build` 成功 / **`verify:bundle` OK(公開シンボル 54 → **55**、増分は新エラー1件のみ)**
- `biome`: 新規3ファイルは診断ゼロ。`publicApi.ts` の指摘は origin/main と同数の既存分

🤖 Generated with [Claude Code](https://claude.com/claude-code)