### PR TITLE
fix: 未知の書き込み操作とソート方向をエラーにする(typo 対策 2/3)

### DIFF
--- a/src/__test__/errors/invalidValueError.test.ts
+++ b/src/__test__/errors/invalidValueError.test.ts
@@ -1,0 +1,29 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+
+describe("GassmaInvalidValueError", () => {
+  test("メッセージが Prisma の文体でピン留めされている", () => {
+    const error = new GassmaInvalidValueError("orderBy", '"asc" | "desc"');
+    expect(error.message).toBe(
+      'Invalid value for argument `orderBy`. Expected "asc" | "desc".',
+    );
+    expect(error.name).toBe("GassmaInvalidValueError");
+  });
+
+  test("nulls 用のメッセージも組み立てられる", () => {
+    const error = new GassmaInvalidValueError("nulls", '"first" | "last"');
+    expect(error.message).toBe(
+      'Invalid value for argument `nulls`. Expected "first" | "last".',
+    );
+  });
+
+  test("Error を継承している", () => {
+    const error = new GassmaInvalidValueError("orderBy", '"asc" | "desc"');
+    expect(Object.prototype.toString.call(error)).toBe("[object Error]");
+  });
+
+  test("toThrow(コンストラクタ) でキャッチできる", () => {
+    expect(() => {
+      throw new GassmaInvalidValueError("sort", '"asc" | "desc"');
+    }).toThrow(GassmaInvalidValueError);
+  });
+});

