### PR TITLE
perf: rowNumber 照合を Set 化して AND/OR/NOT・having を線形に(#187 の main 向け出し直し)

### DIFF
--- a/src/__test__/util/aggregate/aggregateUtil/stringMaxMinTies.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/stringMaxMinTies.test.ts
@@ -1,0 +1,36 @@
+import { getStringMax } from "../../../../util/aggregate/aggregateUtil/max/stringMax";
+import { getStringMin } from "../../../../util/aggregate/aggregateUtil/min/stringMin";
+
+describe("getStringMax / getStringMin のタイブレーク", () => {
+  test("max: 同一文字列が複数あっても正しく返す", () => {
+    expect(getStringMax(["same", "same", "same"])).toBe("same");
+  });
+
+  test("min: 同一文字列が複数あっても正しく返す", () => {
+    expect(getStringMin(["same", "same", "same"])).toBe("same");
+  });
+
+  test("max: 前方一致のタイでは長い方が勝つ", () => {
+    expect(getStringMax(["ab", "abc", "a"])).toBe("abc");
+  });
+
+  test("min: 前方一致のタイでは短い方が勝つ", () => {
+    expect(getStringMin(["abc", "ab", "abcd"])).toBe("ab");
+  });
+
+  test("max: 長いタイ集合でも最後の1文字で決まる", () => {
+    expect(getStringMax(["prefix-a", "prefix-c", "prefix-b"])).toBe("prefix-c");
+  });
+
+  test("min: 長いタイ集合でも最後の1文字で決まる", () => {
+    expect(getStringMin(["prefix-b", "prefix-a", "prefix-c"])).toBe("prefix-a");
+  });
+
+  test("max: タイ集合と無関係な行の同値文字が混ざっても影響しない", () => {
+    expect(getStringMax(["zb", "az", "zc", "az"])).toBe("zc");
+  });
+
+  test("min: タイ集合と無関係な行の同値文字が混ざっても影響しない", () => {
+    expect(getStringMin(["ab", "za", "ac", "za"])).toBe("ab");
+  });
+});

--- a/src/__test__/util/andOrNot/logicMatch.test.ts
+++ b/src/__test__/util/andOrNot/logicMatch.test.ts
@@ -1,0 +1,94 @@
+import type { GassmaAny } from "../../../types/coreTypes";
+import type { HitRowData } from "../../../types/hitRowDataType";
+import { isLogicMatch } from "../../../util/andOrNot/entry";
+import { isNotMatch } from "../../../util/andOrNot/not";
+import { isOrMatch } from "../../../util/andOrNot/or";
+
+describe("andOrNot の行番号照合", () => {
+  const titles: GassmaAny[] = ["id", "name", "age"];
+  const rows: HitRowData[] = [
+    { rowNumber: 1, row: [1, "田中", 20] },
+    { rowNumber: 2, row: [2, "佐藤", 30] },
+    { rowNumber: 3, row: [3, "鈴木", 25] },
+    { rowNumber: 4, row: [4, "高橋", 30] },
+  ];
+
+  describe("isOrMatch", () => {
+    test("重複ヒットは除外され、先勝ちの順序で返す", () => {
+      const result = isOrMatch(rows, [{ age: 30 }, { id: 2 }], titles);
+
+      expect(result.map((r) => r.rowNumber)).toEqual([2, 4]);
+    });
+
+    test("後続の条件で新規ヒットした行は末尾に追加される", () => {
+      const result = isOrMatch(rows, [{ id: 3 }, { age: 30 }], titles);
+
+      expect(result.map((r) => r.rowNumber)).toEqual([3, 2, 4]);
+    });
+
+    test("3条件でも重複なく和集合になる", () => {
+      const result = isOrMatch(
+        rows,
+        [{ age: 30 }, { id: 1 }, { age: { gte: 25 } }],
+        titles,
+      );
+
+      expect(result.map((r) => r.rowNumber)).toEqual([2, 4, 1, 3]);
+    });
+
+    test("返る要素は入力と同一の参照", () => {
+      const result = isOrMatch(rows, [{ id: 2 }, { id: 4 }], titles);
+
+      expect(result[0]).toBe(rows[1]);
+      expect(result[1]).toBe(rows[3]);
+    });
+  });
+
+  describe("isNotMatch", () => {
+    test("条件にマッチした行を除いた補集合を元の順序で返す", () => {
+      const result = isNotMatch(rows, [{ age: 30 }], titles);
+
+      expect(result.map((r) => r.rowNumber)).toEqual([1, 3]);
+    });
+
+    test("複数条件は積集合の補集合になる", () => {
+      const result = isNotMatch(rows, [{ age: 30 }, { id: 2 }], titles);
+
+      expect(result.map((r) => r.rowNumber)).toEqual([1, 3, 4]);
+    });
+
+    test("何もマッチしなければ全行返す", () => {
+      const result = isNotMatch(rows, [{ id: 999 }], titles);
+
+      expect(result.map((r) => r.rowNumber)).toEqual([1, 2, 3, 4]);
+    });
+  });
+
+  describe("isLogicMatch", () => {
+    test("AND と OR の併用は積集合を OR 側の順序で返す", () => {
+      const result = isLogicMatch(
+        rows,
+        { AND: [{ age: { gte: 25 } }], OR: [{ id: 1 }, { id: 2 }] },
+        titles,
+      );
+
+      expect(result.map((r) => r.rowNumber)).toEqual([2]);
+    });
+
+    test("AND と NOT の併用は積集合を NOT 側の順序で返す", () => {
+      const result = isLogicMatch(
+        rows,
+        { AND: [{ age: { gte: 25 } }], NOT: [{ id: 4 }] },
+        titles,
+      );
+
+      expect(result.map((r) => r.rowNumber)).toEqual([2, 3]);
+    });
+
+    test("OR のみなら OR の結果をそのまま返す", () => {
+      const result = isLogicMatch(rows, { OR: [{ id: 3 }, { id: 1 }] }, titles);
+
+      expect(result.map((r) => r.rowNumber)).toEqual([3, 1]);
+    });
+  });
+});

--- a/src/__test__/util/groupby/groupbyUtil/andOrNot/logicMatchHaving.test.ts
+++ b/src/__test__/util/groupby/groupbyUtil/andOrNot/logicMatchHaving.test.ts
@@ -1,0 +1,94 @@
+import type { HitByClassificationedRowData } from "../../../../../types/coreTypes";
+import { isLogicMatchHaving } from "../../../../../util/groupby/groubyUtil/andOrNot/entry";
+import { isNotMatchHaving } from "../../../../../util/groupby/groubyUtil/andOrNot/not";
+import { isOrMatchHaving } from "../../../../../util/groupby/groubyUtil/andOrNot/or";
+
+describe("groupBy having の行番号照合", () => {
+  const by = ["住所"];
+  const groups: HitByClassificationedRowData[] = [
+    {
+      rowNumber: 1,
+      row: [
+        { 住所: "Tokyo", 年齢: 20 },
+        { 住所: "Tokyo", 年齢: 30 },
+      ],
+    },
+    { rowNumber: 2, row: [{ 住所: "Kyoto", 年齢: 40 }] },
+    { rowNumber: 3, row: [{ 住所: "Osaka", 年齢: 30 }] },
+    { rowNumber: 4, row: [{ 住所: "Nagoya", 年齢: 10 }] },
+  ];
+
+  describe("isOrMatchHaving", () => {
+    test("重複ヒットは除外され、新規ヒットのみ末尾に追加される", () => {
+      const result = isOrMatchHaving(
+        groups,
+        [{ 年齢: { _avg: { gte: 30 } } }, { 年齢: { _avg: { gte: 25 } } }],
+        by,
+      );
+
+      expect(result.map((r) => r.rowNumber)).toEqual([2, 3, 1]);
+    });
+
+    test("返る要素は入力と同一の参照", () => {
+      const result = isOrMatchHaving(
+        groups,
+        [{ 年齢: { _avg: { gte: 40 } } }, { 年齢: { _avg: { lte: 10 } } }],
+        by,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(groups[1]);
+      expect(result[1]).toBe(groups[3]);
+    });
+  });
+
+  describe("isNotMatchHaving", () => {
+    test("条件にマッチしたグループを除いた補集合を元の順序で返す", () => {
+      const result = isNotMatchHaving(
+        groups,
+        [{ 年齢: { _avg: { gte: 30 } } }],
+        by,
+      );
+
+      expect(result.map((r) => r.rowNumber)).toEqual([1, 4]);
+    });
+
+    test("何もマッチしなければ全グループ返す", () => {
+      const result = isNotMatchHaving(
+        groups,
+        [{ 年齢: { _avg: { gte: 999 } } }],
+        by,
+      );
+
+      expect(result.map((r) => r.rowNumber)).toEqual([1, 2, 3, 4]);
+    });
+  });
+
+  describe("isLogicMatchHaving", () => {
+    test("AND と OR の併用は積集合を OR 側の順序で返す", () => {
+      const result = isLogicMatchHaving(
+        groups,
+        {
+          AND: [{ 年齢: { _avg: { gte: 25 } } }],
+          OR: [{ 年齢: { _avg: { lte: 30 } } }],
+        },
+        by,
+      );
+
+      expect(result.map((r) => r.rowNumber)).toEqual([1, 3]);
+    });
+
+    test("AND と NOT の併用は積集合を NOT 側の順序で返す", () => {
+      const result = isLogicMatchHaving(
+        groups,
+        {
+          AND: [{ 年齢: { _avg: { gte: 25 } } }],
+          NOT: [{ 年齢: { _avg: { gte: 40 } } }],
+        },
+        by,
+      );
+
+      expect(result.map((r) => r.rowNumber)).toEqual([1, 3]);
+    });
+  });
+});

--- a/src/__test__/util/groupby/groupbyUtil/having/normalHavingFilter/normalHaving.test.ts
+++ b/src/__test__/util/groupby/groupbyUtil/having/normalHavingFilter/normalHaving.test.ts
@@ -1,0 +1,48 @@
+import type { HitByClassificationedRowData } from "../../../../../../types/coreTypes";
+import { normalHaving } from "../../../../../../util/groupby/groubyUtil/having/normalHavingFilter";
+
+describe("normalHaving の集計結果と元グループの対応付け", () => {
+  const by = ["住所"];
+  const groups: HitByClassificationedRowData[] = [
+    {
+      rowNumber: 1,
+      row: [
+        { 住所: "Tokyo", 年齢: 20 },
+        { 住所: "Tokyo", 年齢: 30 },
+      ],
+    },
+    { rowNumber: 2, row: [{ 住所: "Kyoto", 年齢: 40 }] },
+    { rowNumber: 3, row: [{ 住所: "Osaka", 年齢: 30 }] },
+    { rowNumber: 4, row: [{ 住所: "Nagoya", 年齢: 10 }] },
+  ];
+
+  test("集計条件にマッチしたグループを入力順で返す", () => {
+    const result = normalHaving(groups, { 年齢: { _avg: { gte: 30 } } }, by);
+
+    expect(result.map((r) => r?.rowNumber)).toEqual([2, 3]);
+  });
+
+  test("返る要素は入力と同一の参照", () => {
+    const result = normalHaving(groups, { 年齢: { _avg: { lte: 25 } } }, by);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(groups[0]);
+    expect(result[1]).toBe(groups[3]);
+  });
+
+  test("マッチしなければ空配列を返す", () => {
+    const result = normalHaving(groups, { 年齢: { _avg: { gte: 999 } } }, by);
+
+    expect(result).toEqual([]);
+  });
+
+  test("by キーの等価条件と集計条件を併用できる", () => {
+    const result = normalHaving(
+      groups,
+      { 住所: "Tokyo", 年齢: { _avg: { gte: 20 } } },
+      by,
+    );
+
+    expect(result.map((r) => r?.rowNumber)).toEqual([1]);
+  });
+});

--- a/src/util/andOrNot/entry.ts
+++ b/src/util/andOrNot/entry.ts
@@ -25,10 +25,10 @@ const isLogicMatch = (
 
     if (result.length === 0) result = orResult;
     else {
-      const alreadyHitRowNumbers = result.map((row) => row.rowNumber);
+      const alreadyHitRowNumbers = new Set(result.map((row) => row.rowNumber));
 
       result = orResult.filter((row) =>
-        alreadyHitRowNumbers.includes(row.rowNumber),
+        alreadyHitRowNumbers.has(row.rowNumber),
       );
     }
   }
@@ -39,10 +39,10 @@ const isLogicMatch = (
 
     if (result.length === 0) result = notResult;
     else {
-      const alreadyHitRowNumbers = result.map((row) => row.rowNumber);
+      const alreadyHitRowNumbers = new Set(result.map((row) => row.rowNumber));
 
       result = notResult.filter((row) =>
-        alreadyHitRowNumbers.includes(row.rowNumber),
+        alreadyHitRowNumbers.has(row.rowNumber),
       );
     }
   }

--- a/src/util/andOrNot/not.ts
+++ b/src/util/andOrNot/not.ts
@@ -47,12 +47,12 @@ const isNotMatch = (
     }
   });
 
