### PR TITLE
feat: support _all and true shorthand in _count aggregation

### DIFF
--- a/src/__test__/consts/mockControllerUtil.ts
+++ b/src/__test__/consts/mockControllerUtil.ts
@@ -98,6 +98,48 @@ export const getExtendedMockControllerUtil = (): GassmaControllerUtil => ({
 // For backward compatibility
 export const extendedMockControllerUtil = getExtendedMockControllerUtil();
 
+// Function to get mock containing null values (メモ has one null, 備考 is all null)
+export const getNullableMockControllerUtil = (): GassmaControllerUtil => ({
+  sheet: {
+    getDataRange: () =>
+      ({
+        getValues: () => [
+          ["カテゴリ", "メモ", "備考"],
+          ["a", "m1", null],
+          ["a", null, null],
+          ["b", "m2", null],
+        ],
+      }) as any,
+    getLastRow: () => 4,
+    getLastColumn: () => 3,
+    getRange: (
+      row: number,
+      _col: number,
+      numRows: number,
+      _numCols: number,
+    ) => {
+      if (row === 1 && numRows === 1) {
+        // Title row request
+        return {
+          getValues: () => [["カテゴリ", "メモ", "備考"]],
+        } as any;
+      } else {
+        // Data rows request
+        return {
+          getValues: () => [
+            ["a", "m1", null],
+            ["a", null, null],
+            ["b", "m2", null],
+          ],
+        } as any;
+      }
+    },
+  } as any,
+  startRowNumber: 1,
+  startColumnNumber: 1,
+  endColumnNumber: 3,
+});
+
 // Type definition for extended mock sheet with helper methods
 interface MockSheetWithHelpers extends GoogleAppsScript.Spreadsheet.Sheet {
   _getMockData: () => any[][];

--- a/src/__test__/util/aggregate/aggregate.test.ts
+++ b/src/__test__/util/aggregate/aggregate.test.ts
@@ -1,5 +1,8 @@
 import { aggregateFunc } from "../../../util/aggregate/aggregate";
-import { getExtendedMockControllerUtil } from "../../consts/mockControllerUtil";
+import {
+  getExtendedMockControllerUtil,
+  getNullableMockControllerUtil,
+} from "../../consts/mockControllerUtil";
 
 describe("aggregate functionality tests", () => {
   describe("aggregateFunc with single statistics", () => {
@@ -382,6 +385,107 @@ describe("aggregate functionality tests", () => {
 
       expect(result).toEqual({
         _count: { 名前: 8 },
+      });
+    });
+  });
+
+  describe("aggregateFunc _count with _all", () => {
+    test("should count all rows with _all even when some values are null", () => {
+      const result = aggregateFunc(getNullableMockControllerUtil(), {
+        _count: { _all: true },
+      });
+
+      expect(result).toEqual({
+        _count: { _all: 3 },
+      });
+    });
+
+    test("should count all rows with _all even for a column whose values are all null", () => {
+      const result = aggregateFunc(getNullableMockControllerUtil(), {
+        _count: { _all: true, 備考: true },
+      });
+
+      expect(result).toEqual({
+        _count: { _all: 3, 備考: 0 },
+      });
+    });
+
+    test("should keep counting only non-null values for field selection", () => {
+      const result = aggregateFunc(getNullableMockControllerUtil(), {
+        _count: { メモ: true },
+      });
+
+      expect(result).toEqual({
+        _count: { メモ: 2 },
+      });
+    });
+
+    test("should handle _all mixed with field selection", () => {
+      const result = aggregateFunc(getNullableMockControllerUtil(), {
+        _count: { _all: true, メモ: true },
+      });
+
+      expect(result).toEqual({
+        _count: { _all: 3, メモ: 2 },
+      });
+    });
+  });
+
+  describe("aggregateFunc _count with true shorthand", () => {
+    test("should return total row count as a number", () => {
+      const result = aggregateFunc(getNullableMockControllerUtil(), {
+        _count: true,
+      });
+
+      expect(result).toEqual({
+        _count: 3,
+      });
+    });
+
+    test("should respect where condition", () => {
+      const result = aggregateFunc(getNullableMockControllerUtil(), {
+        where: { カテゴリ: "a" },
+        _count: true,
+      });
+
+      expect(result).toEqual({
+        _count: 2,
+      });
+    });
+
+    test("should not affect other aggregations", () => {
+      const result = aggregateFunc(getExtendedMockControllerUtil(), {
+        _count: true,
+        _avg: { 年齢: true },
+        _sum: { 年齢: true },
+        _max: { 年齢: true },
+        _min: { 年齢: true },
+      });
+
+      expect(result).toEqual({
+        _count: 8,
+        _avg: { 年齢: (28 + 35 + 22 + 45 + 28 + 52 + 31 + 28) / 8 },
+        _sum: { 年齢: 28 + 35 + 22 + 45 + 28 + 52 + 31 + 28 },
+        _max: { 年齢: 52 },
+        _min: { 年齢: 22 },
+      });
+    });
+  });
+
+  describe("aggregateFunc _all is special only for _count", () => {
+    test("should treat _all as a normal column for _avg/_sum/_max/_min", () => {
+      const result = aggregateFunc(getExtendedMockControllerUtil(), {
+        _avg: { _all: true },
+        _sum: { _all: true },
+        _max: { _all: true },
+        _min: { _all: true },
+      });
+
+      expect(result).toEqual({
+        _avg: { _all: null },
+        _sum: { _all: null },
+        _max: { _all: null },
+        _min: { _all: null },
       });
     });
   });

--- a/src/__test__/util/aggregate/aggregateSelectionRequired.test.ts
+++ b/src/__test__/util/aggregate/aggregateSelectionRequired.test.ts
@@ -96,24 +96,24 @@ describe("aggregate: 集計指定があれば従来どおり", () => {
   });
 });
 
-describe("aggregate: Select 型を通らない値の実行時挙動", () => {
-  test("_count: true は従来どおり { _count: {} } を返しエラーにしない", () => {
+describe("aggregate: _count の true 省略形", () => {
+  test("_count: true は全行数を数値で返す", () => {
     const users = usersController();
-    // @ts-expect-error Select 型は true を受け付けない
-    expect(users.aggregate({ _count: true })).toEqual({ _count: {} });
+    expect(users.aggregate({ _count: true })).toEqual({ _count: 3 });
   });
 
-  test("where + _count: true も従来どおりエラーにしない", () => {
+  test("where + _count: true は絞り込んだ行数を数値で返す", () => {
     const users = usersController();
-    // @ts-expect-error Select 型は true を受け付けない
     expect(users.aggregate({ where: { age: 20 }, _count: true })).toEqual({
-      _count: {},
+      _count: 1,
     });
   });
+});
 
+describe("aggregate: Select 型を通らない値の実行時挙動", () => {
   test("_count: false は集計指定なしと同じ扱いでエラー", () => {
     const users = usersController();
-    // @ts-expect-error Select 型は false を受け付けない
+    // @ts-expect-error _count は Select | true のみ受け付ける
     expect(() => users.aggregate({ _count: false })).toThrow(
       GassmaAggregateSelectionRequiredError,
     );

--- a/src/__test__/util/aggregate/aggregateUtil/count.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/count.test.ts
@@ -64,3 +64,61 @@ describe("getCount", () => {
     });
   });
 });
+
+describe("getCount with _all", () => {
+  test("should count all rows including rows with null values", () => {
+    const rows = [
+      { cat: "a", memo: "m1" },
+      { cat: "a", memo: null },
+      { cat: "b", memo: "m2" },
+    ];
+    const result = getCount(rows, { _all: true });
+
+    expect(result).toEqual({ _all: 3 });
+  });
+
+  test("should count all rows even when every value in every column is null", () => {
+    const rows = [{ memo: null }, { memo: null }, { memo: null }];
+    const result = getCount(rows, { _all: true });
+
+    expect(result).toEqual({ _all: 3 });
+  });
+
+  test("should return 0 for _all with empty rows", () => {
+    const rows: any[] = [];
+    const result = getCount(rows, { _all: true });
+
+    expect(result).toEqual({ _all: 0 });
+  });
+
+  test("should handle _all mixed with field counts", () => {
+    const rows = [
+      { cat: "a", memo: "m1" },
+      { cat: "a", memo: null },
+      { cat: "b", memo: "m2" },
+    ];
+    const result = getCount(rows, { _all: true, memo: true });
+
+    expect(result).toEqual({ _all: 3, memo: 2 });
+  });
+});
+
+describe("getCount with true shorthand", () => {
+  test("should return total row count as a number", () => {
+    const rows = [
+      { cat: "a", memo: "m1" },
+      { cat: "a", memo: null },
+      { cat: "b", memo: "m2" },
+    ];
+    const result = getCount(rows, true);
+
+    expect(result).toBe(3);
+  });
+
+  test("should return 0 as a number for empty rows", () => {
+    const rows: any[] = [];
+    const result = getCount(rows, true);
+
+    expect(result).toBe(0);
+  });
+});

--- a/src/__test__/util/groupby/groupby.test.ts
+++ b/src/__test__/util/groupby/groupby.test.ts
@@ -1,5 +1,8 @@
 import { groupByFunc } from "../../../util/groupby/groupby";
-import { getExtendedMockControllerUtil } from "../../consts/mockControllerUtil";
+import {
+  getExtendedMockControllerUtil,
+  getNullableMockControllerUtil,
+} from "../../consts/mockControllerUtil";
 import { expectArrayToEqualIgnoringOrder } from "../../helpers/matchers";
 
 describe("groupBy functionality tests", () => {
@@ -294,6 +297,72 @@ describe("groupBy functionality tests", () => {
           _avg: { 年齢: 31 },
           _count: { 名前: 1 },
         },
+      ]);
+    });
+  });
+
+  describe("groupByFunc _count with _all", () => {
+    test("should count all rows per group with _all", () => {
+      const result = groupByFunc(getNullableMockControllerUtil(), {
+        by: "カテゴリ",
+        _count: { _all: true },
+      });
+
+      expectArrayToEqualIgnoringOrder(result, [
+        { カテゴリ: "a", _count: { _all: 2 } },
+        { カテゴリ: "b", _count: { _all: 1 } },
+      ]);
+    });
+
+    test("should keep counting only non-null values for field selection per group", () => {
+      const result = groupByFunc(getNullableMockControllerUtil(), {
+        by: "カテゴリ",
+        _count: { メモ: true },
+      });
+
+      expectArrayToEqualIgnoringOrder(result, [
+        { カテゴリ: "a", _count: { メモ: 1 } },
+        { カテゴリ: "b", _count: { メモ: 1 } },
+      ]);
+    });
+
+    test("should handle _all mixed with field selection per group", () => {
+      const result = groupByFunc(getNullableMockControllerUtil(), {
+        by: "カテゴリ",
+        _count: { _all: true, メモ: true },
+      });
+
+      expectArrayToEqualIgnoringOrder(result, [
+        { カテゴリ: "a", _count: { _all: 2, メモ: 1 } },
+        { カテゴリ: "b", _count: { _all: 1, メモ: 1 } },
+      ]);
+    });
+  });
+
+  describe("groupByFunc _count with true shorthand", () => {
+    test("should return row count per group as a number", () => {
+      const result = groupByFunc(getNullableMockControllerUtil(), {
+        by: "カテゴリ",
+        _count: true,
+      });
+
+      expectArrayToEqualIgnoringOrder(result, [
+        { カテゴリ: "a", _count: 2 },
+        { カテゴリ: "b", _count: 1 },
+      ]);
+    });
+
+    test("should not affect other aggregations", () => {
+      const result = groupByFunc(getExtendedMockControllerUtil(), {
+        by: "住所",
+        _count: true,
+        _avg: { 年齢: true },
+      });
+
+      expectArrayToEqualIgnoringOrder(result, [
+        { 住所: "Tokyo", _count: 4, _avg: { 年齢: (28 + 22 + 28 + 31) / 4 } },
+        { 住所: "Osaka", _count: 2, _avg: { 年齢: (35 + 52) / 2 } },
+        { 住所: "Kyoto", _count: 2, _avg: { 年齢: (45 + 28) / 2 } },
       ]);
     });
   });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -467,7 +467,7 @@ declare namespace Gassma {
     skip?: number | SkipValue;
     cursor?: Record<string, unknown> | SkipValue;
     _avg?: Select | SkipValue;
-    _count?: Select | SkipValue;
+    _count?: Select | true | SkipValue;
     _max?: Select | SkipValue;
     _min?: Select | SkipValue;
     _sum?: Select | SkipValue;
@@ -513,7 +513,7 @@ declare namespace Gassma {
     take?: number | SkipValue;
     skip?: number | SkipValue;
     _avg?: Select | SkipValue;
-    _count?: Select | SkipValue;
+    _count?: Select | true | SkipValue;
     _max?: Select | SkipValue;
     _min?: Select | SkipValue;
     _sum?: Select | SkipValue;

--- a/src/types/aggregateType.ts
+++ b/src/types/aggregateType.ts
@@ -7,7 +7,7 @@ type AggregateData = {
   skip?: number;
   cursor?: Record<string, unknown>;
   _avg?: Select;
-  _count?: Select;
+  _count?: Select | true;
   _max?: Select;
   _min?: Select;
   _sum?: Select;

--- a/src/util/aggregate/aggregateUtil/count.ts
+++ b/src/util/aggregate/aggregateUtil/count.ts
@@ -1,11 +1,18 @@
 import type { Select } from "../../../types/coreTypes";
 
-const getCount = (rows: Record<string, any>[], avgData: Select) => {
-  const avgKeys = Object.keys(avgData);
+const getCount = (rows: Record<string, any>[], countData: Select | true) => {
+  if (countData === true) return rows.length;
+
+  const countKeys = Object.keys(countData);
 
   const countResult = {};
 
-  avgKeys.forEach((key) => {
+  countKeys.forEach((key) => {
+    if (key === "_all") {
+      countResult[key] = rows.length;
+      return;
+    }
+
     const hitCount = rows.filter((row) => {
       return row[key] !== null && row[key] !== undefined;
     }).length;


### PR DESCRIPTION
## 概要

`_count` の Prisma 未対応だった2つの形をサポートします。

| 指定 | 修正前 | 修正後(= Prisma) |
|---|---|---|
| `_count: { _all: true }` | **`{ _all: 0 }`** ❌ | **`{ _all: 3 }`**(NULL 含む全行数) |
| `_count: true` | 型が通らない ❌ | **`3`**(数値そのもの) |
| `_count: { memo: true }` | `{ memo: 2 }` | `{ memo: 2 }`(**変更なし**) |

`_all` は「`_all` という名前の列」として扱われ、そんな列は存在しないので**常に 0 を返していました**。

`aggregate` と `groupBy` の両方に効きます(`getCount` を共有しているため)。

## Prisma 実測(7.4.1)

3行のデータ(`memo` は1行が NULL)で確認しました:

```
aggregate  _count: true                   →  3
aggregate  _count: { _all: true }         →  {"_all": 3}
aggregate  _count: { memo: true }         →  {"memo": 2}      ← 非 NULL のみ
aggregate  _count: { _all: true, memo: true } → {"_all": 3, "memo": 2}
groupBy    _count: { _all: true }         →  [{_count:{_all:2}, cat:"a"}, {_count:{_all:1}, cat:"b"}]
groupBy    _count: true                   →  [{_count:2, cat:"a"}, {_count:1, cat:"b"}]
```

## `_all` と `true` は `_count` 専用です

`_avg` / `_sum` / `_max` / `_min` に渡すと Prisma はエラーになることを実測で確認しました:

```
Unknown field `_all` for select statement on model `ItemMaxAggregateOutputType`.
```

理由も明快で、`_count` は「何行あるか」を数えるので「NULL 含めて全部」に意味がある一方、他の集計は**特定の列の値**を対象にするため「全部」という対象が存在しません。

**したがって `_avg`/`_sum`/`_max`/`_min` は一切変更していません。** `_avg: { _all: true }` が従来どおり通常列扱い(`null`)になることを回帰テストで固定しています。

## 実装

本体の変更は2ファイルだけです。

`src/util/aggregate/aggregateUtil/count.ts`(26行):

```ts
const getCount = (rows, countData: Select | true) => {
  if (countData === true) return rows.length;
  // キー走査中、"_all" なら NULL を無視して行数、それ以外は従来どおり非 NULL カウント
};
```

呼び出し元(`aggregate.ts` / `groupby.ts`)は `if (count)` が `true` でも truthy なので**無変更**です。

型は `_count?: Select | true` に拡張(`_all` キーは既存の index signature で通ります)。`having` の `_count`(`NumberFilterConditions`)は対象外で変更していません。

## テスト

t-wada 流 TDD。型レベル Red → ランタイム Red(`Expected {"_all": 3} / Received {"_all": 0}`)→ Green の順で確認しています。**21ケース追加、全体2092件パス**。lint / format:check / verify:bundle すべて clean。

- `_all` が NULL 込みで行数を返す(**全値が NULL の列でも行数**になること)
- 列指定が従来どおり非 NULL のみ数える(**回帰ガード**)
- 混在 `{ _all: true, memo: true }`
- `true` 省略形が数値を返す
- groupBy でグループごとに正しく数える
- **`_avg`/`_sum`/`_max`/`_min` の挙動が変わっていないこと(回帰ガード)**

テスト用に、Prisma 実測と同一構造のモック(カテゴリ a,a,b / メモ1行 NULL / 備考が全 NULL)を追加しています。

## 既存テストの更新について

`aggregateSelectionRequired.test.ts` に「`_count: true` は型を通らず、実行時は `{ _count: {} }` を返す」という**旧挙動を固定していたテスト**があり、`@ts-expect-error` が未使用になって落ちるため新仕様のテストに書き換えました。今回の仕様変更の直接の帰結です(`_count: false` がエラーになるテストは従来どおり残しています)。

## 残作業

CLI 側の型生成の追随が必要です(別 PR):

- `_count` の入力型に `true` 省略形を許容(`true` を許すのは `_count` だけ)
- `_count` の入力オブジェクトに `_all?: true` を追加(`_avg`/`_sum`/`_max`/`_min` には**追加しない**)
- 結果型を入力に応じて分岐(`true` → `number`、オブジェクト → `{ _all?: number; ... }`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3cprMDRquLdm95Wcriyja