### PR TITLE
perf: $transaction 内の仮想シート読みを slice 化(読みメモ化は不採用)

### DIFF
--- a/src/__test__/util/transaction/virtualSheetStore.test.ts
+++ b/src/__test__/util/transaction/virtualSheetStore.test.ts
@@ -1,0 +1,92 @@
+import { createVirtualSheetStore } from "../../../util/transaction/virtualSheetStore";
+import { makeLoggedSheet } from "./transactionTestClient";
+
+const initialUsers = [
+  ["id", "name", "age"],
+  [1, "Alice", 20],
+  [2, "Bob", 30],
+];
+
+describe("virtualSheetStore の getRangeValues", () => {
+  test("グリッド全体をそのまま返す", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const store = createVirtualSheetStore();
+
+    expect(store.getRangeValues(sheet, 1, 1, 3, 3)).toEqual(initialUsers);
+  });
+
+  test("部分範囲を返す", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const store = createVirtualSheetStore();
+
+    expect(store.getRangeValues(sheet, 2, 2, 2, 2)).toEqual([
+      ["Alice", 20],
+      ["Bob", 30],
+    ]);
+  });
+
+  test("行が要求列数より短い場合は空文字で埋める", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const store = createVirtualSheetStore();
+
+    store.appendRows(sheet, 1, 2, [[3, "Carol"]]);
+
+    expect(store.getRangeValues(sheet, 4, 1, 1, 5)).toEqual([
+      [3, "Carol", "", "", ""],
+    ]);
+  });
+
+  test("存在しない行は空文字の行として返す", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const store = createVirtualSheetStore();
+
+    expect(store.getRangeValues(sheet, 3, 1, 3, 3)).toEqual([
+      [2, "Bob", 30],
+      ["", "", ""],
+      ["", "", ""],
+    ]);
+  });
+
+  test("行の途中に undefined が入っている疎行は空文字になる", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const store = createVirtualSheetStore();
+
+    store.updateRow(sheet, 4, 3, 1, [99]);
+
+    expect(store.getRangeValues(sheet, 4, 1, 1, 3)).toEqual([["", "", 99]]);
+  });
+
+  test("列オフセット付きでも短い行が埋まる", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const store = createVirtualSheetStore();
+
+    expect(store.getRangeValues(sheet, 2, 2, 1, 4)).toEqual([
+      ["Alice", 20, "", ""],
+    ]);
+  });
+
+  test("返り値を破壊的変更しても内部状態が壊れない", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const store = createVirtualSheetStore();
+
+    const first = store.getRangeValues(sheet, 2, 1, 2, 3);
+    first[0][1] = "MUTATED";
+    first[1] = ["X", "Y", "Z"];
+
+    expect(store.getRangeValues(sheet, 2, 1, 2, 3)).toEqual([
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+    ]);
+  });
+
+  test("返り値の変更が updateRow の対象行にも影響しない", () => {
+    const { sheet } = makeLoggedSheet("Users", initialUsers);
+    const store = createVirtualSheetStore();
+
+    const values = store.getRangeValues(sheet, 2, 1, 1, 3);
+    values[0][2] = 999;
+    store.updateRow(sheet, 2, 1, 3, [1, "Alice", 21]);
+
+    expect(store.getRangeValues(sheet, 2, 1, 1, 3)).toEqual([[1, "Alice", 21]]);
+  });
+});