-  const resultRowsDataNumbers = resultRowsData.map(
-    (oneRow) => oneRow.rowNumber,
+  const resultRowsDataNumbers = new Set(
+    resultRowsData.map((oneRow) => oneRow.rowNumber),
   );
 
   const notResultRowsData = rowsData.filter(
-    (oneRow) => !resultRowsDataNumbers.includes(oneRow.rowNumber),
+    (oneRow) => !resultRowsDataNumbers.has(oneRow.rowNumber),
   );
 
   return notResultRowsData;

--- a/src/util/andOrNot/or.ts
+++ b/src/util/andOrNot/or.ts
@@ -50,10 +50,12 @@ const isOrMatch = (
       return;
     }
 
-    const alreadyHitRowNumbers = resultRowsData.map((row) => row.rowNumber);
+    const alreadyHitRowNumbers = new Set(
+      resultRowsData.map((row) => row.rowNumber),
+    );
 
     const newInsertedArray = findedData.filter(
-      (row) => !alreadyHitRowNumbers.includes(row.rowNumber),
+      (row) => !alreadyHitRowNumbers.has(row.rowNumber),
     );
 
     resultRowsData = resultRowsData.concat(newInsertedArray);

--- a/src/util/groupby/groubyUtil/andOrNot/entry.ts
+++ b/src/util/groupby/groubyUtil/andOrNot/entry.ts
@@ -27,10 +27,10 @@ const isLogicMatchHaving = (
 
     if (result.length === 0) result = orResult;
     else {
-      const alreadyHitRowNumbers = result.map((row) => row.rowNumber);
+      const alreadyHitRowNumbers = new Set(result.map((row) => row.rowNumber));
 
       result = orResult.filter((row) =>
-        alreadyHitRowNumbers.includes(row.rowNumber),
+        alreadyHitRowNumbers.has(row.rowNumber),
       );
     }
   }
@@ -41,10 +41,10 @@ const isLogicMatchHaving = (
 
     if (result.length === 0) result = notResult;
     else {
-      const alreadyHitRowNumbers = result.map((row) => row.rowNumber);
+      const alreadyHitRowNumbers = new Set(result.map((row) => row.rowNumber));
 
       result = notResult.filter((row) =>
-        alreadyHitRowNumbers.includes(row.rowNumber),
+        alreadyHitRowNumbers.has(row.rowNumber),
       );
     }
   }

--- a/src/util/groupby/groubyUtil/andOrNot/not.ts
+++ b/src/util/groupby/groubyUtil/andOrNot/not.ts
@@ -21,12 +21,12 @@ const isNotMatchHaving = (
     }
   });
 
