### PR TITLE
perf: containsValue を Set 化してリレーション全経路を線形化

### DIFF
--- a/src/__test__/util/find/whereInReusedArray.test.ts
+++ b/src/__test__/util/find/whereInReusedArray.test.ts
@@ -1,0 +1,62 @@
+import { findManyFunc } from "../../../util/find/findMany";
+import { getExtendedMockControllerUtil } from "../../consts/mockControllerUtil";
+
+const names = (result: Record<string, unknown>[]): unknown[] =>
+  result.map((r) => r["名前"]).sort();
+
+describe("クエリを跨いで使い回した in 配列の in-place 変更", () => {
+  test("同 length で書き換えた値が次のクエリに反映される(in)", () => {
+    const addresses = ["Tokyo", "Kyoto"];
+
+    const first = findManyFunc(getExtendedMockControllerUtil(), {
+      where: { 住所: { in: addresses } },
+    });
+    expect(names(first)).toEqual([
+      "Alice",
+      "Charlie",
+      "David",
+      "Eve",
+      "Grace",
+      "Henry",
+    ]);
+
+    addresses[0] = "Osaka";
+
+    const second = findManyFunc(getExtendedMockControllerUtil(), {
+      where: { 住所: { in: addresses } },
+    });
+    expect(names(second)).toEqual(["Bob", "David", "Frank", "Henry"]);
+  });
+
+  test("同 length で書き換えた値が次のクエリに反映される(notIn)", () => {
+    const addresses = ["Tokyo", "Kyoto"];
+
+    const first = findManyFunc(getExtendedMockControllerUtil(), {
+      where: { 住所: { notIn: addresses } },
+    });
+    expect(names(first)).toEqual(["Bob", "Frank"]);
+
+    addresses[0] = "Osaka";
+
+    const second = findManyFunc(getExtendedMockControllerUtil(), {
+      where: { 住所: { notIn: addresses } },
+    });
+    expect(names(second)).toEqual(["Alice", "Charlie", "Eve", "Grace"]);
+  });
+
+  test("AND 内の in 配列の in-place 変更も次のクエリに反映される", () => {
+    const addresses = ["Tokyo", "Kyoto"];
+
+    const first = findManyFunc(getExtendedMockControllerUtil(), {
+      where: { AND: [{ 住所: { in: addresses } }, { 年齢: { gte: 30 } }] },
+    });
+    expect(names(first)).toEqual(["David", "Grace"]);
+
+    addresses[0] = "Osaka";
+
+    const second = findManyFunc(getExtendedMockControllerUtil(), {
+      where: { AND: [{ 住所: { in: addresses } }, { 年齢: { gte: 30 } }] },
+    });
+    expect(names(second)).toEqual(["Bob", "David", "Frank"]);
+  });
+});

--- a/src/__test__/util/groupby/groupbyUtil/having.test.ts
+++ b/src/__test__/util/groupby/groupbyUtil/having.test.ts
@@ -542,3 +542,31 @@ describe("groupByFunc with having clause", () => {
     });
   });
 });
+
+describe("having で使い回した in 配列の in-place 変更", () => {
+  test("同 length で書き換えた値が次のクエリに反映される", () => {
+    const counts = [4, 99];
+
+    const first = groupByFunc(getExtendedMockControllerUtil(), {
+      by: "住所",
+      having: { 名前: { _count: { in: counts } } },
+      _count: { 名前: true },
+    });
+    expectArrayToEqualIgnoringOrder(first, [
+      { 住所: "Tokyo", _count: { 名前: 4 } },
+    ]);
+
+    counts[1] = 2;
+
+    const second = groupByFunc(getExtendedMockControllerUtil(), {
+      by: "住所",
+      having: { 名前: { _count: { in: counts } } },
+      _count: { 名前: true },
+    });
+    expectArrayToEqualIgnoringOrder(second, [
+      { 住所: "Tokyo", _count: { 名前: 4 } },
+      { 住所: "Osaka", _count: { 名前: 2 } },
+      { 住所: "Kyoto", _count: { 名前: 2 } },
+    ]);
+  });
+});

--- a/src/__test__/util/other/isValueEqual.test.ts
+++ b/src/__test__/util/other/isValueEqual.test.ts
@@ -2,7 +2,11 @@ import {
   createCrossRealmDate,
   createCrossRealmValue,
 } from "../../consts/crossRealm";
