### PR TITLE
perf: groupBy のグルーピングを Map 化して線形に

### DIFF
--- a/src/__test__/util/groupby/groupbyUtil/byClassification.test.ts
+++ b/src/__test__/util/groupby/groupbyUtil/byClassification.test.ts
@@ -1,0 +1,228 @@
+import { byClassification } from "../../../../util/groupby/groubyUtil/by";
+
+describe("byClassification のグループ順・行順", () => {
+  test("グループは初出順に並ぶ", () => {
+    const rows = [
+      { k: "b", v: 1 },
+      { k: "a", v: 2 },
+      { k: "b", v: 3 },
+      { k: "c", v: 4 },
+      { k: "a", v: 5 },
+    ];
+
+    const result = byClassification(rows, ["k"]);
+
+    expect(result.map((group: { k: string }[]) => group[0].k)).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+  });
+
+  test("グループ内の行は元の順序を保つ", () => {
+    const rows = [
+      { k: "a", v: 1 },
+      { k: "b", v: 2 },
+      { k: "a", v: 3 },
+      { k: "a", v: 4 },
+    ];
+
+    const result = byClassification(rows, ["k"]);
+
+    expect(result[0].map((row: { v: number }) => row.v)).toEqual([1, 3, 4]);
+  });
+
+  test("グループ内の行は同一参照", () => {
+    const rows = [
+      { k: "a", v: 1 },
+      { k: "a", v: 2 },
+    ];
+
+    const result = byClassification(rows, ["k"]);
+
+    expect(result[0][0]).toBe(rows[0]);
+    expect(result[0][1]).toBe(rows[1]);
+  });
+
+  test("全行同一キーなら1グループ", () => {
+    const rows = [{ k: 1 }, { k: 1 }, { k: 1 }];
+
+    const result = byClassification(rows, ["k"]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(3);
+  });
+
+  test("全行ユニークなら行数ぶんのグループ", () => {
+    const rows = [{ k: 1 }, { k: 2 }, { k: 3 }];
+
+    const result = byClassification(rows, ["k"]);
+
+    expect(result).toHaveLength(3);
+    expect(result.every((group: unknown[]) => group.length === 1)).toBe(true);
+  });
+
+  test("空の入力は空の結果", () => {
+    expect(byClassification([], ["k"])).toEqual([]);
+  });
+});
+
+describe("byClassification の型区別", () => {
+  test('数値 0 と文字列 "0" は別グループ', () => {
+    const rows = [{ k: 0 }, { k: "0" }];
+
+    expect(byClassification(rows, ["k"])).toHaveLength(2);
+  });
+
+  test("true と 1 は別グループ", () => {
+    const rows = [{ k: true }, { k: 1 }];
+
+    expect(byClassification(rows, ["k"])).toHaveLength(2);
+  });
+
+  test("null と undefined と空文字は別グループ", () => {
+    const rows = [{ k: null }, { k: undefined }, { k: "" }];
+
+    expect(byClassification(rows, ["k"])).toHaveLength(3);
+  });
+
+  test("-0 と 0 は同一グループ", () => {
+    const rows = [{ k: -0 }, { k: 0 }];
+
+    expect(byClassification(rows, ["k"])).toHaveLength(1);
+  });
+
+  test("負数・小数はそれぞれ区別される", () => {
+    const rows = [{ k: -1 }, { k: 1 }, { k: 1.5 }, { k: -1 }];
+
+    const result = byClassification(rows, ["k"]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toHaveLength(2);
+  });
+
+  test("正規化キー形式の文字列は Date と衝突しない", () => {
+    const at = new Date("2026-07-18T09:30:00.000Z");
+    const rows = [{ k: at }, { k: `date:${at.getTime()}` }];
+
+    expect(byClassification(rows, ["k"])).toHaveLength(2);
+  });
+
+  test('文字列 "str:1" と "1" は別グループ', () => {
+    const rows = [{ k: "str:1" }, { k: "1" }];
+
+    expect(byClassification(rows, ["k"])).toHaveLength(2);
+  });
+});
+
+describe("byClassification の NaN / Invalid Date(現行挙動の保存)", () => {
+  test("NaN キーは初出位置に空グループを残し行は含まれない", () => {
+    const rows = [
+      { k: 1, v: "a" },
+      { k: NaN, v: "b" },
+      { k: 2, v: "c" },
+      { k: NaN, v: "d" },
+    ];
+
+    const result = byClassification(rows, ["k"]);
+
+    expect(result).toEqual([[{ k: 1, v: "a" }], [], [{ k: 2, v: "c" }]]);
+  });
+
+  test("Invalid Date は同一インスタンスで1つ・別インスタンスで別の空グループ", () => {
+    const shared = new Date("invalid");
+    const rows = [
+      { k: shared, v: "a" },
+      { k: shared, v: "b" },
+      { k: new Date("invalid"), v: "c" },
+      { k: 1, v: "d" },
+    ];
+
+    const result = byClassification(rows, ["k"]);
+
+    expect(result).toEqual([[], [], [{ k: 1, v: "d" }]]);
+  });
+
+  test("深さ2: 非最終カラムの NaN 行は空グループを残さず消える", () => {
+    const rows = [
+      { a: NaN, b: 1, v: "x" },
+      { a: 1, b: 1, v: "y" },
+    ];
+
+    const result = byClassification(rows, ["a", "b"]);
+
+    expect(result).toEqual([[{ a: 1, b: 1, v: "y" }]]);
+  });
+
+  test("深さ2: 最終カラムの NaN は空グループを残す", () => {
+    const rows = [
+      { a: 1, b: NaN, v: "x" },
+      { a: 1, b: 2, v: "y" },
+    ];
+
+    const result = byClassification(rows, ["a", "b"]);
+
+    expect(result).toEqual([[], [{ a: 1, b: 2, v: "y" }]]);
+  });
+});
+
+describe("byClassification の複数カラム", () => {
+  test("深さ2: 外側カラム初出順→内側カラム初出順で平坦化される", () => {
+    const rows = [
+      { a: "x", b: 1, v: 1 },
+      { a: "y", b: 1, v: 2 },
+      { a: "x", b: 2, v: 3 },
+      { a: "x", b: 1, v: 4 },
+      { a: "y", b: 3, v: 5 },
+    ];
+
+    const result = byClassification(rows, ["a", "b"]);
+
+    expect(
+      result.map((group: { a: string; b: number }[]) => [
+        group[0].a,
+        group[0].b,
+      ]),
+    ).toEqual([
+      ["x", 1],
+      ["x", 2],
+      ["y", 1],
+      ["y", 3],
+    ]);
+    expect(result[0].map((row: { v: number }) => row.v)).toEqual([1, 4]);
+  });
+
+  test("深さ3: 入れ子の平坦化後も各グループは行配列", () => {
+    const rows = [
+      { a: 1, b: 1, c: 1 },
+      { a: 1, b: 1, c: 2 },
+      { a: 1, b: 2, c: 1 },
+      { a: 2, b: 1, c: 1 },
+    ];
+
+    const result = byClassification(rows, ["a", "b", "c"]);
+
+    expect(result).toHaveLength(4);
+    expect(
+      result.every(
+        (group: unknown[]) =>
+          Array.isArray(group) &&
+          group.length === 1 &&
+          !Array.isArray(group[0]),
+      ),
+    ).toBe(true);
+  });
+
+  test("深さ2: 同時刻・別インスタンスの Date キーは同一グループ", () => {
+    const rows = [
+      { at: new Date("2026-07-18T09:30:00.000Z"), city: "Tokyo", v: 1 },
+      { at: new Date("2026-07-18T09:30:00.000Z"), city: "Tokyo", v: 2 },
+      { at: new Date("2026-07-18T09:31:00.000Z"), city: "Tokyo", v: 3 },
+    ];
+
+    const result = byClassification(rows, ["at", "city"]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toHaveLength(2);
+  });
+});

--- a/src/util/groupby/groubyUtil/by.ts
+++ b/src/util/groupby/groubyUtil/by.ts
@@ -1,5 +1,33 @@
-import type { GassmaAny } from "../../../types/coreTypes";
-import { containsValue, isValueEqual } from "../../other/isValueEqual";
+import { isDateValue } from "../../other/isDateValue";
+import { toLookupKey } from "../../other/toLookupKey";
+
+const isSelfUnequal = (value: unknown): boolean =>
+  isDateValue(value)
+    ? Number.isNaN(value.getTime())
+    : typeof value === "number" && Number.isNaN(value);
+
+const groupByColumn = (
+  rows: Record<string, any>[],
+  column: string,
+): Record<string, any>[][] => {
+  const groups = new Map<unknown, Record<string, any>[]>();
+
+  rows.forEach((row) => {
+    const data = row[column];
+    const selfUnequal = isSelfUnequal(data);
+    const key = selfUnequal && isDateValue(data) ? data : toLookupKey(data);
+    const group = groups.get(key);
+
+    if (group === undefined) {
+      groups.set(key, selfUnequal ? [] : [row]);
+      return;
+    }
+
+    if (!selfUnequal) group.push(row);
+  });
+
+  return Array.from(groups.values());
+};
 
 const bySearch = (
   rows: Record<string, any>[],
@@ -8,29 +36,9 @@ const bySearch = (
 ): any[] => {
   if (depth === byData.length) return rows;
 
-  const matches: GassmaAny[] = [];
-
-  rows.forEach((row) => {
-    const data: GassmaAny = row[byData[depth]];
-
-    if (containsValue(matches, data)) return;
-
-    matches.push(data);
-  });
-
-  const classificationedMatches = matches.map((match) =>
-    rows.filter((row) => {
-      const data = row[byData[depth]];
-
-      return isValueEqual(data, match);
-    }),
+  return groupByColumn(rows, byData[depth]).map((group) =>
+    bySearch(group, byData, depth + 1),
   );
-
-  const result = classificationedMatches.map((classificationedMatch) =>
-    bySearch(classificationedMatch, byData, depth + 1),
-  );
-
-  return result;
 };
 
 const byClassification = (rows: Record<string, any>[], byData: string[]) => {


### PR DESCRIPTION
計算量調査の推奨着手順 **5番目**。これで本体側(手順1〜6)は完了です。

## 問題

`src/util/groupby/groubyUtil/by.ts` の `bySearch` が、ユニーク値を線形探索で集めたあと、**グループごとに全行を `filter`** していました。

```ts
const classificationedMatches = matches.map((match) =>
  rows.filter((row) => isValueEqual(row[byData[depth]], match)),   // G × N
);
```

**カーディナリティが高いカラムで groupBy すると破綻**します。N=20,000 の全行ユニークで **81.8秒**でした。

## 修正

`toLookupKey` で正規化したキーの **`Map<key, rows[]>` による1パスのグルーピング**に置き換えました。

保存したもの:

- **初出順**(旧 `matches` の順 = Map の挿入順)
- **グループ内の行順**(1パスで元の順に push)
- **再帰の入れ子形状**(`byClassification` の `flat(byData.length - 1)` が依存しているため)
- 行オブジェクトの**参照同一性**

## 性能実測(median of 3)

| シナリオ | N | 修正前 | 修正後 |
|---|---|---|---|
| 全行ユニーク | 2,500 | 1,234ms | **0.9ms** |
| | 5,000 | 4,747ms | 1.8ms |
| | 10,000 | 19,153ms | 3.7ms |
| | 20,000 | **81,840ms** | **7.7ms** |
| G=100 固定 | 20,000 | 270ms | **6.3ms** |
| 深さ2(a=50種 × b=ユニーク) | 20,000 | 1,681ms | **14.0ms** |

修正前は倍化ごとに約4倍(二次)、修正後は全シナリオで約2倍(線形)。G=100 固定のケースも旧実装は各行で `matches` を走査していたため実は O(N×G) で、こちらも改善しています。

## 挙動不変の検証

- **既存テストは1件も変更していません**
- 旧実装をコピーした property-based 突き合わせで、シード付き乱数の **3,000 ケース**(深さ1〜3、`null`/`undefined`/空文字/`"0"` と `0`/`true` と `1`/±0/同時刻の別 Date/Invalid Date/NaN/`"date:<epoch>"` などの正規化キー衝突狙い文字列)を**行の参照レベルまで完全一致**で確認(確認後に一時テストは削除)
- 追加テスト20件。初出順・行順・参照同一性・型区別・正規化キー衝突・深さ2/3 の平坦化順序と形状・縮退ケース
- **最新 main(#188・#189・#190 込み)の上で** `npm test`(176 suites / **2,192 tests**)/ `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル55件)すべて pass

## ⚠️ 保存した「現行のバグ挙動」(別途対応が必要)

Map 化にあたって、**現行実装が NaN / Invalid Date で壊れている**ことが実測で確認できました。**本PRでは性能改善に徹し、この挙動を厳密に保存しています**(直していません)。

原因は、グループの収集が `containsValue`(内部で `includes` = SameValueZero)なのに、振り分けが `isValueEqual`(`NaN === NaN` は false、Invalid Date は `getTime()` 同士が `NaN === NaN` で**同一インスタンスでも false**)である**非対称性**です。収集はできるのに振り分けで誰もマッチせず、**空グループ**が生まれます。

| ケース | 現行の挙動 |
|---|---|
| `by` の**最終カラム**が NaN / Invalid Date | 空グループが残り、**`groupByFunc` が `TypeError: Cannot read properties of undefined` で落ちる**(`groupby.ts` の `oneClass[0][oneBy]`) |
| **非最終カラム**が NaN / Invalid Date | 空グループの再帰先が空配列 → `flat` で消滅 → **該当行が無言で消える** |
| Invalid Date の別インスタンス | インスタンスごとに別の空グループができる |

Invalid Date のキーだけは `toLookupKey` を使うと全インスタンスが `date:NaN` に潰れて「別インスタンス = 別グループ」が壊れるため、**インスタンス自体をキー**にしています(`toLookupKey` 本体は無変更)。

**修正方針の判断はお願いします**(Prisma の意味論に合わせるなら NaN も Invalid Date も1グループにまとめる、が素直だと思いますが、仕様変更になるため勝手には決めません)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)