-  const resultHavingDataNumbers = resultHavingData.map(
-    (oneHavingData) => oneHavingData.rowNumber,
+  const resultHavingDataNumbers = new Set(
+    resultHavingData.map((oneHavingData) => oneHavingData.rowNumber),
   );
 
   const notResultHavingData = willHavingData.filter(
-    (oneHaving) => !resultHavingDataNumbers.includes(oneHaving.rowNumber),
+    (oneHaving) => !resultHavingDataNumbers.has(oneHaving.rowNumber),
   );
 
   return notResultHavingData;

--- a/src/util/groupby/groubyUtil/andOrNot/or.ts
+++ b/src/util/groupby/groubyUtil/andOrNot/or.ts
@@ -25,12 +25,12 @@ const isOrMatchHaving = (
       return;
     }
 
-    const alreadyHitByClassificationRowNumbers = resultHavingData.map(
-      (row) => row.rowNumber,
+    const alreadyHitByClassificationRowNumbers = new Set(
+      resultHavingData.map((row) => row.rowNumber),
     );
 
     const newInsertedArray = findedHavingData.filter(
-      (row) => !alreadyHitByClassificationRowNumbers.includes(row.rowNumber),
+      (row) => !alreadyHitByClassificationRowNumbers.has(row.rowNumber),
     );
 
     resultHavingData = resultHavingData.concat(newInsertedArray);

--- a/src/util/groupby/groubyUtil/having/normalHavingFilter.ts
+++ b/src/util/groupby/groubyUtil/having/normalHavingFilter.ts
@@ -107,12 +107,17 @@ const normalHaving = (
     }),
   );
 