--- a/src/__test__/util/unknownOperations.test.ts
+++ b/src/__test__/util/unknownOperations.test.ts
@@ -1,0 +1,402 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../errors/argument/argumentError";
+import { raw } from "../../util/raw/raw";
+import { buildTestClient, sheetOf } from "./extends/extendsTestClient";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "./transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const NUMBER_OPS = "increment, decrement, multiply, divide";
+
+const looseUsers = (options?: {
+  relations?: boolean;
+}): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const typed = sheetOf(buildTestClient(options), "Users");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+const expectAliceIntact = (typed: ReturnType<typeof sheetOf>) => {
+  const alice = typed.findFirst({ where: { id: 1 } }) as Record<
+    string,
+    unknown
+  >;
+  expect(alice).toEqual({ id: 1, name: "Alice", age: 20 });
+  expect(typeof alice.age).toBe("number");
+};
+
+describe("数値演算子の typo", () => {
+  test("update: incrment はエラーになりセルの実体が変化しない", () => {
+    const env = buildTxTestEnv();
+    const loose: any = sheetOf(env.client, "Users");
+    const before = env.users.snapshot();
+    const fn = () =>
+      loose.update({ where: { id: 1 }, data: { age: { incrment: 1 } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      `Unknown argument \`incrment\`. Did you mean \`increment\`?\n\nAvailable: ${NUMBER_OPS}`,
+    );
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("update: 正しい increment は従来どおり加算される", () => {
+    const { typed } = looseUsers();
+    const result = typed.update({
+      where: { id: 1 },
+      data: { age: { increment: 1 } },
+    }) as Record<string, unknown>;
+    expect(result.age).toBe(21);
+  });
+
+  test("updateMany: dcrement はエラーになり行が変化しない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () =>
+      loose.updateMany({ where: {}, data: { age: { dcrement: 1 } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `dcrement`. Did you mean `decrement`?",
+    );
+    expectAliceIntact(typed);
+  });
+
+  test("updateManyAndReturn: multiplyy はエラー", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () =>
+      loose.updateManyAndReturn({ where: {}, data: { age: { multiplyy: 2 } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `multiplyy`. Did you mean `multiply`?",
+    );
+    expectAliceIntact(typed);
+  });
+
+  test("upsert(update 側): incrment はエラーになり行が変化しない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () =>
+      loose.upsert({
+        where: { id: 1 },
+        create: { id: 1, name: "Alice", age: 20 },
+        update: { age: { incrment: 1 } },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expectAliceIntact(typed);
+  });
+
+  test("有効キーと未知キーが混在してもエラー", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () =>
+      loose.update({
+        where: { id: 1 },
+        data: { age: { increment: 1, foo: 2 } },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(`Unknown argument \`foo\`.\n\nAvailable: ${NUMBER_OPS}`);
+    expectAliceIntact(typed);
+  });
+
+  test("Date の値は素通しされる", () => {
+    const { typed } = looseUsers();
+    const date = new Date("2026-01-02T03:04:05Z");
+    const result = typed.update({
+      where: { id: 1 },
+      data: { name: date },
+    }) as Record<string, unknown>;
+    expect(result.name).toEqual(date);
+  });
+
+  test("Gassma.raw の値は素通しされる", () => {
+    const { typed } = looseUsers();
+    const result = typed.update({
+      where: { id: 1 },
+      data: { name: raw("=SUM(1,2)") },
+    }) as Record<string, unknown>;
+    expect(result.name).toBe("=SUM(1,2)");
+  });
+
+  test("演算子でない普通のオブジェクト値もエラーになり書き込まれない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () =>
+      loose.update({ where: { id: 1 }, data: { name: { foo: "bar" } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(`Unknown argument \`foo\`.\n\nAvailable: ${NUMBER_OPS}`);
+    expectAliceIntact(typed);
+  });
+});
+
+describe("nested write の操作キー typo", () => {
+  const buildRelClient = () => {
+    const client = buildTestClient({ relations: true });
+    return {
+      users: sheetOf(client, "Users"),
+      posts: sheetOf(client, "Posts"),
+      looseUsers: sheetOf(client, "Users") as any,
+    };
+  };
+
+  test("create: crate はエラーになり親も子も作られない", () => {
+    const { users, posts, looseUsers } = buildRelClient();
+    const fn = () =>
+      looseUsers.create({
+        data: {
+          id: 4,
+          name: "Dave",
+          age: 50,
+          posts: { crate: [{ id: 103, title: "New Post" }] },
+        },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `crate`. Did you mean `create`?\n\nAvailable: create, createMany, connect, connectOrCreate",
+    );
+    expect(users.count({})).toBe(3);
+    expect(posts.count({})).toBe(2);
+  });
+
+  test("create: connct はエラー", () => {
+    const { looseUsers, users } = buildRelClient();
+    const fn = () =>
+      looseUsers.create({
+        data: { id: 4, name: "Dave", age: 50, posts: { connct: { id: 101 } } },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `connct`. Did you mean `connect`?");
+    expect(users.count({})).toBe(3);
+  });
+
+  test("create: update 専用の set は create では許されない", () => {
+    const { looseUsers, users } = buildRelClient();
+    const fn = () =>
+      looseUsers.create({
+        data: { id: 4, name: "Dave", age: 50, posts: { set: [] } },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `set`.\n\nAvailable: create, createMany, connect, connectOrCreate",
+    );
+    expect(users.count({})).toBe(3);
+  });
+
+  test("update: disconect はエラーになり行が変化しない", () => {
+    const { looseUsers, users } = buildRelClient();
+    const fn = () =>
+      looseUsers.update({
+        where: { id: 1 },
+        data: { posts: { disconect: true } },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `disconect`. Did you mean `disconnect`?\n\nAvailable: create, createMany, connect, connectOrCreate, update, delete, deleteMany, disconnect, set",
+    );
+    expectAliceIntact(users);
+  });
+
+  test("update: st は set をサジェストする", () => {
+    const { looseUsers } = buildRelClient();
+    const fn = () =>
+      looseUsers.update({ where: { id: 1 }, data: { posts: { st: [] } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `st`. Did you mean `set`?");
+  });
+
+  test("update: 正しい set は従来どおり動く", () => {
+    const { users, posts } = buildRelClient();
+    const looseU: any = users;
+    looseU.update({ where: { id: 1 }, data: { posts: { set: [] } } });
+    expect(posts.count({ where: { authorId: 1 } })).toBe(0);
+  });
+
+  test("connectOrCreate の内側キー creat はエラー", () => {
+    const { looseUsers, posts } = buildRelClient();
+    const fn = () =>
+      looseUsers.create({
+        data: {
+          id: 4,
+          name: "Dave",
+          age: 50,
+          posts: {
+            connectOrCreate: {
+              where: { id: 103 },
+              creat: { id: 103, title: "New Post" },
+            },
+          },
+        },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `creat`. Did you mean `create`?\n\nAvailable: where, create",
+    );
+    expect(posts.count({})).toBe(2);
+  });
+
+  test("connectOrCreate の内側キー wher(配列形式・update 経由)もエラー", () => {
+    const { looseUsers } = buildRelClient();
+    const fn = () =>
+      looseUsers.update({
+        where: { id: 1 },
+        data: {
+          posts: {
+            connectOrCreate: [
+              { wher: { id: 103 }, create: { id: 103, title: "New Post" } },
+            ],
+          },
+        },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `wher`. Did you mean `where`?");
+  });
+
+  test("正しい nested create は従来どおり動く", () => {
+    const { users, posts } = buildRelClient();
+    const looseU: any = users;
+    looseU.create({
+      data: {
+        id: 4,
+        name: "Dave",
+        age: 50,
+        posts: { create: [{ id: 103, title: "New Post" }] },
+      },
+    });
+    expect(users.count({})).toBe(4);
+    expect(posts.count({ where: { authorId: 4 } })).toBe(1);
+  });
+});
+
+describe("orderBy の方向 typo", () => {
+  test('findMany: "DESC" はエラーになる', () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ orderBy: { age: "DESC" } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      'Invalid value for argument `orderBy`. Expected "asc" | "desc".',
+    );
+  });
+
+  test('findFirst: "DESC" はエラーになる(黙って最小を返さない)', () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findFirst({ orderBy: { age: "DESC" } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+  });
+
+  test("findMany: 配列形式の 2 本目でもエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () =>
+      loose.findMany({ orderBy: [{ age: "desc" }, { name: "ASC" }] });
+    expect(fn).toThrow(GassmaInvalidValueError);
+  });
+
+  test('sort の値 "DESC" はエラー', () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ orderBy: { age: { sort: "DESC" } } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      'Invalid value for argument `sort`. Expected "asc" | "desc".',
+    );
+  });
+
+  test('nulls の値 "frist" はエラー', () => {
+    const { loose } = looseUsers();
+    const fn = () =>
+      loose.findMany({ orderBy: { age: { sort: "desc", nulls: "frist" } } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      'Invalid value for argument `nulls`. Expected "first" | "last".',
+    );
+  });
+
+  test("srot(sort の typo)はサジェスト付きエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ orderBy: { age: { srot: "desc" } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `srot`. Did you mean `sort`?\n\nAvailable: sort, nulls",
+    );
+  });
+
+  test("srot はリレーションありのシートでも同じエラー(生 TypeError にしない)", () => {
+    const { loose } = looseUsers({ relations: true });
+    const fn = () => loose.findMany({ orderBy: { age: { srot: "desc" } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `srot`. Did you mean `sort`?");
+  });
+
+  test("sort と nuls(nulls の typo)の同居もエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () =>
+      loose.findMany({ orderBy: { age: { sort: "desc", nuls: "first" } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `nuls`. Did you mean `nulls`?");
+  });
+
+  test('リレーション orderBy の方向 "DESC" もエラー', () => {
+    const { loose } = looseUsers({ relations: true });
+    const fn = () => loose.findMany({ orderBy: { posts: { _count: "DESC" } } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+  });
+
+  test("正しい orderBy は従来どおり動く", () => {
+    const { typed } = looseUsers();
+    const desc = typed.findMany({ orderBy: { age: "desc" } }) as Record<
+      string,
+      unknown
+    >[];
+    expect(desc.map((r) => r.age)).toEqual([40, 30, 20]);
+    const withInput = typed.findMany({
+      orderBy: { age: { sort: "desc", nulls: "last" } },
+    }) as Record<string, unknown>[];
+    expect(withInput.map((r) => r.age)).toEqual([40, 30, 20]);
+  });
+
+  test("リレーション orderBy(正しい値)は従来どおり動く", () => {
+    const { typed } = looseUsers({ relations: true });
+    const result = typed.findMany({
+      orderBy: { posts: { _count: "desc" } },
+    }) as Record<string, unknown>[];
+    expect(result).toHaveLength(3);
+  });
+});
+
+describe("$transaction / $extends 経由", () => {
+  test("tx 内の update({age:{incrment}}) もエラーになりセルが変化しない", () => {
+    const env = buildTxTestEnv();
+    const tx = (env.client as any).$transaction.bind(env.client);
+    const before = env.users.snapshot();
+    expect(() =>
+      tx((txClient: any) => {
+        txClient.Users.update({
+          where: { id: 1 },
+          data: { age: { incrment: 1 } },
+        });
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("$extends の query フックを素通しした typo もエラー", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      query: {
+        Users: {
+          update({ args, query }) {
+            return query(args);
+          },
+        },
+      },
+    });
+    const loose: any = extended.Users;
+    expect(() =>
+      loose.update({ where: { id: 1 }, data: { age: { incrment: 1 } } }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(extended.Users.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+    });
+  });
+});

--- a/src/errors/argument/argumentError.ts
+++ b/src/errors/argument/argumentError.ts
@@ -24,4 +24,17 @@ class GassmaUnknownArgumentError extends Error {
   }
 }
 
-export { GassmaMissingArgumentError, GassmaUnknownArgumentError };
+class GassmaInvalidValueError extends Error {
+  constructor(argumentName: string, expected: string) {
+    super(
+      `Invalid value for argument \`${argumentName}\`. Expected ${expected}.`,
+    );
+    this.name = "GassmaInvalidValueError";
+  }
+}
+
+export {
+  GassmaMissingArgumentError,
+  GassmaUnknownArgumentError,
+  GassmaInvalidValueError,
+};

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -79,6 +79,10 @@ import {
   type ValidatedOperation,
   validateTopLevelKeys,
 } from "./util/validate/validateTopLevelKeys";
+import {
+  validateCreateDataOperations,
+  validateUpdateDataOperations,
+} from "./util/validate/validateDataOperations";
 import { resolveNestedUpdate } from "./util/update/nestedWrite/resolveNestedUpdate";
 import { resolveNumberOperations } from "./util/update/resolveNumberOperation";
 import { updateManyFunc } from "./util/update/updateMany";
@@ -185,6 +189,12 @@ class GassmaController {
     );
     validateTopLevelKeys(operation, normalized);
     return normalized;
+  }
+
+  private relationNames(): string[] {
+    return this.relationContext
+      ? Object.keys(this.relationContext.relations)
+      : [];
   }
 
   private stripIgnored(data: Record<string, unknown>): Record<string, unknown> {
@@ -364,6 +374,7 @@ class GassmaController {
     if (createdData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
+    validateCreateDataOperations(createdData.data, this.relationNames());
     return createManyFunc(
       this.getGassmaControllerUtil(),
       this.applyCreateManyPreprocess(createdData),
@@ -379,6 +390,7 @@ class GassmaController {
     if (createdData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
+    validateCreateDataOperations(createdData.data, this.relationNames());
     if (createdData.include && createdData.select) {
       throw new GassmaIncludeSelectConflictError();
     }
@@ -425,6 +437,7 @@ class GassmaController {
     if (createdData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
+    validateCreateDataOperations(createdData.data, this.relationNames());
     if (createdData.include && createdData.select) {
       throw new GassmaIncludeSelectConflictError();
     }
@@ -845,6 +858,7 @@ class GassmaController {
     if (updateData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
+    validateUpdateDataOperations(updateData.data, this.relationNames());
     if (updateData.include && updateData.select) {
       throw new GassmaIncludeSelectConflictError();
     }
@@ -910,6 +924,7 @@ class GassmaController {
     if (updateData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
+    validateUpdateDataOperations(updateData.data, this.relationNames());
     updateData = {
       ...updateData,
       where: this.resolveWhere(updateData.where),
@@ -947,6 +962,7 @@ class GassmaController {
     if (updateData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
+    validateUpdateDataOperations(updateData.data, this.relationNames());
     updateData = {
       ...updateData,
       where: this.resolveWhere(updateData.where),
@@ -999,6 +1015,8 @@ class GassmaController {
     if (upsertData.update === undefined) {
       throw new GassmaMissingArgumentError("update");
     }
+    validateCreateDataOperations(upsertData.create, this.relationNames());
+    validateUpdateDataOperations(upsertData.update, this.relationNames());
     if (upsertData.include && upsertData.select) {
       throw new GassmaIncludeSelectConflictError();
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -632,6 +632,9 @@ declare namespace Gassma {
   class GassmaUnknownArgumentError extends Error {
     constructor(argumentName: string, availableArguments: string[]);
   }
+  class GassmaInvalidValueError extends Error {
+    constructor(argumentName: string, expected: string);
+  }
   class GassmaFindSelectOmitConflictError extends Error {
     constructor();
   }

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -88,6 +88,7 @@ export const GassmaMissingArgumentError =
   argumentErrors.GassmaMissingArgumentError;
 export const GassmaUnknownArgumentError =
   argumentErrors.GassmaUnknownArgumentError;
+export const GassmaInvalidValueError = argumentErrors.GassmaInvalidValueError;
 
 export const GassmaFindSelectOmitConflictError =
   findErrors.GassmaFindSelectOmitConflictError;

--- a/src/util/create/nestedWrite/extractRelationData.ts
+++ b/src/util/create/nestedWrite/extractRelationData.ts
@@ -36,4 +36,4 @@ const extractRelationData = (
   return { scalarData, relationOps };
 };
 
-export { extractRelationData, isNestedWriteOperation };
+export { NESTED_WRITE_KEYS, extractRelationData, isNestedWriteOperation };

--- a/src/util/find/findUtil/orderBy.ts
+++ b/src/util/find/findUtil/orderBy.ts
@@ -1,8 +1,13 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../../errors/argument/argumentError";
 import type {
   OrderBy,
   SortOrderInput,
   RelationOrderBy,
 } from "../../../types/coreTypes";
+import { isDict } from "../../other/isDict";
 
 type ParsedOrderByEntry = [
   string,
@@ -22,16 +27,38 @@ const isScalarDirection = (
   return value === "asc" || value === "desc";
 };
 
+const SORT_INPUT_KEYS = ["sort", "nulls"];
+
 const parseOrderByEntry = (option: OrderBy): ParsedOrderByEntry => {
   const [key, value] = Object.entries(option)[0];
   if (isSortOrderInput(value)) {
+    Object.keys(value).forEach((inputKey) => {
+      if (!SORT_INPUT_KEYS.includes(inputKey)) {
+        throw new GassmaUnknownArgumentError(inputKey, SORT_INPUT_KEYS);
+      }
+    });
+    if (!isScalarDirection(value.sort)) {
+      throw new GassmaInvalidValueError("sort", '"asc" | "desc"');
+    }
+    if (
+      value.nulls !== undefined &&
+      value.nulls !== "first" &&
+      value.nulls !== "last"
+    ) {
+      throw new GassmaInvalidValueError("nulls", '"first" | "last"');
+    }
     return [key, value.sort, value.nulls];
   }
   if (isScalarDirection(value)) {
     return [key, value, undefined];
   }
-  // RelationOrderBy should be resolved before reaching here
-  return [key, "asc", undefined];
+  if (isDict(value)) {
+    const innerKey = Object.keys(value)[0];
+    if (innerKey !== undefined) {
+      throw new GassmaUnknownArgumentError(innerKey, SORT_INPUT_KEYS);
+    }
+  }
+  throw new GassmaInvalidValueError("orderBy", '"asc" | "desc"');
 };
 
 const search = (

--- a/src/util/find/findUtil/resolveRelationOrderBy.ts
+++ b/src/util/find/findUtil/resolveRelationOrderBy.ts
@@ -106,6 +106,7 @@ const resolveRelationOrderBy = (
   orderByArr.forEach((entry) => {
     const [key, value] = Object.entries(entry)[0];
     if (!isRelationOrderByValue(value)) return;
+    if (!(key in context.relations)) return;
 
     const relValue = value as Record<string, "asc" | "desc">;
 
@@ -118,7 +119,8 @@ const resolveRelationOrderBy = (
 
   const resolvedOrderBy: OrderBy[] = orderByArr.map((entry) => {
     const [key, value] = Object.entries(entry)[0];
-    if (!isRelationOrderByValue(value)) return entry;
+    if (!isRelationOrderByValue(value) || !(key in context.relations))
+      return entry;
 
     const relValue = value as Record<string, "asc" | "desc">;
     const [sortField, sortDir] = Object.entries(relValue)[0];

--- a/src/util/update/nestedWrite/extractRelationDataForUpdate.ts
+++ b/src/util/update/nestedWrite/extractRelationDataForUpdate.ts
@@ -46,4 +46,8 @@ const extractRelationDataForUpdate = (
   return { scalarData, relationOps };
 };
 
-export { extractRelationDataForUpdate, isUpdateNestedWriteOperation };
+export {
+  UPDATE_NESTED_WRITE_KEYS,
+  extractRelationDataForUpdate,
+  isUpdateNestedWriteOperation,
+};

--- a/src/util/update/resolveNumberOperation.ts
+++ b/src/util/update/resolveNumberOperation.ts
@@ -34,4 +34,9 @@ const resolveNumberOperations = (
   return resolved;
 };
 
-export { isNumberOperation, resolveNumberOperation, resolveNumberOperations };
+export {
+  NUMBER_OPERATION_KEYS,
+  isNumberOperation,
+  resolveNumberOperation,
+  resolveNumberOperations,
+};

--- a/src/util/validate/validateDataOperations.ts
+++ b/src/util/validate/validateDataOperations.ts
@@ -1,0 +1,94 @@
+import { GassmaUnknownArgumentError } from "../../errors/argument/argumentError";
+import { NESTED_WRITE_KEYS } from "../create/nestedWrite/extractRelationData";
+import { isDateValue } from "../other/isDateValue";
+import { isDict } from "../other/isDict";
+import { isRawValue } from "../raw/raw";
+import {
+  UPDATE_NESTED_WRITE_KEYS,
+  isUpdateNestedWriteOperation,
+} from "../update/nestedWrite/extractRelationDataForUpdate";
+import {
+  NUMBER_OPERATION_KEYS,
+  isNumberOperation,
+} from "../update/resolveNumberOperation";
+
+const CONNECT_OR_CREATE_KEYS = ["where", "create"];
+
+const isPlainObjectValue = (value: unknown): value is Record<string, unknown> =>
+  isDict(value) && !isDateValue(value) && !isRawValue(value);
+
+const assertKnownKeys = (
+  value: Record<string, unknown>,
+  allowed: string[],
+): void => {
+  Object.keys(value).forEach((key) => {
+    if (!allowed.includes(key)) {
+      throw new GassmaUnknownArgumentError(key, allowed);
+    }
+  });
+};
+
+const validateConnectOrCreateItems = (
+  operation: Record<string, unknown>,
+): void => {
+  if (!("connectOrCreate" in operation)) return;
+  const rawItems = operation.connectOrCreate;
+  const items = Array.isArray(rawItems) ? rawItems : [rawItems];
+  items.forEach((item) => {
+    if (!isPlainObjectValue(item)) return;
+    assertKnownKeys(item, CONNECT_OR_CREATE_KEYS);
+  });
+};
+
+const validateRelationOperation = (
+  operation: Record<string, unknown>,
+  allowed: string[],
+): void => {
+  assertKnownKeys(operation, allowed);
+  validateConnectOrCreateItems(operation);
+};
+
+const validateCreateRow = (
+  row: Record<string, unknown>,
+  relationNames: string[],
+): void => {
+  Object.entries(row).forEach(([key, value]) => {
+    if (!isPlainObjectValue(value)) return;
+    if (!relationNames.includes(key)) return;
+    validateRelationOperation(value, NESTED_WRITE_KEYS);
+  });
+};
+
+const validateCreateDataOperations = (
+  data: unknown,
+  relationNames: string[],
+): void => {
+  if (Array.isArray(data)) {
+    data.forEach((row) => {
+      if (!isPlainObjectValue(row)) return;
+      validateCreateRow(row, relationNames);
+    });
+    return;
+  }
+  if (!isPlainObjectValue(data)) return;
+  validateCreateRow(data, relationNames);
+};
+
+const validateUpdateDataOperations = (
+  data: unknown,
+  relationNames: string[],
+): void => {
+  if (!isPlainObjectValue(data)) return;
+  Object.entries(data).forEach(([key, value]) => {
+    if (!isPlainObjectValue(value)) return;
+    if (relationNames.includes(key)) {
+      if (isNumberOperation(value)) return;
+      validateRelationOperation(value, UPDATE_NESTED_WRITE_KEYS);
+      return;
+    }
+    if (isUpdateNestedWriteOperation(value)) return;
+    assertKnownKeys(value, NUMBER_OPERATION_KEYS);
+  });
+};
+
+export { validateCreateDataOperations, validateUpdateDataOperations };


### PR DESCRIPTION
typo 対策の**3段階の2段目**です。1段目は #192、`count` の縮小は #193。

> [!WARNING]
> **破壊的変更です。** これまで黙って通っていた入力がエラーになります。

## 問題

### 1. 数値演算子の typo が**データを破壊**する

今回の調査で見つかった中で、**唯一「静かに無視する」のではなく既存データを失わせる**ケースです。

```js
update({ where: { 名前: "Alice" }, data: { 年齢: { incrment: 1 } } })
// → セルの実体  typeof=object  value={"incrment":1}     元の 20 が消える
// → 正しい increment なら 21
```

許可リストの照合に落ちると「演算ではない普通の値」と判定され、**オブジェクトがそのままセルに書き込まれます**。

### 2. nested write の操作キー typo が**完全に黙殺**される

```js
posts.create({ data: { id: 2, title: "B", tags: { crate: [{ name: "n1" }] } } })
// → 返り値 { id: 2, title: "B" }   正しい綴りの返り値と完全に同一
// → Tags / 中間テーブルは無変化
```

`crate` が許可リストに無いため「nested 操作ではない」と判定されて通常の値に落ち、そこから列名照合で消える**2段構え**です。

### 3. `orderBy` の方向 typo が**黙って昇順**になる

```js
findMany({ orderBy: { 年齢: "desc" } })   // → [52,45,35,31,28,28,28,22]
findMany({ orderBy: { 年齢: "DESC" } })   // → [22,28,28,28,31,35,45,52]   逆!
findFirst({ orderBy: { 年齢: "DESC" } })  // → 22(最小)。"desc" なら 52
```

「最新1件」のつもりで最古を掴みます。`{ srot: "desc" }` のように `sort` キー自体を typo すると、リレーションありのシートでは**生の `TypeError`** で落ちていました。

## 修正

実装が実際にサポートしているキー・値の集合で検証します。

- **数値演算子**: `increment` / `decrement` / `multiply` / `divide`(`set` は現行コードに無いため含めていません)
- **nested write**: create 系と update 系で集合が違うので**それぞれ正しい方**で照合します。create で `set` を渡すと `Available: create, createMany, connect, connectOrCreate` でエラーになります。`connectOrCreate` の内側(`where` / `create`)も対象
- **`orderBy`**: 方向は `"asc" | "desc"`、`nulls` は `"first" | "last"`、sort オブジェクトのキーは `sort` / `nulls`

未知のキーは既存の `GassmaUnknownArgumentError`(サジェスト付き)、不正な値は新設の **`GassmaInvalidValueError`** を使います。

```
Unknown argument `incrment`. Did you mean `increment`?
Invalid value for argument `orderBy`. Expected "asc" | "desc".
```

`{ srot: "desc" }` も `Unknown argument \`srot\`. Did you mean \`sort\`?` になり、**生の TypeError が消えます**。

## 「演算」と「普通の値」の判別

ここが設計上の難所でした。`data` の値がオブジェクトのとき、それが数値演算なのか、そのままセルに書くべき値なのかを区別する必要があります。

```ts
isDict(value) && !isDateValue(value) && !isRawValue(value)
```

- **Date** は `isDateValue`(`Object.prototype.toString`)で素通し
- **`Gassma.raw`** は Symbol ブランドで素通し
- **配列**は `isDict` が false なので素通し(従来どおり)

どちらも**realm 安全**です。GAS のライブラリ境界では `instanceof` が偽になるため使えません。

残った「素の dict」は、update の `data` では**正当な値になり得ません**(セルに書けるのはスカラー / Date / Raw のみ)。`{ increment: 1, foo: 2 }` のような**混在も `foo` でエラー**になります。

## 実証(修正前後を実測)

修正前のコードを一時的に復元して before を取り、修正後と比較しています。

| ケース | 修正前 | 修正後 |
|---|---|---|
| `{ 年齢: { incrment: 1 } }` | **セルが `{incrment:1}` になり値が消失** | エラー + **スナップショット完全一致で不変** |
| `tags: { crate: [...] }` | 返り値成功・子は無変化の黙殺 | エラー(親行も作られない) |
| `orderBy: { 年齢: "DESC" }` | `[20,30,40]` と昇順に化ける | `GassmaInvalidValueError` |
| `{ srot: "desc" }` | 生の `TypeError` / 黙って asc | `Unknown argument \`srot\`. Did you mean \`sort\`?` |

## 壊していないことの確認

- 検証の配線は **controller の各メソッド冒頭のみ**(7箇所、各1行)。リレーションの内部呼び出しはすべて `injectRelations` の `*OnSheet` → controller 公開メソッド経由なので、**対象シート側のリレーション集合で再検証される**構造です
- **既存2,242件が期待値無変更で全 green**(nested write・cascade・`$transaction`・`$extends`・読みキャッシュを含む)
- tx 内の update typo と `$extends` の query フック経由の typo についてもテストを新設

## 検証結果

- `npm test`: **2,277件 全 green**(2,242 → +35、**既存テストの変更0件**)
- `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル **57件**・エラークラス 47件)すべて pass

## 判断が要る点

**1. スカラーの `set`(`data: { 年齢: { set: 5 } }`)は素通しのままです。**

Prisma にはある構文ですが gassma は未対応で、**現状はオブジェクトがセルに書かれて破壊されます**。`set` は nested write のキーでもあるため「リレーション名の typo」と区別がつかず、その判別は3段目(列名照合)の領分になります。**スカラー `set` を実装するか、3段目でエラー化するか**の判断をお願いします。

**2. `create` の `data` に非リレーションの dict を渡した場合**(`create({ data: { 年齢: { increment: 1 } } })` 等)も同じ理由で素通しです(Prisma はエラー)。

**3. リレーション内側の `update` の `data`** にある typo は、内部で `updateMany` に到達した時点でエラーになりますが、**親行の書き込み後**なので部分適用が残り得ます。黙殺ではなくエラーにはなるため、前倒しの再帰検証は今回のスコープ外としました。

## cli 追随

**`GassmaInvalidValueError`** を cli のエラーミラーに追加する必要があります(コンストラクタは `(argumentName: string, expected: string)`、独自プロパティなし)。別 PR で対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)