### PR TITLE
fix: 未知のトップレベル引数とフィルタ演算子をエラーにする(typo 対策 1/3)

### DIFF
--- a/src/__test__/errors/unknownArgumentError.test.ts
+++ b/src/__test__/errors/unknownArgumentError.test.ts
@@ -1,0 +1,50 @@
+import { GassmaUnknownArgumentError } from "../../errors/argument/argumentError";
+
+describe("GassmaUnknownArgumentError", () => {
+  test("近い候補があればサジェスト付きのメッセージになる", () => {
+    const error = new GassmaUnknownArgumentError("whre", ["where", "limit"]);
+    expect(error.message).toBe(
+      "Unknown argument `whre`. Did you mean `where`?\n\nAvailable: where, limit",
+    );
+    expect(error.name).toBe("GassmaUnknownArgumentError");
+  });
+
+  test("日本語の列名でもサジェストが働く", () => {
+    const error = new GassmaUnknownArgumentError("名まえ", [
+      "名前",
+      "年齢",
+      "住所",
+      "郵便番号",
+      "職業",
+    ]);
+    expect(error.message).toBe(
+      "Unknown argument `名まえ`. Did you mean `名前`?\n\nAvailable: 名前, 年齢, 住所, 郵便番号, 職業",
+    );
+  });
+
+  test("近い候補が無ければサジェスト行は出さず Available のみ", () => {
+    const error = new GassmaUnknownArgumentError("foobarbaz", [
+      "where",
+      "limit",
+    ]);
+    expect(error.message).toBe(
+      "Unknown argument `foobarbaz`.\n\nAvailable: where, limit",
+    );
+  });
+
+  test("候補が空なら Available 行を出さない", () => {
+    const error = new GassmaUnknownArgumentError("whre", []);
+    expect(error.message).toBe("Unknown argument `whre`.");
+  });
+
+  test("候補が配列でなくても構築に失敗しない(型なし利用者コード対策)", () => {
+    const LooseCtor: any = GassmaUnknownArgumentError;
+    const error = new LooseCtor("arg1", "arg2");
+    expect(error.message).toBe("Unknown argument `arg1`.");
+  });
+
+  test("Error を継承している", () => {
+    const error = new GassmaUnknownArgumentError("whre", ["where"]);
+    expect(Object.prototype.toString.call(error)).toBe("[object Error]");
+  });
+});

--- a/src/__test__/publicApi.test.ts
+++ b/src/__test__/publicApi.test.ts
@@ -1,3 +1,4 @@
+import { GassmaUnknownArgumentError } from "../errors/argument/argumentError";
 import { NotFoundError } from "../errors/find/findError";
 import { GassmaClient } from "../gassma";
 import { GassmaController } from "../gassmaController";
@@ -39,6 +40,21 @@ describe("publicApi", () => {
       if (name === "skip") return;
       expect(typeof value).toBe("function");
     });