+  const rowByNumber = new Map<number, HitByClassificationedRowData>();
+  byClassificationedRowWithoutPattern.forEach((oneByClassificationedRow) => {
+    if (!rowByNumber.has(oneByClassificationedRow.rowNumber))
+      rowByNumber.set(
+        oneByClassificationedRow.rowNumber,
+        oneByClassificationedRow,
+      );
+  });
+
   const normalHavingFiltered = normalHavingResult.map(
-    (oneHavingAggregateData) =>
-      byClassificationedRowWithoutPattern.find(
-        (oneByClassificationedRow) =>
-          oneByClassificationedRow.rowNumber === oneHavingAggregateData.index,
-      ),
+    (oneHavingAggregateData) => rowByNumber.get(oneHavingAggregateData.index),
   );
 
   return normalHavingFiltered;


### PR DESCRIPTION
> [!WARNING]
> **#187 の内容は main に届いていません。** #187 は base が `perf/contains-value-set` でしたが、そのブランチが #184 として main にマージされた**後**に #187 がマージされたため、変更が `perf/contains-value-set` に取り残されました。**これは私のブランチ設計ミスです**(積み上げ PR にした結果、マージ順で取りこぼしました)。
>
> 本PRは #187 のコミットを**現在の main の上に cherry-pick し直した**ものです。内容は #187 と同一で、`main` に既に入っている #185(cascade)・#186(`_count: _all`)とも同居した状態で全検証済みです。#187 はクローズして構いません。