--- a/src/util/transaction/virtualSheetStore.ts
+++ b/src/util/transaction/virtualSheetStore.ts
@@ -82,6 +82,17 @@ const createVirtualSheetStore = () => {
 
   const getLastRow = (sheet: Sheet): number => getVirtual(sheet).grid.length;
 
+  const normalizeCells = (
+    cells: unknown[],
+    columnLength: number,
+  ): unknown[] => {
+    while (cells.length < columnLength) {
+      cells.push("");
+    }
+    if (!cells.includes(undefined)) return cells;
+    return Array.from(cells, (cell) => (cell === undefined ? "" : cell));
+  };
+
   const getRangeValues = (
     sheet: Sheet,
     rowNumber: number,
@@ -90,12 +101,15 @@ const createVirtualSheetStore = () => {
     columnLength: number,
   ): any[][] => {
     const virtual = getVirtual(sheet);
+    const startColumn = columnNumber - 1;
     return Array.from({ length: rowLength }, (_, rowIndex) => {
-      const row = virtual.grid[rowNumber - 1 + rowIndex] ?? [];
-      return Array.from({ length: columnLength }, (_, columnIndex) => {
-        const cell = row[columnNumber - 1 + columnIndex];
-        return cell === undefined ? "" : cell;
-      });
+      const row = virtual.grid[rowNumber - 1 + rowIndex];
+      if (row === undefined)
+        return Array.from({ length: columnLength }, () => "");
+      return normalizeCells(
+        row.slice(startColumn, startColumn + columnLength),
+        columnLength,
+      );
     });
   };
 


### PR DESCRIPTION
計算量調査の推奨着手順 **6番目**。**調査時の推奨(読みメモ化)は実測の結果、不採用にしています**(理由は後述)。

## 問題

`$transaction` は書き込みをバッファして仮想グリッド上で処理するため、tx 内の各操作は仮想グリッドを読みます。その `getRangeValues` が**セル1個ごとに `Array.from` のコールバックを呼んで**いました。

```ts
return Array.from({ length: rowLength }, (_, rowIndex) => {
  const row = virtual.grid[rowNumber - 1 + rowIndex] ?? [];
  return Array.from({ length: columnLength }, (_, columnIndex) => {   // セル数だけ関数呼び出し
    const cell = row[columnNumber - 1 + columnIndex];
    return cell === undefined ? "" : cell;
  });
});
```

tx 内でループを回して単発 op を叩くと、これが毎回グリッド全体に対して走ります。

## 修正

**行を `slice` で取り出し、短い場合と疎な場合だけ正規化**します。

疎配列の穴埋めには落とし穴があり、**`map` は配列の穴をスキップしてしまう**ため `Array.from` を使っています。穴の検出も `indexOf` ではなく `includes`(穴を `undefined` として扱う)である必要があります。

保存した挙動:

- 行が要求列数より短い場合の `""` 埋め
- 行自体が存在しない場合
- 行の途中に `undefined` が入っている疎配列
- **返り値が仮想グリッドの内部配列を共有しないこと**(`slice` がコピーを返す)

## 性能実測

`getRangeValues` 単体(N=5,000、100回):

| 列数 C | 修正前 | 修正後 | 改善 |
|---|---|---|---|
| 3 | 91ms | **18ms** | 5.1x |
| 20 | 313ms | **24ms** | **13.0x** |

tx 内 `update` ループ(N=5,000、C=3):

| K | 修正前 | 修正後 | 改善 |
|---|---|---|---|
| 250 | 297ms | **133ms** | 2.2x |
| 500 | 633ms | **183ms** | 3.5x |
| 1,000 | 1,176ms | **389ms** | 3.0x |
| 2,000 | 2,407ms | **785ms** | 3.1x |

列数の影響(K=1,000、N=5,000)は、修正前が C 3→20 で 2.6倍だったのが**修正後 1.4倍**とほぼ消滅しました。K に対しては修正前後とも線形で、定数倍が落ちた形です。

`updateMany` 1回(N=1,600)= 1.9→1.7ms、rollback 有効(copyTo バックアップ込み)でも退行なしを確認しています。

## 読みメモ化を採用しなかった理由(調査推奨からの変更)

調査メモでは「tx 中は仮想グリッドを単一ソースとして `getAllData` 結果をメモ化」を推奨していましたが、**実装して計測したところ悪化した**ため入れていません。

- 既存の読みキャッシュ機構(#175)に相乗りする実験は3行で成立し、全テストも green でした。**しかし K=1,000 / C=3 で 302→541ms、C=20 で 484→1,028ms と悪化**しました
- 理由は構造的です。update ループは**「読み→書き」が交互**なので、**各書き込みが直前のメモを無効化し、キャッシュが一度もヒットしません**。ヒットしないままミス時の保存コスト(セルごとの `isDateValue` 判定を伴う全コピー)だけが上乗せされます
- そもそも**仮想グリッド自体が「書き込みが反映され続けるメモ」**であり、リーダー層にもう一段メモを重ねる余地がありませんでした

なお、write 系 op は `runWithoutReadCache` で `writeDepth > 0` になるため既存の読みキャッシュを素通りする、という設計上の事実も確認できました(read 系 op は tx 内でもキャッシュを通ります)。

これ以上削るなら、(a) 変換済みビューを write-through で維持して**コピーせず共有配列を返す**か、(b) `whereFilter` の O(N) 走査自体を行インデックスで消すか、の2方向しかありません。(a) は「呼び出し元が結果を一切変更しない」という契約が必要で、**無効化漏れより悪い「黙って tx の状態が壊れる」失敗モード**を持つため推奨しません。(b) は別タスク規模です。

## 挙動不変の検証

- **既存テストは1件も変更していません**
- 追加テスト8件。実装を差し替える**前に**現行実装で green になる characterization テストを書いて挙動を固定しています(全体読み / 部分範囲 / 短い行の `""` 埋め / 存在しない行 / 疎行の途中 `undefined` / 列オフセット + 短い行 / 返り値の破壊的変更が内部状態に波及しないこと×2)
- キャッシュ層を持たない実装なので、**古い値が返る経路は構造的にゼロ**です
- `npm test`(169 suites / 2,117 tests)/ `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル55件)すべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)