+  });
+
+  test("GassmaUnknownArgumentError は本体のクラスと同一", () => {
+    expect(publicApi.GassmaUnknownArgumentError).toBe(
+      GassmaUnknownArgumentError,
+    );
+  });
+
+  test("未知キーで投げられたエラーは公開クラスの instanceof を満たす", () => {
+    const client = buildTestClient();
+    const users = sheetOf(client, "Users");
+    const loose: any = users;
+    expect(() => loose.deleteMany({ whre: { name: "Alice" } })).toThrow(
+      publicApi.GassmaUnknownArgumentError,
+    );
   });
 
   test("ライブラリ内部から投げられたエラーは公開クラスの instanceof を満たす", () => {

--- a/src/__test__/util/filterConditions/filterConditionsUnknownOperator.test.ts
+++ b/src/__test__/util/filterConditions/filterConditionsUnknownOperator.test.ts
@@ -1,0 +1,49 @@
+import { GassmaUnknownArgumentError } from "../../../errors/argument/argumentError";
+import { isFilterConditionsMatch } from "../../../util/filterConditions/filterConditions";
+
+describe("未知のフィルタ演算子", () => {
+  test("gth (gt の typo) は GassmaUnknownArgumentError", () => {
+    expect(() => isFilterConditionsMatch(30, { gth: 30 } as never)).toThrow(
+      GassmaUnknownArgumentError,
+    );
+    expect(() => isFilterConditionsMatch(30, { gth: 30 } as never)).toThrow(
+      "Unknown argument `gth`. Did you mean `gt`?",
+    );
+  });
+
+  test("メッセージに利用可能な演算子一覧が含まれる", () => {
+    expect(() => isFilterConditionsMatch(30, { gth: 30 } as never)).toThrow(
+      "Available: equals, not, in, notIn, lt, lte, gt, gte, contains, startsWith, endsWith, mode",
+    );
+  });
+
+  test("正しい演算子と未知の演算子が同居してもエラー", () => {
+    expect(() =>
+      isFilterConditionsMatch(30, { gt: 10, lth: 40 } as never),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("空オブジェクトは従来どおり全てにマッチする(挙動維持)", () => {
+    expect(isFilterConditionsMatch(30, {})).toBe(true);
+    expect(isFilterConditionsMatch(null, {})).toBe(true);
+  });
+
+  test("有効な12演算子はエラーにならない", () => {
+    expect(
+      isFilterConditionsMatch("hello", {
+        equals: "hello",
+        not: "x",
+        in: ["hello"],
+        notIn: ["x"],
+        lt: "z",
+        lte: "z",
+        gt: "a",
+        gte: "a",
+        contains: "ell",
+        startsWith: "he",
+        endsWith: "lo",
+        mode: "default",
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/__test__/util/other/suggestClosest.test.ts
+++ b/src/__test__/util/other/suggestClosest.test.ts
@@ -1,0 +1,33 @@
+import { suggestClosest } from "../../../util/other/suggestClosest";
+
+describe("suggestClosest", () => {
+  test("1文字の挿入 typo は最も近い候補を返す", () => {
+    expect(suggestClosest("whre", ["where", "limit"])).toBe("where");
+  });
+
+  test("1文字の転置 typo も候補を返す", () => {
+    expect(suggestClosest("gth", ["equals", "gt", "gte", "lt"])).toBe("gt");
+  });
+
+  test("日本語の列名でも文字単位の距離で候補を返す", () => {
+    expect(
+      suggestClosest("名まえ", ["名前", "年齢", "住所", "郵便番号", "職業"]),
+    ).toBe("名前");
+  });
+
+  test("どの候補からも遠い入力は null を返す", () => {
+    expect(suggestClosest("foobarbaz", ["where", "limit"])).toBeNull();
+  });
+
+  test("全文字が異なる短い入力は距離が小さくても null を返す", () => {
+    expect(suggestClosest("xyz", ["gt", "lt"])).toBeNull();
+  });
+
+  test("候補が空なら null を返す", () => {
+    expect(suggestClosest("whre", [])).toBeNull();
+  });
+
+  test("距離が同じ場合は先頭の候補を返す", () => {
+    expect(suggestClosest("gtx", ["gte", "gta"])).toBe("gte");
+  });
+});

--- a/src/__test__/util/unknownArguments.test.ts
+++ b/src/__test__/util/unknownArguments.test.ts
@@ -1,0 +1,281 @@
+import { GassmaUnknownArgumentError } from "../../errors/argument/argumentError";
+import { skip } from "../../util/skip/skip";
+import { buildTestClient, sheetOf } from "./extends/extendsTestClient";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "./transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const looseUsers = (options?: {
+  relations?: boolean;
+}): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const typed = sheetOf(buildTestClient(options), "Users");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+const expectUnknown = (fn: () => unknown, argumentName: string) => {
+  expect(fn).toThrow(GassmaUnknownArgumentError);
+  expect(fn).toThrow(`Unknown argument \`${argumentName}\`.`);
+};
+
+describe("deleteMany: 未知のトップレベルキー", () => {
+  test("whre (where の typo) はエラーになり行を削除しない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () => loose.deleteMany({ whre: { name: "Alice" } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `whre`. Did you mean `where`?\n\nAvailable: where, limit",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("正しい where と未知キーが同居してもエラー", () => {
+    const { loose, typed } = looseUsers();
+    expectUnknown(
+      () => loose.deleteMany({ where: { name: "Alice" }, limt: 1 }),
+      "limt",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+});
+
+describe("deleteMany: 未知のフィルタ演算子でシートが変化しない", () => {
+  test("gth (gt の typo) はエラーになり行を削除しない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () => loose.deleteMany({ where: { age: { gth: 30 } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `gth`. Did you mean `gt`?");
+    expect(typed.count({})).toBe(3);
+  });
+});
+
+describe("各操作の未知のトップレベルキー", () => {
+  test("findMany: oderBy", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ oderBy: { id: "asc" } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `oderBy`. Did you mean `orderBy`?");
+  });
+
+  test("findFirst: whre", () => {
+    const { loose } = looseUsers();
+    expectUnknown(() => loose.findFirst({ whre: { id: 1 } }), "whre");
+  });
+
+  test("findFirstOrThrow: incldue", () => {
+    const { loose } = looseUsers();
+    expectUnknown(() => loose.findFirstOrThrow({ incldue: {} }), "incldue");
+  });
+
+  test("count: wheer", () => {
+    const { loose } = looseUsers();
+    expectUnknown(() => loose.count({ wheer: { id: 1 } }), "wheer");
+  });
+
+  test("aggregate: whre (正しい _sum と同居)", () => {
+    const { loose } = looseUsers();
+    expectUnknown(
+      () => loose.aggregate({ _sum: { age: true }, whre: {} }),
+      "whre",
+    );
+  });
+
+  test("groupBy: havng (正しい by と同居)", () => {
+    const { loose } = looseUsers();
+    expectUnknown(
+      () => loose.groupBy({ by: ["name"], havng: { age: { gt: 1 } } }),
+      "havng",
+    );
+  });
+
+  test("create: dta はエラーになり行を作らない", () => {
+    const { loose, typed } = looseUsers();
+    expectUnknown(
+      () => loose.create({ dta: { id: 4, name: "Dave", age: 50 } }),
+      "dta",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("createMany: skipDuplicates は近い候補が無いので Available のみ", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () => loose.createMany({ data: [], skipDuplicates: true });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `skipDuplicates`.\n\nAvailable: data");
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("createManyAndReturn: slect", () => {
+    const { loose } = looseUsers();
+    expectUnknown(
+      () => loose.createManyAndReturn({ data: [], slect: {} }),
+      "slect",
+    );
+  });
+
+  test("update: wher はエラーになり行を更新しない", () => {
+    const { loose, typed } = looseUsers();
+    expectUnknown(
+      () => loose.update({ wher: { id: 1 }, data: { name: "X" } }),
+      "wher",
+    );
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+    });
+  });
+
+  test("updateMany: limt はエラーになり行を更新しない", () => {
+    const { loose, typed } = looseUsers();
+    expectUnknown(
+      () => loose.updateMany({ where: {}, data: { age: 0 }, limt: 1 }),
+      "limt",
+    );
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+    });
+  });
+
+  test("updateManyAndReturn: datta", () => {
+    const { loose } = looseUsers();
+    expectUnknown(
+      () => loose.updateManyAndReturn({ where: {}, datta: { age: 0 } }),
+      "datta",
+    );
+  });
+
+  test("upsert: craete", () => {
+    const { loose } = looseUsers();
+    expectUnknown(
+      () =>
+        loose.upsert({
+          where: { id: 1 },
+          craete: { id: 1 },
+          update: { name: "X" },
+        }),
+      "craete",
+    );
+  });
+
+  test("delete: includ はエラーになり行を削除しない", () => {
+    const { loose, typed } = looseUsers();
+    expectUnknown(
+      () => loose.delete({ where: { id: 1 }, includ: {} }),
+      "includ",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+});
+
+describe("where 内の未知演算子(経路別)", () => {
+  test("AND の中でもエラー", () => {
+    const { loose } = looseUsers();
+    expectUnknown(
+      () => loose.findMany({ where: { AND: [{ age: { gth: 10 } }] } }),
+      "gth",
+    );
+  });
+
+  test("OR の中でもエラー", () => {
+    const { loose } = looseUsers();
+    expectUnknown(
+      () => loose.findMany({ where: { OR: [{ age: { lts: 10 } }] } }),
+      "lts",
+    );
+  });
+
+  test("NOT の中でもエラー", () => {
+    const { loose } = looseUsers();
+    expectUnknown(
+      () => loose.findMany({ where: { NOT: [{ age: { eqauls: 10 } }] } }),
+      "eqauls",
+    );
+  });
+
+  test("リレーションフィルタの内側でもエラー", () => {
+    const { loose } = looseUsers({ relations: true });
+    const fn = () =>
+      loose.findMany({
+        where: { posts: { some: { title: { containz: "Post" } } } },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `containz`. Did you mean `contains`?");
+  });
+
+  test("where: { 列: {} } は従来どおり全件マッチ(挙動維持)", () => {
+    const { typed } = looseUsers();
+    expect(typed.findMany({ where: { age: {} } })).toHaveLength(3);
+  });
+});
+
+describe("skip センチネル", () => {
+  test("値が skip のキーは省略扱いになり未知キー検証にかからない", () => {
+    const { loose } = looseUsers();
+    expect(loose.findMany({ where: { id: 1 }, foo: skip })).toEqual([
+      { id: 1, name: "Alice", age: 20 },
+    ]);
+  });
+});
+
+describe("$transaction 経由", () => {
+  test("tx 内の deleteMany({whre}) もエラーになりシートが変化しない", () => {
+    const env = buildTxTestEnv();
+    const tx = (env.client as any).$transaction.bind(env.client);
+    expect(() =>
+      tx((txClient: any) => {
+        txClient.Users.deleteMany({ whre: { name: "Alice" } });
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+    ]);
+  });
+});
+
+describe("$extends 経由", () => {
+  test("query フックを素通しした未知キーもエラー", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      query: {
+        Users: {
+          deleteMany({ args, query }) {
+            return query(args);
+          },
+        },
+      },
+    });
+    const loose: any = extended.Users;
+    expectUnknown(() => loose.deleteMany({ whre: { name: "Alice" } }), "whre");
+    expect(extended.Users.count({})).toBe(3);
+  });
+
+  test("result 拡張と select の組み合わせは従来どおり動く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      result: {
+        Users: {
+          upperName: {
+            needs: { name: true },
+            compute: (user: { name: string }) => user.name.toUpperCase(),
+          },
+        },
+      },
+    });
+    expect(
+      extended.Users.findFirst({
+        where: { id: 1 },
+        select: { upperName: true },
+      }),
+    ).toEqual({ upperName: "ALICE" });
+  });
+});

--- a/src/errors/argument/argumentError.ts
+++ b/src/errors/argument/argumentError.ts
@@ -1,3 +1,5 @@
+import { suggestClosest } from "../../util/other/suggestClosest";
+
 class GassmaMissingArgumentError extends Error {
   constructor(argumentName: string) {
     super(`Argument \`${argumentName}\` is missing.`);
@@ -5,4 +7,21 @@ class GassmaMissingArgumentError extends Error {
   }
 }
 
-export { GassmaMissingArgumentError };
+class GassmaUnknownArgumentError extends Error {
+  constructor(argumentName: string, availableArguments: string[]) {
+    const available = Array.isArray(availableArguments)
+      ? availableArguments
+      : [];
+    const suggestion = suggestClosest(argumentName, available);
+    const head =
+      suggestion === null
+        ? `Unknown argument \`${argumentName}\`.`
+        : `Unknown argument \`${argumentName}\`. Did you mean \`${suggestion}\`?`;
+    const tail =
+      available.length === 0 ? "" : `\n\nAvailable: ${available.join(", ")}`;
+    super(`${head}${tail}`);
+    this.name = "GassmaUnknownArgumentError";
+  }
+}
+
+export { GassmaMissingArgumentError, GassmaUnknownArgumentError };

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -75,6 +75,10 @@ import { resolveCount } from "./util/relation/resolveCount";
 import { resolveInclude } from "./util/relation/resolveInclude";
 import { resolveWhereRelation } from "./util/relation/whereRelation/resolveWhereRelation";
 import { normalizeQueryInput } from "./util/skip/normalizeQueryInput";
+import {
+  type ValidatedOperation,
+  validateTopLevelKeys,
+} from "./util/validate/validateTopLevelKeys";
 import { resolveNestedUpdate } from "./util/update/nestedWrite/resolveNestedUpdate";
 import { resolveNumberOperations } from "./util/update/resolveNumberOperation";
 import { updateManyFunc } from "./util/update/updateMany";
@@ -170,12 +174,17 @@ class GassmaController {
     this.strictUndefinedChecks = enabled;
   }
 
-  private normalizeInput<T>(input: T): T;
-  private normalizeInput(input: unknown): unknown {
-    return normalizeQueryInput(
+  private normalizeInput<T>(input: T, operation: ValidatedOperation): T;
+  private normalizeInput(
+    input: unknown,
+    operation: ValidatedOperation,
+  ): unknown {
+    const normalized = normalizeQueryInput(
       input === undefined ? {} : input,
       this.strictUndefinedChecks,
     );
+    validateTopLevelKeys(operation, normalized);
+    return normalized;
   }
 
   private stripIgnored(data: Record<string, unknown>): Record<string, unknown> {
@@ -351,7 +360,7 @@ class GassmaController {
   }
 
   private createManyRaw(createdData: CreateManyData) {
-    createdData = this.normalizeInput(createdData);
+    createdData = this.normalizeInput(createdData, "createMany");
     if (createdData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
@@ -366,7 +375,7 @@ class GassmaController {
   }
 
   private createManyAndReturnRaw(createdData: CreateManyAndReturnData) {
-    createdData = this.normalizeInput(createdData);
+    createdData = this.normalizeInput(createdData, "createManyAndReturn");
     if (createdData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
@@ -412,7 +421,7 @@ class GassmaController {
   }
 
   private createRaw(createdData: CreateData) {
-    createdData = this.normalizeInput(createdData);
+    createdData = this.normalizeInput(createdData, "create");
     if (createdData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
@@ -464,7 +473,7 @@ class GassmaController {
 
   public findFirst(findData: FindFirstData = {}) {
     return runWithReadCache(() =>
-      this.findFirstRaw(this.normalizeInput(findData)),
+      this.findFirstRaw(this.normalizeInput(findData, "findFirst")),
     );
   }
 
@@ -658,7 +667,7 @@ class GassmaController {
 
   public findMany(findData: FindData = {}) {
     return runWithReadCache(() =>
-      this.findManyRaw(this.normalizeInput(findData)),
+      this.findManyRaw(this.normalizeInput(findData, "findMany")),
     );
   }
 
@@ -829,7 +838,7 @@ class GassmaController {
   }
 
   private updateRaw(updateData: UpdateSingleData) {
-    updateData = this.normalizeInput(updateData);
+    updateData = this.normalizeInput(updateData, "update");
     if (updateData.where === undefined) {
       throw new GassmaMissingArgumentError("where");
     }
@@ -897,7 +906,7 @@ class GassmaController {
   }
 
   private updateManyRaw(updateData: UpdateData) {
-    updateData = this.normalizeInput(updateData);
+    updateData = this.normalizeInput(updateData, "updateMany");
     if (updateData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
@@ -934,7 +943,7 @@ class GassmaController {
   }
 
   private updateManyAndReturnRaw(updateData: UpdateData) {
-    updateData = this.normalizeInput(updateData);
+    updateData = this.normalizeInput(updateData, "updateManyAndReturn");
     if (updateData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
@@ -980,7 +989,7 @@ class GassmaController {
   }
 
   private upsertRaw(upsertData: UpsertSingleData) {
-    upsertData = this.normalizeInput(upsertData);
+    upsertData = this.normalizeInput(upsertData, "upsert");
     if (upsertData.where === undefined) {
       throw new GassmaMissingArgumentError("where");
     }
@@ -1034,7 +1043,7 @@ class GassmaController {
   }
 
   private deleteRaw(deleteData: DeleteSingleData) {
-    deleteData = this.normalizeInput(deleteData);
+    deleteData = this.normalizeInput(deleteData, "delete");
     if (deleteData.where === undefined) {
       throw new GassmaMissingArgumentError("where");
     }
@@ -1070,7 +1079,7 @@ class GassmaController {
   }
 
   private deleteManyRaw(deleteData: DeleteData) {
-    deleteData = this.normalizeInput(deleteData);
+    deleteData = this.normalizeInput(deleteData, "deleteMany");
     deleteData = { ...deleteData, where: this.resolveWhere(deleteData.where) };
 
     if (this.relationContext) {
@@ -1087,7 +1096,7 @@ class GassmaController {
 
   public aggregate(aggregateData: AggregateData) {
     return runWithReadCache(() =>
-      this.aggregateRaw(this.normalizeInput(aggregateData)),
+      this.aggregateRaw(this.normalizeInput(aggregateData, "aggregate")),
     );
   }
 
@@ -1101,7 +1110,7 @@ class GassmaController {
 
   public count(countData: CountData = {}) {
     return runWithReadCache(() =>
-      this.countRaw(this.normalizeInput(countData)),
+      this.countRaw(this.normalizeInput(countData, "count")),
     );
   }
 
@@ -1112,7 +1121,7 @@ class GassmaController {
 
   public groupBy(groupByData: GroupByData) {
     return runWithReadCache(() =>
-      this.groupByRaw(this.normalizeInput(groupByData)),
+      this.groupByRaw(this.normalizeInput(groupByData, "groupBy")),
     );
   }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -629,6 +629,9 @@ declare namespace Gassma {
   class GassmaMissingArgumentError extends Error {
     constructor(argumentName: string);
   }
+  class GassmaUnknownArgumentError extends Error {
+    constructor(argumentName: string, availableArguments: string[]);
+  }
   class GassmaFindSelectOmitConflictError extends Error {
     constructor();
   }

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -86,6 +86,8 @@ export const GassmaSkipInArrayError = skipErrors.GassmaSkipInArrayError;
 
 export const GassmaMissingArgumentError =
   argumentErrors.GassmaMissingArgumentError;
+export const GassmaUnknownArgumentError =
+  argumentErrors.GassmaUnknownArgumentError;
 
 export const GassmaFindSelectOmitConflictError =
   findErrors.GassmaFindSelectOmitConflictError;

--- a/src/util/filterConditions/filterConditions.ts
+++ b/src/util/filterConditions/filterConditions.ts
@@ -1,5 +1,21 @@
+import { GassmaUnknownArgumentError } from "../../errors/argument/argumentError";
 import type { FilterConditions, GassmaAny } from "../../types/coreTypes";
 import { containsValue, isValueEqual } from "../other/isValueEqual";
+
+const FILTER_OPERATORS = [
+  "equals",
+  "not",
+  "in",
+  "notIn",
+  "lt",
+  "lte",
+  "gt",
+  "gte",
+  "contains",
+  "startsWith",
+  "endsWith",
+  "mode",
+];
 
 const isFilterConditionsMatch = (
   cellData: GassmaAny,
@@ -78,7 +94,7 @@ const isFilterConditionsMatch = (
       case "mode":
         return true;
       default:
-        return true;
+        throw new GassmaUnknownArgumentError(optionName, FILTER_OPERATORS);
     }
   });
 

--- a/src/util/other/suggestClosest.ts
+++ b/src/util/other/suggestClosest.ts
@@ -1,0 +1,40 @@
+const levenshtein = (a: string[], b: string[]): number => {
+  let prev = Array.from({ length: a.length + 1 }, (_, i) => i);
+
+  b.forEach((bChar, j) => {
+    const current = [j + 1];
+    a.forEach((aChar, i) => {
+      const cost = aChar === bChar ? 0 : 1;
+      current.push(Math.min(current[i] + 1, prev[i + 1] + 1, prev[i] + cost));
+    });
+    prev = current;
+  });
+
+  return prev[a.length];
+};
+
+const MAX_DISTANCE = 3;
+
+const suggestClosest = (input: string, candidates: string[]): string | null => {
+  const inputChars = Array.from(input);
+
+  let best: string | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  candidates.forEach((candidate) => {
+    const distance = levenshtein(inputChars, Array.from(candidate));
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  });
+
+  if (best === null) return null;
+
+  const maxLength = Math.max(inputChars.length, Array.from(best).length);
+  if (bestDistance <= MAX_DISTANCE && bestDistance < maxLength) return best;
+
+  return null;
+};
+
+export { suggestClosest };

--- a/src/util/validate/validateTopLevelKeys.ts
+++ b/src/util/validate/validateTopLevelKeys.ts
@@ -1,0 +1,82 @@
+import { GassmaUnknownArgumentError } from "../../errors/argument/argumentError";
+import { isDict } from "../other/isDict";
+
+const FIND_KEYS = [
+  "where",
+  "orderBy",
+  "cursor",
+  "take",
+  "skip",
+  "distinct",
+  "select",
+  "omit",
+  "include",
+];
+
+const ALLOWED_TOP_LEVEL_KEYS = {
+  findMany: FIND_KEYS,
+  findFirst: FIND_KEYS,
+  count: [
+    "where",
+    "orderBy",
+    "cursor",
+    "take",
+    "skip",
+    "distinct",
+    "select",
+    "omit",
+  ],
+  aggregate: [
+    "where",
+    "orderBy",
+    "cursor",
+    "take",
+    "skip",
+    "_avg",
+    "_count",
+    "_max",
+    "_min",
+    "_sum",
+  ],
+  groupBy: [
+    "by",
+    "where",
+    "having",
+    "orderBy",
+    "take",
+    "skip",
+    "_avg",
+    "_count",
+    "_max",
+    "_min",
+    "_sum",
+  ],
+  create: ["data", "select", "omit", "include"],
+  createMany: ["data"],
+  createManyAndReturn: ["data", "select", "omit", "include"],
+  update: ["where", "data", "select", "omit", "include"],
+  updateMany: ["where", "data", "limit"],
+  updateManyAndReturn: ["where", "data", "limit"],
+  upsert: ["where", "create", "update", "select", "omit", "include"],
+  delete: ["where", "select", "omit", "include"],
+  deleteMany: ["where", "limit"],
+};
+
+type ValidatedOperation = keyof typeof ALLOWED_TOP_LEVEL_KEYS;
+
+const validateTopLevelKeys = (
+  operation: ValidatedOperation,
+  input: unknown,
+): void => {
+  if (!isDict(input)) return;
+
+  const allowed = ALLOWED_TOP_LEVEL_KEYS[operation];
+  Object.keys(input).forEach((key) => {
+    if (!allowed.includes(key)) {
+      throw new GassmaUnknownArgumentError(key, allowed);
+    }
+  });
+};
+
+export { validateTopLevelKeys };
+export type { ValidatedOperation };


### PR DESCRIPTION
typo が黙って無視されて全件削除を引き起こす問題への対応、**3段階の1段目**です。調査の全体像は `LLM/typo-silence.html`(ローカル)にまとめています。

> [!WARNING]
> **破壊的変更です。** これまで黙って通っていた入力がエラーになります。ただしその変化は、**すでにバグとして踏んでいたものが表面化するだけ**です。

## 問題

1文字の書き間違いで全件が消えていました。

```js
deleteMany({ whre: { 名前: "Alice" } })        // where の typo
// → {"count":8}  全データ行が削除される(見出し行のみ残る)

deleteMany({ where: { 年齢: { gth: 30 } } })   // gt の typo
// → {"count":8}  全件削除(正しい gt なら 4)
```

原因は2つです。

- **未知のトップレベルキーを誰も検証していない**。`deleteData.where ?? {}` の形なので、`whre` は誰にも見られず `where` が `undefined` → `{}` → **「引数なし = 全件」という正規の仕様に合流**する
- **未知の演算子が `true` になる**。`filterConditions.ts` の `default: return true`。判定が `Object.keys().every()` なので、未知キーが1つ真になると条件全体が通る

Prisma 7.4.1 は同じ入力を型と実行時の二重で拒否し、**データに一切触れません**(実測で件数不変を確認済み)。

## 修正

### トップレベルキーの検証

**16操作それぞれの許可リスト**を作り、未知キーを拒否します。検証は `normalizeInput`(全16操作がちょうど1回通る唯一の choke point)に差し込み、**ロジックは `src/util/validate/` 側**に置いています(`gassmaController.ts` にロジックを増やさないため)。

許可リストは推測ではなく、**実装が実際に読んでいるキー**を全経路 file:line で洗い出して決めています。

### 未知の演算子

`default: return true` を throw に変更。`where` 直下・`AND`/`OR`/`NOT` の中・リレーションフィルタの内側・`groupBy` の `having` は**すべて単一の `isFilterConditionsMatch` に合流する**構造なので、1箇所の変更で全経路をカバーします(経路別のテストあり)。

`where: { 年齢: {} }`(空オブジェクト = 全件マッチ)は**キーが0個で未知キーが存在しない**ため、挙動を変えていません。

## エラーメッセージ

新設した `GassmaUnknownArgumentError` は、既存の `GassmaMissingArgumentError`(``Argument `data` is missing.``)と同じ Prisma 文体に揃えています。

```
Unknown argument `wehre`. Did you mean `where`?

Available: where, orderBy, cursor, take, skip, distinct, select, omit, include
```

```
Unknown argument `gth`. Did you mean `gt`?

Available: equals, not, in, notIn, lt, lte, gt, gte, contains, startsWith, endsWith, mode
```

近い候補が無いときは**推測を出さず一覧だけ**にします(Prisma も同じ)。

```
Unknown argument `zzzzzz`.

Available: where, orderBy, cursor, take, skip, distinct, select, omit, include
```

サジェストは Levenshtein 距離を**コードポイント単位**で計算し、「距離 ≤ 3 かつ 距離 < 両者の最大文字数」で採用します。比率ベースのしきい値だと `名まえ` → `名前`(距離2・最大長3)のような**短い日本語の列名で全滅する**ため絶対値にしています。後者の条件は「全文字が異なる短い入力」への誤サジェストを排除するためです(テストで固定)。

## 壊していないことの確認

- **内部呼び出し**: `RelationContext` 経由の6コールバックの呼び出し箇所(nested write / cascade / whereRelation / resolveCount 等、40箇所超)を file:line で列挙し、渡すキーが `where` / `data` / `include` / `omit` / `take` / `limit` と `{}` のみ = **すべて正規キー**であることを確認
- **既存テスト2,192件が1文字も変更せずに green**(リレーション・nested write・cascade・トランザクション・拡張のテストを含む)
- **`$transaction`**: tx 内の `deleteMany({whre})` がエラーになり、**シートが変化しない**(flush されない)ことをテストで確認
- **`$extends`**: query フック素通しで未知キーがエラーになること、result 拡張 + `select`(算出フィールド)の正常系が従来どおり動くことを確認

## 検証結果

- `npm test`: **2,238件 全 green**(2,192 → +46、**既存テストの変更0件**)
- `tsc --noEmit` / lint / format / **`verify:bundle`**(公開シンボル 56件・エラークラス 46件)すべて pass

追加テストは、サジェストのしきい値(7件)、エラーメッセージ形式(6件)、演算子の全経路(5件)、**冒頭2例のシート不変を含む16操作の検証**(26件)、公開 API の同一性(2件)です。

## 判断が要る点

**1. `updateManyAndReturn` の `select` / `omit` / `include` を不許可にしました。**

実装がこれらを読んでいないためです。現状を実測して確認しました。

```js
// 現在の main
updateManyAndReturn({ where: {...}, data: {...}, select: { name: true } })
// → [{"id":1,"name":"Alice","age":21}]   select が無視され全列が返る
```

**黙って無視するより、エラーで知らせる方が良い**という今回の方針に沿った判断です。ただし Prisma は `updateManyAndReturn` で `select` をサポートしているので、**将来 select 対応を実装したら許可に戻す**性質のものです。

**2. `count` は実装準拠で `select` / `omit` / `distinct` も許可しています。**

型宣言は `where/orderBy/take/skip/cursor` のみですが、実装は spread によりこれらも機能してしまうため。Prisma の `count` は `select` は受けますが `omit`/`distinct` は受けないので、**Prisma 完全一致にするなら別途縮小の判断**が要ります。

**3. skip センチネル(`{ foo: skip }`)は検証前に除去されるためエラーになりません。**

`skip` = 省略扱いという既存仕様に整合させています。

## この後

- **2段目**: 数値演算子・nested write・`orderBy` の方向の許可リスト(データ破壊と nested write の黙殺が消える)
- **3段目**: 列名照合(残りの全件破壊・先頭行破壊・no-op が消える)

また **gassma-cli 側の `getGassmaErrorClasses()` が手動メンテのミラー**になっているため、`GassmaUnknownArgumentError` の追随 PR を別途出します(コンストラクタは `(argumentName: string, availableArguments: string[])`、独自プロパティなし)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)