-import { containsValue, isValueEqual } from "../../../util/other/isValueEqual";
+import {
+  containsValue,
+  isValueEqual,
+  resetMembershipCache,
+} from "../../../util/other/isValueEqual";
 
 describe("isValueEqual", () => {
   test("should return true for Dates with the same time but different instances", () => {
@@ -110,6 +114,148 @@ describe("containsValue", () => {
     expect(containsValue(["a", "b"], "a")).toBe(true);
     expect(containsValue([1, 2], 3)).toBe(false);
     expect(containsValue([Number.NaN], Number.NaN)).toBe(true);
+  });
+});
+
+describe("containsValue の旧実装との同値性(境界値総当たり)", () => {
+  const oldContainsValue = (
+    list: readonly unknown[],
+    value: unknown,
+  ): boolean =>
+    list.includes(value) || list.some((item) => isValueEqual(item, value));
+
+  const d1a = new Date("2026-01-01T00:00:00.000Z");
+  const d1b = new Date("2026-01-01T00:00:00.000Z");
+  const d2 = new Date("2026-01-02T00:00:00.000Z");
+  const invalid1 = new Date("invalid");
+  const invalid2 = new Date("invalid");
+  const crossD1 = createCrossRealmDate("2026-01-01T00:00:00.000Z");
+  const obj = { key: "value" };
+  const boundaryValues: readonly unknown[] = [
+    Number.NaN,
+    0,
+    -0,
+    null,
+    undefined,
+    "",
+    "0",
+    "1",
+    1,
+    true,
+    false,
+    "2026-01-01T00:00:00.000Z",
+    d1a,
+    d1b,
+    d2,
+    invalid1,
+    invalid2,
+    `date:${d1a.getTime()}`,
+    "str:1",
+    obj,
+    crossD1,
+  ];
+
+  test("1要素リスト×全境界値の総当たりで旧実装と一致する", () => {
+    boundaryValues.forEach((listValue) => {
+      boundaryValues.forEach((probe) => {
+        expect(containsValue([listValue], probe)).toBe(
+          oldContainsValue([listValue], probe),
+        );
+      });
+    });
+  });
+
+  test("全境界値リストに対する判定が旧実装と一致する", () => {
+    boundaryValues.forEach((probe) => {
+      expect(containsValue(boundaryValues, probe)).toBe(
+        oldContainsValue(boundaryValues, probe),
+      );
+    });
+  });
+
+  test("空配列では常に false", () => {
+    boundaryValues.forEach((probe) => {
+      expect(containsValue([], probe)).toBe(false);
+    });
+  });
+
+  test("巨大配列でも旧実装と一致する", () => {
+    const bigList: unknown[] = [];
+    for (let i = 0; i < 5000; i++) {
+      bigList.push(`key${i}`, i, new Date(1700000000000 + i));
+    }
+    const probes = [
+      "key4999",
+      "missing",
+      4999,
+      5000,
+      new Date(1700000004999),
+      new Date(1700000005000),
+      Number.NaN,
+      null,
+    ];
+    probes.forEach((probe) => {
+      expect(containsValue(bigList, probe)).toBe(
+        oldContainsValue(bigList, probe),
+      );
+    });
+  });
+});
+
+describe("containsValue は同一配列のミューテーション後も正しい", () => {
+  test("push で追加した値を見つけられる(by.ts の重複除去パターン)", () => {
+    const list: unknown[] = [];
+    expect(containsValue(list, "a")).toBe(false);
+    list.push("a");
+    expect(containsValue(list, "a")).toBe(true);
+    expect(containsValue(list, "b")).toBe(false);
+    list.push("b");
+    expect(containsValue(list, "b")).toBe(true);
+  });
+
+  test("splice で削除した値は見つからない", () => {
+    const list: unknown[] = ["a", "b"];
+    expect(containsValue(list, "a")).toBe(true);
+    list.splice(0, 1);
+    expect(containsValue(list, "a")).toBe(false);
+    expect(containsValue(list, "b")).toBe(true);
+  });
+
+  test("push した Date も時刻一致で見つけられる", () => {
+    const list: unknown[] = [new Date("2026-01-01T00:00:00.000Z")];
+    expect(containsValue(list, new Date("2026-01-02T00:00:00.000Z"))).toBe(
+      false,
+    );
+    list.push(new Date("2026-01-02T00:00:00.000Z"));
+    expect(containsValue(list, new Date("2026-01-02T00:00:00.000Z"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("resetMembershipCache", () => {
+  test("リセット後は同 length の in-place 変更が反映される", () => {
+    const list: unknown[] = [1, 2, 3];
+    expect(containsValue(list, 1)).toBe(true);
+    list[0] = 99;
+    resetMembershipCache();
+    expect(containsValue(list, 99)).toBe(true);
+    expect(containsValue(list, 1)).toBe(false);
+  });
+
+  test("リセット後は同 length で入れ替えた Date も時刻一致で判定される", () => {
+    const list: unknown[] = [new Date("2026-01-01T00:00:00.000Z")];
+    expect(containsValue(list, new Date("2026-01-01T00:00:00.000Z"))).toBe(
+      true,
+    );
+    list[0] = new Date("2026-02-01T00:00:00.000Z");
+    resetMembershipCache();
+    expect(containsValue(list, new Date("2026-02-01T00:00:00.000Z"))).toBe(
+      true,
+    );
+    expect(containsValue(list, new Date("2026-01-01T00:00:00.000Z"))).toBe(
+      false,
+    );
   });
 });
 

--- a/src/util/core/filterRowsByWhere.ts
+++ b/src/util/core/filterRowsByWhere.ts
@@ -7,7 +7,7 @@ import type { HitRowData } from "../../types/hitRowDataType";
 import { isLogicMatch } from "../andOrNot/entry";
 import { matchFilterCondition } from "../filterConditions/matchFilterCondition";
 import { isDict } from "../other/isDict";
-import { isValueEqual } from "../other/isValueEqual";
+import { isValueEqual, resetMembershipCache } from "../other/isValueEqual";
 import { getWantFindIndexFromTitles } from "./getWantFindIndex";
 
 const filterRowsByWhere = (
@@ -15,6 +15,7 @@ const filterRowsByWhere = (
   titles: GassmaAny[],
   where: WhereUse,
 ): HitRowData[] => {
+  resetMembershipCache();
   if (Object.keys(where).length === 0) {
     return allDataList.map((row, index): HitRowData => {
       return {

--- a/src/util/groupby/groubyUtil/having/normalHavingFilter.ts
+++ b/src/util/groupby/groubyUtil/having/normalHavingFilter.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../../../types/coreTypes";
 import { isFilterConditionsMatch } from "../../../filterConditions/filterConditions";
 import { isDict } from "../../../other/isDict";
+import { resetMembershipCache } from "../../../other/isValueEqual";
 import { getAggregate } from "../getAggregate";
 import { notPatternFilter } from "./normalHavingFilter/notPatternFilter";
 
@@ -37,6 +38,7 @@ const normalHaving = (
   havingData: HavingUse,
   by: string[],
 ) => {
+  resetMembershipCache();
   const byClassificationedRowWithoutPattern = notPatternFilter(
     byClassificationedRow,
     havingData,

--- a/src/util/other/isValueEqual.ts
+++ b/src/util/other/isValueEqual.ts
@@ -1,4 +1,5 @@
 import { isDateValue } from "./isDateValue";
+import { toLookupKey } from "./toLookupKey";
 
 const isValueEqual = (a: unknown, b: unknown): boolean => {
   if (isDateValue(a) && isDateValue(b)) {
@@ -7,7 +8,33 @@ const isValueEqual = (a: unknown, b: unknown): boolean => {
   return a === b;
 };
 
-const containsValue = (list: readonly unknown[], value: unknown): boolean =>
-  list.includes(value) || list.some((item) => isValueEqual(item, value));
+// Invalid Date は getTime() が NaN で正規化キーが衝突するため参照そのものをキーにする
+const toMembershipKey = (value: unknown): unknown =>
+  isDateValue(value) && Number.isNaN(value.getTime())
+    ? value
+    : toLookupKey(value);
 
-export { containsValue, isValueEqual };
+type MembershipEntry = { length: number; keys: Set<unknown> };
+
+let membershipCache = new WeakMap<readonly unknown[], MembershipEntry>();
+
+// フィルタパス起点で呼び、キャッシュ寿命を1パスに閉じる(パス跨ぎの stale 防止)
+const resetMembershipCache = (): void => {
+  membershipCache = new WeakMap();
+};
+
+const getMembershipKeys = (list: readonly unknown[]): Set<unknown> => {
+  const cached = membershipCache.get(list);
+  if (cached && cached.length === list.length) return cached.keys;
+  const keys = new Set<unknown>();
+  list.forEach((item) => {
+    keys.add(toMembershipKey(item));
+  });
+  membershipCache.set(list, { length: list.length, keys });
+  return keys;
+};
+
+const containsValue = (list: readonly unknown[], value: unknown): boolean =>
+  getMembershipKeys(list).has(toMembershipKey(value));
+
+export { containsValue, isValueEqual, resetMembershipCache };


### PR DESCRIPTION
計算量調査の推奨着手順 **2番目**。1関数の修正で、リレーション解決の全経路が O(親 × 子) から線形になります。

## 問題

`containsValue` が配列を**二重走査**していました。

```ts
const containsValue = (list, value) =>
  list.includes(value) || list.some((item) => isValueEqual(item, value));
```

`includes` は参照比較なので Date では**必ず外れ**、`some` でもう一周します。この関数は `{in: collectKeys(...)}` を経由して以下の全経路が踏みます。

- `include` 全4種 / `_count` 全4経路
- `where` のリレーション条件(`some` / `none` / `is` / `isNot`)
- リレーション `orderBy` / `onDelete`・`onUpdate` カスケード

`collectKeys` は重複除去をしないため、配列長は親の件数そのものです。

> [!NOTE]
> 数値キーは V8 のベクトル化で二次の挙動が隠れます。**文字列キー・Date キー・ミスが多い経路**で顕在化します。

## 修正

配列から正規化キーの `Set` を一度だけ構築し、以降は O(1) の `has` で判定します。

### Invalid Date は参照でキー化

`toLookupKey` は Date を `date:${getTime()}` に正規化しますが、**Invalid Date は `getTime()` が `NaN` なので全インスタンスが `date:NaN` に潰れます**。旧実装では別インスタンスの Invalid Date は等しくない(`NaN === NaN` が false)ため、そのまま使うと挙動が変わります。Invalid Date のみ参照そのものをキーにして旧挙動を保存しました。

### キャッシュ寿命は「1回のフィルタパス」

配列の identity をキーにクエリを跨いでキャッシュすると、利用者が同じ配列を同 length で in-place 変更したときに **stale な結果が静かに返る**問題がありました。

```js
const ids = [1, 2, 3];
gassma.User.findMany({ where: { id: { in: ids } } });
ids[0] = 99;                                        // 同 length・in-place
gassma.User.findMany({ where: { id: { in: ids } } }); // 99 が効かない
```

`filterRowsByWhere` と `normalHaving` の入口でキャッシュを世代交代させ、寿命を1パスに閉じました。二次の爆発は「1パス内で N 行 × 同じ配列」で起きるため、**この変更で性能の利得は失われません**(下表)。利用者の配列が `containsValue` に到達する経路はこの2つの起点配下のみで、パス中は同期実行のため配列が変更される余地もありません。

## 性能実測(N=16,000、best of 3)

| 経路 | 修正前 | 修正後 |
|---|---|---|
| `include` manyToOne(文字列キー) | 118.9ms | **7.1ms**(16.7x) |
| `where` some | 118.9ms | **6.2ms**(19.2x) |
| `where` isNot | 125.5ms | **5.4ms**(23.2x) |
| 単体・文字列全ミス | 1555.5ms | **1.0ms** |

N=2,000 → 16,000(8倍)で 1.1ms → 7.1ms と線形性も確認しています。

## 挙動不変の検証

- **既存テストは全て無変更で green**
- 旧実装をコピーした同値性テストで、境界値21種(NaN / 0・-0 / null / undefined / `""` / `"0"`・`"1"`・`1` / 真偽値 / ISO 文字列 / 同時刻の別 Date インスタンス / 別の Date / Invalid Date 2件 / `"date:<epoch>"`・`"str:1"` の衝突狙い文字列 / オブジェクト参照 / クロス realm Date)の **21 × 21 総当たり**と、15,000 要素の混在配列で新旧完全一致
- テスト数 2073 → **2086**(+13)。うち in-place 変更が次のクエリに反映されることの検証を `in` / `notIn` / `AND` 内 / `having` の4経路で追加
- `npm test`(168 suites / 2086 tests)/ `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル55件)すべて pass

## 見送った項目

`collectKeys` の重複除去は**今回見送り**ました。Set 化によって重複要素のコストがほぼ消え、実益が Set 構築コストの微減だけになった一方、重複した `in` 配列をホワイトボックスに検証している既存テスト3件の期待値変更が必要になるためです。別タスクとして記録しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)