### PR TITLE
perf: onUpdate Cascade の順序解決を O(P³) から線形に

### DIFF
--- a/src/__test__/util/relation/onUpdate/cascadeUpdatePlan.test.ts
+++ b/src/__test__/util/relation/onUpdate/cascadeUpdatePlan.test.ts
@@ -147,6 +147,92 @@ describe("buildCascadeSteps", () => {
     expect(factory).toHaveBeenCalledTimes(1);
   });
 
+  it("別インスタンスの Invalid Date の旧値は別グループとして残る", () => {
+    const invalidA = new Date("invalid");
+    const invalidB = new Date("invalid");
+    const factory = makeTempFactory();
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: invalidA, newValue: 1 },
+        { oldValue: invalidB, newValue: 2 },
+      ],
+      factory,
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [invalidA], newValue: 1 },
+      { oldValues: [invalidB], newValue: 2 },
+    ]);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("Invalid Date の新値は同一インスタンスでも併合されない", () => {
+    const invalidA = new Date("invalid");
+    const invalidB = new Date("invalid");
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: invalidA },
+        { oldValue: 2, newValue: invalidA },
+        { oldValue: 3, newValue: invalidB },
+      ],
+      makeTempFactory(),
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [1], newValue: invalidA },
+      { oldValues: [2], newValue: invalidA },
+      { oldValues: [3], newValue: invalidB },
+    ]);
+  });
+
+  it("後段グループの実行で解けた先頭グループは他の未処理グループより先に実行される", () => {
+    const factory = makeTempFactory();
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: 2 },
+        { oldValue: 2, newValue: 3 },
+        { oldValue: 9, newValue: 10 },
+      ],
+      factory,
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [2], newValue: 3 },
+      { oldValues: [1], newValue: 2 },
+      { oldValues: [9], newValue: 10 },
+    ]);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("複数の循環は先頭側から順に一時値で解決し書き戻しはまとめて最後に回る", () => {
+    const factory = makeTempFactory();
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: 2 },
+        { oldValue: 2, newValue: 1 },
+        { oldValue: 10, newValue: 11 },
+        { oldValue: 11, newValue: 12 },
+        { oldValue: 12, newValue: 10 },
+      ],
+      factory,
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [1], newValue: "tmp0" },
+      { oldValues: [2], newValue: 1 },
+      { oldValues: [10], newValue: "tmp1" },
+      { oldValues: [12], newValue: 10 },
+      { oldValues: [11], newValue: 12 },
+      { oldValues: ["tmp0"], newValue: 2 },
+      { oldValues: ["tmp1"], newValue: 11 },
+    ]);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
   it("どのステップも oldValues が空にならない", () => {
     const scenarios: ChangedPair[][] = [
       [],

--- a/src/util/relation/onUpdate/cascadeUpdatePlan.ts
+++ b/src/util/relation/onUpdate/cascadeUpdatePlan.ts
@@ -1,5 +1,6 @@
 import type { GassmaAny } from "../../../types/coreTypes";
-import { containsValue, isValueEqual } from "../../other/isValueEqual";
+import { isDateValue } from "../../other/isDateValue";
+import { toLookupKey } from "../../other/toLookupKey";
 
 type ChangedPair = {
   oldValue: GassmaAny;
@@ -11,49 +12,130 @@ type CascadeStep = {
   newValue: GassmaAny;
 };
 
+const isNaNValue = (value: GassmaAny): boolean =>
+  typeof value === "number" && Number.isNaN(value);
+
+const isInvalidDateValue = (value: GassmaAny): boolean =>
+  isDateValue(value) && Number.isNaN(value.getTime());
+
+const toPlanKey = (value: GassmaAny): unknown =>
+  isInvalidDateValue(value) ? value : toLookupKey(value);
+
 const groupPairsByNewValue = (pairs: ChangedPair[]): CascadeStep[] => {
   const groups: CascadeStep[] = [];
-  const seenOldValues: GassmaAny[] = [];
+  const seenOldKeys = new Set<unknown>();
+  const groupByNewKey = new Map<unknown, CascadeStep>();
   pairs.forEach(({ oldValue, newValue }) => {
-    if (containsValue(seenOldValues, oldValue)) return;
-    seenOldValues.push(oldValue);
-    const group = groups.find((g) => isValueEqual(g.newValue, newValue));
+    const oldKey = toPlanKey(oldValue);
+    if (seenOldKeys.has(oldKey)) return;
+    seenOldKeys.add(oldKey);
+    const mergeable = !(isNaNValue(newValue) || isInvalidDateValue(newValue));
+    const group = mergeable
+      ? groupByNewKey.get(toPlanKey(newValue))
+      : undefined;
     if (group) {
       group.oldValues.push(oldValue);
       return;
     }
-    groups.push({ oldValues: [oldValue], newValue });
+    const created: CascadeStep = { oldValues: [oldValue], newValue };
+    groups.push(created);
+    if (mergeable) groupByNewKey.set(toPlanKey(newValue), created);
   });
   return groups;
 };
 
-const isBlocked = (group: CascadeStep, pending: CascadeStep[]): boolean =>
-  pending.some(
-    (other) =>
-      other !== group && containsValue(other.oldValues, group.newValue),
-  );
+const createIndexMinHeap = () => {
+  const heap: number[] = [];
+  const swap = (a: number, b: number): void => {
+    const tmp = heap[a];
+    heap[a] = heap[b];
+    heap[b] = tmp;
+  };
+  const push = (value: number): void => {
+    heap.push(value);
+    let i = heap.length - 1;
+    while (i > 0) {
+      const parent = (i - 1) >> 1;
+      if (heap[parent] <= heap[i]) break;
+      swap(parent, i);
+      i = parent;
+    }
+  };
+  const pop = (): number | undefined => {
+    if (heap.length === 0) return undefined;
+    const top = heap[0];
+    const last = heap.pop();
+    if (heap.length === 0 || last === undefined) return top;
+    heap[0] = last;
+    let i = 0;
+    let smallest = 0;
+    do {
+      i = smallest;
+      const left = i * 2 + 1;
+      const right = left + 1;
+      if (left < heap.length && heap[left] < heap[smallest]) smallest = left;
+      if (right < heap.length && heap[right] < heap[smallest]) smallest = right;
+      if (smallest !== i) swap(i, smallest);
+    } while (smallest !== i);
+    return top;
+  };
+  return { push, pop };
+};
+
+const buildBlockerGraph = (groups: CascadeStep[]) => {
+  const ownerByOldKey = new Map<unknown, number>();
+  groups.forEach((group, index) => {
+    group.oldValues.forEach((value) => {
+      ownerByOldKey.set(toPlanKey(value), index);
+    });
+  });
+  const childIndexes: number[][] = groups.map(() => []);
+  const ready = createIndexMinHeap();
+  groups.forEach((group, index) => {
+    const blocker = ownerByOldKey.get(toPlanKey(group.newValue));
+    if (blocker === undefined || blocker === index) {
+      ready.push(index);
+      return;
+    }
+    childIndexes[blocker].push(index);
+  });
+  return { childIndexes, ready };
+};
 
 const buildCascadeSteps = (
   pairs: ChangedPair[],
   nextTempValue: () => GassmaAny,
 ): CascadeStep[] => {
-  const pending = groupPairsByNewValue(pairs);
+  const groups = groupPairsByNewValue(pairs);
+  const { childIndexes, ready } = buildBlockerGraph(groups);
   const steps: CascadeStep[] = [];
   const deferred: CascadeStep[] = [];
-
-  while (pending.length > 0) {
-    const index = pending.findIndex((group) => !isBlocked(group, pending));
-    if (index >= 0) {
-      steps.push(pending[index]);
-      pending.splice(index, 1);
+  const done: boolean[] = groups.map(() => false);
+  const finish = (index: number): void => {
+    done[index] = true;
+    childIndexes[index].forEach((child) => {
+      ready.push(child);
+    });
+  };
+  let cursor = 0;
+  let remaining = groups.length;
+  while (remaining > 0) {
+    const index = ready.pop();
+    if (index !== undefined) {
+      if (done[index]) continue;
+      steps.push(groups[index]);
+      finish(index);
+      remaining -= 1;
       continue;
     }
-    const [cyclic] = pending.splice(0, 1);
+    while (done[cursor]) cursor += 1;
+    const cyclic = groups[cursor];
     const tempValue = nextTempValue();
     steps.push({ oldValues: cyclic.oldValues, newValue: tempValue });
     deferred.push({ oldValues: [tempValue], newValue: cyclic.newValue });
+    finish(cursor);
+    remaining -= 1;
   }
-
   return steps.concat(deferred);
 };
 


### PR DESCRIPTION
計算量調査の推奨着手順 **1番目**。調査で見つかった中で**唯一の三次**で、しかも #174 で自分たちが入れたコードです。

## 問題

`src/util/relation/onUpdate/cascadeUpdatePlan.ts` の `buildCascadeSteps` が O(P³) でした(P = 変更ペア数)。

```ts
while (pending.length > 0) {                                       // P 回
  const index = pending.findIndex((group) => !isBlocked(group, pending));  // P 走査
  //                                          isBlocked の中で some(P 走査)
```

`id + 1` のような再採番では毎回末尾しか実行可能にならず、最悪ケースを常に踏みます。同ファイルの `groupPairsByNewValue` も、連鎖が無くても常時 O(P²)(`containsValue` + `groups.find`)でした。

発火条件は **`onUpdate: Cascade` の親キーを数百〜数千行まとめてずらす更新**です。#174 の設計(グループ化 + 順序付け + 循環時の一時値)自体は正しく、**実装が線形走査だったこと**が原因です。

## 修正

1. **グループ化**: 旧値の dedupe を `Set`、新値によるグループ併合を `Map` に置換
2. **依存グラフ**: 旧値はグループ間で重複しないため、**各グループのブロッカーは高々1つ**(in-degree ≤ 1)。旧値 → グループ index の Map から一発で構築
3. **順序決定**: index の **min-heap** を使った Kahn 法。循環時は単調前進カーソルで最小 index の残存グループを一時値化

厳密には O(P log P) ですが、実測は完全に線形です。「実行可能なうち最小 index」という旧実装の順序を厳密に再現するために優先度付きキューを選びました(順序を変えれば真の O(P) も可能ですが、**出力の完全一致を優先**しています)。

## 性能実測(`id + 1` の再採番チェーン = 旧実装の最悪ケース)

| P | 修正前 | 修正後 |
|---|---|---|
| 200 | 182ms | **0.43ms** |
| 400 | 1,402ms | **0.49ms** |
| 800 | 11,483ms | **0.80ms** |
| 1,600 | **91,737ms** | **1.54ms** |
| 3,200 | 計測打ち切り(約12分の外挿) | **2.75ms** |
| 10,000 | — | 9.53ms |
| 100,000 | — | 99.05ms |

修正前は倍化ごとに 7.7〜8.2 倍(=三次)。修正後は倍化ごとに約 1.1〜2 倍で、P=100,000 でも 99ms です。

## 挙動不変の検証

### 新旧出力の property-based 比較

旧実装をインライン化した一時テストで、**ランダム 600 ケース**を `toEqual` で比較し **600/600 完全一致**。値プールを小さくして連鎖・循環・重複を密に発生させています。

- 347 ケースが循環(一時値)を含む
- **164 ケースが Invalid Date を含む**(フレッシュインスタンスと、プール再利用による同一参照の再出現の両方)
- Date 同時刻の別インスタンス / null / boolean / NaN も混在

### 見落としやすかった2つの非対称性

いずれも旧実装の挙動を**忠実に再現**しています。

**NaN**: 旧実装は旧値 dedupe とブロック判定に `includes`(SameValueZero → `NaN` は等しい)、新値の併合に `isValueEqual`(`===` → `NaN` は等しくない)を使っており、**同じ NaN でも文脈によって扱いが違います**。Map / Set は SameValueZero なので素朴に置換すると新値側の挙動が変わるため、併合側にガードを入れています。

**Invalid Date**: `toLookupKey` は Date を `date:${getTime()}` に正規化するため、**Invalid Date は全インスタンスが `date:NaN` に潰れます**。旧実装は別インスタンスを等しくないと判定するので、そのままでは**カスケードのグループが1つ丸ごと消えて子行の更新が黙って行われません**。Invalid Date のみ参照をキーにして回避しています。さらに `isValueEqual` は**同一インスタンスの Invalid Date でも false** になるため、併合ガードも Invalid Date に拡張しました(参照キーで別インスタンスの非衝突、ガードで同一インスタンスの非併合を担保)。

`toLookupKey` 本体は変更していません(groupBy / distinct が依存しているため)。

### テスト

- **既存テストは全て無変更で green**(cascadeUpdatePlan 9件・resolveOnUpdate・cascadeUpdateOrder・cascadeTempValue を含む48件、期待値の変更ゼロ)
- テスト数 2073 → **2077**(+4)。heap 順序の回帰・複数循環の書き戻し順・Invalid Date の2ケースを恒久テストとして追加
- `npm test`(167 suites / 2077 tests)/ `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル55件)すべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)