### PR TITLE
fix: count の引数を実際にサポートしているものだけに絞る

### DIFF
--- a/src/__test__/util/unknownArguments.test.ts
+++ b/src/__test__/util/unknownArguments.test.ts
@@ -77,6 +77,30 @@ describe("各操作の未知のトップレベルキー", () => {
     expectUnknown(() => loose.count({ wheer: { id: 1 } }), "wheer");
   });
 
+  test("count: select は許可されない", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.count({ select: { _all: true } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `select`.\n\nAvailable: where, orderBy, take, skip, cursor",
+    );
+  });
+
+  test("count: omit は許可されない", () => {
+    const { loose } = looseUsers();
+    expectUnknown(() => loose.count({ omit: { name: true } }), "omit");
+  });
+
+  test("count: distinct は許可されない", () => {
+    const { loose } = looseUsers();
+    expectUnknown(() => loose.count({ distinct: ["name"] }), "distinct");
+  });
+
+  test("count: where は従来どおり効く", () => {
+    const { typed } = looseUsers();
+    expect(typed.count({ where: { name: "Alice" } })).toBe(1);
+  });
+
   test("aggregate: whre (正しい _sum と同居)", () => {
     const { loose } = looseUsers();
     expectUnknown(

--- a/src/util/validate/validateTopLevelKeys.ts
+++ b/src/util/validate/validateTopLevelKeys.ts
@@ -16,16 +16,7 @@ const FIND_KEYS = [
 const ALLOWED_TOP_LEVEL_KEYS = {
   findMany: FIND_KEYS,
   findFirst: FIND_KEYS,
-  count: [
-    "where",
-    "orderBy",
-    "cursor",
-    "take",
-    "skip",
-    "distinct",
-    "select",
-    "omit",
-  ],
+  count: ["where", "orderBy", "take", "skip", "cursor"],
   aggregate: [
     "where",
     "orderBy",


### PR DESCRIPTION
#192 のレビューで挙げた「判断が要る点 2」への対応です。ご指示(**Prisma で使えないなら使えなくする**)に従いました。

## 問題

`count` は `select` / `omit` / `distinct` を受け取れてしまいますが、**3つとも完全に無視して素の数値を返す**だけでした。実測結果です。

```js
count()                            // → 2
count({ select: { _all: true } })  // → 2      Prisma なら { _all: 2 }
count({ select: { name: true } })  // → 2
count({ omit: { name: true } })    // → 2
count({ distinct: ["name"] })      // → 2
count({ where: { name: "Alice" } })// → 1      where は正しく効く
```

実装が spread で下位の find に素通ししていたため受理されるだけで、**型宣言(`CountData`)にもこの3つは存在しません**。

Prisma の挙動は以下です。

- **`select`**: サポートされている(`{ _all: 2 }` のようなオブジェクトを返す)
- **`omit` / `distinct`**: **受け付けない**

## 修正

`count` の許可キーを **`where` / `orderBy` / `take` / `skip` / `cursor` の5つ**に絞りました。`CountData` 型の宣言と一致します。3つとも `GassmaUnknownArgumentError` になります。

```
Unknown argument `select`.

Available: where, orderBy, take, skip, cursor
```

`select` は Prisma にある機能なので**将来実装したら許可に戻す**性質のものですが、**実装されていないものを黙って受理するより、受け付けないと明示する方が良い**という判断です。未実装であることはメモリに記録しました。

## 検証結果

- `npm test`: **2,242件 全 green**(2,238 → +4)。**落ちた既存テストはゼロ**で、`count({select})` 等を使う既存テストは存在しませんでした(grep でも確認)
- `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル56件)すべて pass

実装の変更は許可リストの1箇所のみです。追加テストは3つのエラー化(メッセージの `Available:` まで検証)と、`where` の正常系維持です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)