以下、#187 と同じ説明です。

## 問題

行を `.filter()` で回しながら、その中で**別配列に対する `includes` を毎行実行**していました。N 行に対して N²/2 回の比較になります。

```ts
const alreadyHitRowNumbers = resultRowsData.map((row) => row.rowNumber);
const newInsertedArray = findedData.filter(
  (row) => !alreadyHitRowNumbers.includes(row.rowNumber),  // 毎行、全件走査
);
```

`OR` の重複除去、`NOT` の補集合、`AND` と `OR`/`NOT` の積集合、having 側の同型コードが該当します。

## 修正

ループの**外**で `Set` を一度作り、中では `.has()` を使います。**rowNumber は内部生成の整数**なので、`includes`(SameValueZero)と `Set.has`(SameValueZero)は完全に同一の意味論です。値の正規化は不要でした。

`normalHavingFilter.ts` は `includes` ではなく **`.map` の中で `.find`** という同型のパターンだったため、`Map<number, HitByClassificationedRowData>` に置換しました。`.find` は未ヒット時に `undefined` を返すので `Map.get` と一致し、rowNumber が重複した場合の**先勝ちも `has` ガードで保存**しています。

対象9ファイル(うち `groubyUtil/andOrNot/not.ts` は調査リストになかったが完全に同型だったもの)。

`updateMany.ts` などの `wantUpdateIndex.includes` は**配列サイズが列数固定**で N に比例しないため対象外としています。

## 性能実測(best of 5)

| 経路 | N=2,000 | N=8,000 | N=32,000 | 短縮率(N=32,000) |
|---|---|---|---|---|
| OR(3分岐・重複あり) | 0.6 → 0.4ms | 5.5 → 1.3ms | 68.5 → **5.8ms** | 11.8x |
| NOT | 0.4 → 0.1ms | 3.8 → 0.6ms | 56.9 → **2.8ms** | 20.0x |
| AND + OR 併用 | 0.8 → 0.4ms | 8.3 → 1.4ms | 114.0 → **7.2ms** | 15.8x |
| having(normalHaving) | 8.6 → 0.8ms | 29.9 → 3.8ms | 475.3 → **18.3ms** | 26.0x |
| having(OR 2分岐) | 4.4 → 1.2ms | 63.4 → 7.1ms | 1053.7 → **32.2ms** | 32.7x |

N を倍化したときの時間倍率は、修正前が 3.4〜4.4 倍(二次)、修正後が 1.6〜2.4 倍(線形)に収束しています。

## 挙動不変の検証

- **既存テストは1件も変更していません**
- 追加テスト28件。OR の重複除去と先勝ち順序・**結果要素の参照同一性**・NOT の補集合と順序・AND との積集合の順序・集計結果から元グループへの対応付けを、実装変更の**前に**書いて green を確認してからピン留めとして置換しています
- **現在の main の上で** `npm test`(172 suites / **2,137 tests**)/ `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル55件)すべて pass

## 補足

`stringMax.ts` / `stringMin.ts` の同型 `includes` も直せますが、**次のPR(推奨手順4)がこの2ファイルを `reduce` で全面書き換えする**ため実装変更は含めていません。ただし**タイブレークのピン留めテスト8件は含めて**あります(手順4の書き換えに対する安全網。現行実装のままでも green です)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)