### PR TITLE
fix: distinct / cursor / orderBy の未知の列名をエラーにする(typo 対策 3-3)

### DIFF
--- a/src/__test__/util/find/unknownFieldReferences.test.ts
+++ b/src/__test__/util/find/unknownFieldReferences.test.ts
@@ -1,0 +1,261 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../../errors/argument/argumentError";
+import { buildTestClient, sheetOf } from "../extends/extendsTestClient";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "../transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const looseUsers = (options?: {
+  relations?: boolean;
+}): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const typed = sheetOf(buildTestClient(options), "Users");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+const loosePosts = (): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const typed = sheetOf(buildTestClient({ relations: true }), "Posts");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+describe("distinct: 存在しない列名", () => {
+  test("findMany: typo した列名はエラー(1行に潰れない)", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ distinct: ["aeg"] });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `aeg`. Did you mean `age`?");
+  });
+
+  test("findMany: 文字列指定の typo もエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ distinct: "aeg" });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("findFirst: typo した列名はエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findFirst({ distinct: ["nmae"] });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `nmae`. Did you mean `name`?");
+  });
+
+  test("正しい列と typo が混在してもエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ distinct: ["name", "aeg"] });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("relation orderBy と併用した distinct の typo もエラー", () => {
+    const { loose } = loosePosts();
+    const fn = () =>
+      loose.findMany({
+        orderBy: { author: { name: "asc" } },
+        distinct: ["titel"],
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `titel`. Did you mean `title`?");
+  });
+
+  test("relation orderBy つき findFirst の distinct の typo もエラー", () => {
+    const { loose } = loosePosts();
+    const fn = () =>
+      loose.findFirst({
+        orderBy: { author: { name: "asc" } },
+        distinct: ["titel"],
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("正しい distinct は従来どおり動く", () => {
+    const { typed } = looseUsers();
+    expect(typed.findMany({ distinct: ["name"] })).toHaveLength(3);
+  });
+});
+
+describe("cursor: 存在しない列名", () => {
+  test("findMany: typo した列名はエラー(0行にならない)", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ cursor: { di: 2 } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `di`.\n\nAvailable: id, name, age");
+  });
+
+  test("findFirst: typo した列名はエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findFirst({ cursor: { di: 2 } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("count: typo した列名はエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.count({ cursor: { di: 2 } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("relation orderBy と併用した cursor の typo もエラー", () => {
+    const { loose } = loosePosts();
+    const fn = () =>
+      loose.findMany({
+        orderBy: { author: { name: "asc" } },
+        cursor: { di: 101 },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("正しい cursor は従来どおり動く", () => {
+    const { typed } = looseUsers();
+    expect(typed.findMany({ cursor: { id: 2 } })).toEqual([
+      { id: 2, name: "Bob", age: 30 },
+      { id: 3, name: "Carol", age: 40 },
+    ]);
+  });
+
+  test("存在する列で値が一致しない場合は従来どおり0行", () => {
+    const { typed } = looseUsers();
+    expect(typed.findMany({ cursor: { id: 99 } })).toEqual([]);
+  });
+});
+
+describe("orderBy: 存在しない列名・リレーション名", () => {
+  test("列名の typo (方向指定) はエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ orderBy: { aeg: "desc" } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `aeg`. Did you mean `age`?");
+  });
+
+  test("列名の typo (sort/nulls 形式) はエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () =>
+      loose.findMany({ orderBy: { aeg: { sort: "desc", nulls: "first" } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("リレーション未定義シートで dict 値の未知キーは TypeError でなくエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ orderBy: { nmae: { name: "asc" } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `nmae`. Did you mean `name`?");
+  });
+
+  test("リレーション定義済みシートで未知キーの dict 値は TypeError でなくエラー", () => {
+    const { loose } = loosePosts();
+    const fn = () => loose.findMany({ orderBy: { athor: { name: "asc" } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `athor`. Did you mean `author`?");
+  });
+
+  test("findFirst でも未知キーの dict 値はエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findFirst({ orderBy: { nmae: { name: "asc" } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("複数キーの orderBy でも各キーが検証される", () => {
+    const { loose } = looseUsers();
+    const fn = () =>
+      loose.findMany({ orderBy: [{ name: "asc" }, { aeg: "desc" }] });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("リレーション名に方向を直接指定するとエラー", () => {
+    const { loose } = loosePosts();
+    const fn = () => loose.findMany({ orderBy: { author: "asc" } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+  });
+
+  test("正しいリレーション orderBy は従来どおり動く", () => {
+    const { typed } = loosePosts();
+    expect(typed.findMany({ orderBy: { author: { name: "desc" } } })).toEqual([
+      { id: 102, authorId: 2, title: "Post B" },
+      { id: 101, authorId: 1, title: "Post A" },
+    ]);
+  });
+
+  test("正しい sort/nulls 形式は従来どおり動く", () => {
+    const { typed } = looseUsers();
+    expect(
+      typed.findMany({ orderBy: { age: { sort: "desc", nulls: "first" } } }),
+    ).toEqual([
+      { id: 3, name: "Carol", age: 40 },
+      { id: 2, name: "Bob", age: 30 },
+      { id: 1, name: "Alice", age: 20 },
+    ]);
+  });
+
+  test("スカラーとリレーション混在の orderBy は従来どおり動く", () => {
+    const { typed } = loosePosts();
+    expect(
+      typed.findMany({
+        orderBy: [{ title: "asc" }, { author: { name: "desc" } }],
+      }),
+    ).toEqual([
+      { id: 101, authorId: 1, title: "Post A" },
+      { id: 102, authorId: 2, title: "Post B" },
+    ]);
+  });
+
+  test("$transaction 内でも orderBy の typo はエラー", () => {
+    const env = buildTxTestEnv();
+    const tx = (env.client as any).$transaction.bind(env.client);
+    expect(() =>
+      tx((txClient: any) =>
+        txClient.Users.findMany({ orderBy: { aeg: "desc" } }),
+      ),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("$extends の算出フィールドは orderBy に使えない", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      result: {
+        Users: {
+          upperName: {
+            needs: { name: true },
+            compute: (user: { name: string }) => user.name.toUpperCase(),
+          },
+        },
+      },
+    });
+    const loose: any = extended.Users;
+    expect(() => loose.findMany({ orderBy: { upperName: "asc" } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+  });
+
+  test("$extends の算出フィールドは distinct に使えない", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      result: {
+        Users: {
+          upperName: {
+            needs: { name: true },
+            compute: (user: { name: string }) => user.name.toUpperCase(),
+          },
+        },
+      },
+    });
+    const loose: any = extended.Users;
+    expect(() => loose.findMany({ distinct: ["upperName"] })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+  });
+
+  test("_count の relation orderBy は従来どおり動く", () => {
+    const { typed } = loosePosts();
+    expect(
+      typed.findMany({ orderBy: { comments: { _count: "asc" } } }),
+    ).toEqual([
+      { id: 102, authorId: 2, title: "Post B" },
+      { id: 101, authorId: 1, title: "Post A" },
+    ]);
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -75,6 +75,7 @@ import { resolveCount } from "./util/relation/resolveCount";
 import { resolveInclude } from "./util/relation/resolveInclude";
 import { resolveWhereRelation } from "./util/relation/whereRelation/resolveWhereRelation";
 import { normalizeQueryInput } from "./util/skip/normalizeQueryInput";
+import { validateOrderByKeys } from "./util/validate/validateOrderByKeys";
 import {
   type ValidatedOperation,
   validateTopLevelKeys,
@@ -526,6 +527,13 @@ class GassmaController {
         ? orderBy
         : [orderBy]
       : [];
+    if (orderByArr.length > 0) {
+      validateOrderByKeys(
+        orderByArr,
+        this.getColumnHeaders(),
+        this.relationNames(),
+      );
+    }
     const { hasRelationOrderBy } = separateRelationOrderBy(orderByArr);
 
     if (hasRelationOrderBy && this.relationContext) {
@@ -720,6 +728,13 @@ class GassmaController {
         ? fmOrderBy
         : [fmOrderBy]
       : [];
+    if (fmOrderByArr.length > 0) {
+      validateOrderByKeys(
+        fmOrderByArr,
+        this.getColumnHeaders(),
+        this.relationNames(),
+      );
+    }
     const { hasRelationOrderBy: fmHasRelation } =
       separateRelationOrderBy(fmOrderByArr);
 

--- a/src/util/find/findFirst.ts
+++ b/src/util/find/findFirst.ts
@@ -10,6 +10,10 @@ import { applyCursor } from "./findUtil/applyCursor";
 import { applyDistinct } from "./findUtil/applyDistinct";
 import { applyFindFirstTake } from "./findUtil/applyFindFirstTake";
 import { applySkipTake } from "./findUtil/applySkipTake";
+import {
+  validateCursorKeys,
+  validateDistinctKeys,
+} from "../validate/validateFieldKeys";
 
 const findFirstFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
@@ -49,10 +53,12 @@ const findFirstFunc = (
 
   const cursor = "cursor" in findData ? findData.cursor : null;
   if (cursor) {
+    validateCursorKeys(cursor, titles);
     findDataDictArray = applyCursor(findDataDictArray, cursor);
   }
 
   if (distinct) {
+    validateDistinctKeys(distinct, titles);
     findDataDictArray = applyDistinct(findDataDictArray, distinct);
   }
 

--- a/src/util/find/findFirstWithRelationOrderBy.ts
+++ b/src/util/find/findFirstWithRelationOrderBy.ts
@@ -9,6 +9,11 @@ import { applyCursor } from "./findUtil/applyCursor";
 import { applyDistinct } from "./findUtil/applyDistinct";
 import { applyFindFirstTake } from "./findUtil/applyFindFirstTake";
 import { applySkipTake } from "./findUtil/applySkipTake";
+import { getTitle } from "../core/getTitle";
+import {
+  validateCursorKeys,
+  validateDistinctKeys,
+} from "../validate/validateFieldKeys";
 
 const findFirstWithRelationOrderBy = (
   controllerUtil: GassmaControllerUtil,
@@ -38,6 +43,11 @@ const findFirstWithRelationOrderBy = (
   const directed = applyFindFirstTake(sorted, take);
 
   const cursor = "cursor" in findData ? findData.cursor : null;
+  if (cursor || distinct) {
+    const titles = getTitle(controllerUtil);
+    if (cursor) validateCursorKeys(cursor, titles);
+    if (distinct) validateDistinctKeys(distinct, titles);
+  }
   const cursored = cursor ? applyCursor(directed, cursor) : directed;
 
   const distincted = distinct ? applyDistinct(cursored, distinct) : cursored;

--- a/src/util/find/findMany.ts
+++ b/src/util/find/findMany.ts
@@ -7,6 +7,10 @@ import { findedDataSelect } from "./findUtil/findDataSelect";
 import { omitFunc } from "./findUtil/omit";
 import { orderByFunc } from "./findUtil/orderBy";
 import { applyCursorDistinctSkipTake } from "./findUtil/applyCursorDistinctSkipTake";
+import {
+  validateCursorKeys,
+  validateDistinctKeys,
+} from "../validate/validateFieldKeys";
 
 const findManyFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
@@ -42,6 +46,8 @@ const findManyFunc = (
     );
 
   const cursor = "cursor" in findData ? findData.cursor : null;
+  if (cursor) validateCursorKeys(cursor, titles);
+  if (distinct) validateDistinctKeys(distinct, titles);
   findDataDictArray = applyCursorDistinctSkipTake(
     findDataDictArray,
     cursor,

--- a/src/util/find/findManyWithRelationOrderBy.ts
+++ b/src/util/find/findManyWithRelationOrderBy.ts
@@ -6,6 +6,11 @@ import { resolveRelationOrderBy } from "./findUtil/resolveRelationOrderBy";
 import { applySelectOmit } from "./findUtil/applySelectOmit";
 import { applyCursorDistinctSkipTake } from "./findUtil/applyCursorDistinctSkipTake";
 import type { OrderBy } from "../../types/coreTypes";
+import { getTitle } from "../core/getTitle";
+import {
+  validateCursorKeys,
+  validateDistinctKeys,
+} from "../validate/validateFieldKeys";
 
 const findManyWithRelationOrderBy = (
   controllerUtil: GassmaControllerUtil,
@@ -33,6 +38,11 @@ const findManyWithRelationOrderBy = (
 
   // Step 3: Prisma 実測順 (ソート後に cursor → distinct → skip → take)
   const cursor = "cursor" in findData ? findData.cursor : null;
+  if (cursor || distinct) {
+    const titles = getTitle(controllerUtil);
+    if (cursor) validateCursorKeys(cursor, titles);
+    if (distinct) validateDistinctKeys(distinct, titles);
+  }
   const paged = applyCursorDistinctSkipTake(
     sorted,
     cursor,

--- a/src/util/validate/validateFieldKeys.ts
+++ b/src/util/validate/validateFieldKeys.ts
@@ -1,0 +1,25 @@
+import { GassmaUnknownArgumentError } from "../../errors/argument/argumentError";
+
+const validateFieldKeys = (keys: string[], titles: string[]): void => {
+  keys.forEach((key) => {
+    if (!titles.includes(key)) {
+      throw new GassmaUnknownArgumentError(key, titles);
+    }
+  });
+};
+
+const validateDistinctKeys = (
+  distinct: string | string[],
+  titles: string[],
+): void => {
+  validateFieldKeys(Array.isArray(distinct) ? distinct : [distinct], titles);
+};
+
+const validateCursorKeys = (
+  cursor: Record<string, unknown>,
+  titles: string[],
+): void => {
+  validateFieldKeys(Object.keys(cursor), titles);
+};
+
+export { validateCursorKeys, validateDistinctKeys };

--- a/src/util/validate/validateOrderByKeys.ts
+++ b/src/util/validate/validateOrderByKeys.ts
@@ -1,0 +1,41 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../errors/argument/argumentError";
+import type { OrderBy } from "../../types/coreTypes";
+import { isRelationOrderByValue } from "../find/findUtil/separateRelationOrderBy";
+import { isDict } from "../other/isDict";
+
+const validateOrderByEntryKey = (
+  key: string,
+  value: unknown,
+  titles: string[],
+  relationNames: string[],
+): void => {
+  if (isRelationOrderByValue(value)) {
+    if (relationNames.includes(key) || titles.includes(key)) return;
+    throw new GassmaUnknownArgumentError(key, [...titles, ...relationNames]);
+  }
+  if (titles.includes(key)) return;
+  if (relationNames.includes(key)) {
+    throw new GassmaInvalidValueError(key, "a relation orderBy object");
+  }
+  throw new GassmaUnknownArgumentError(key, [...titles, ...relationNames]);
+};
+
+const validateOrderByKeys = (
+  orderByArr: OrderBy[],
+  titles: string[],
+  relationNames: string[],
+): void => {
+  orderByArr.forEach((entry) => {
+    if (!isDict(entry)) {
+      throw new GassmaInvalidValueError("orderBy", '"asc" | "desc"');
+    }
+    Object.entries(entry).forEach(([key, value]) => {
+      validateOrderByEntryKey(key, value, titles, relationNames);
+    });
+  });
+};
+
+export { validateOrderByKeys };


### PR DESCRIPTION
typo 対策の3段目のうち、**`where` / `data` とは別経路**の3つを担当する PR です。1段目は #192、`count` 縮小は #193、2段目は #194。

> [!WARNING]
> **破壊的変更です。** これまで黙って通っていた入力がエラーになります。

## 問題

`where` の列名 typo が「条件が消えて**全行マッチ**」になるのに対し、この3つは **`row[key]` の dict 参照**で動くため別の壊れ方をします。**間違いを広げるのではなく、違う答えを返します。**

```js
findMany({ distinct: ["aeg"] })      // → 1行に潰れる(全行が undefined キーで同一扱い)
findMany({ cursor: { di: 2 } })      // → 0行(黙って空)
findMany({ orderBy: { aeg: "desc" } })  // → 並び順が変わらない(黙殺)
findMany({ orderBy: { author: "asc" } })  // → リレーション名に方向を直接指定。黙殺
```

`distinct` の「1行に潰れる」は特に紛らわしく、**正しく重複排除した結果に見えます**。

## 修正

キーをシートの見出し(`orderBy` はそれに加えてリレーション名)と照合し、実行前に弾きます。**新しいエラークラスは追加していません**。既存の `GassmaUnknownArgumentError` と `GassmaInvalidValueError` で足ります。

```
Unknown argument `aeg`. Did you mean `age`?
Unknown argument `di`.

Available: id, name, age
```

リレーション名に方向を直接指定した場合(`{ author: "asc" }`)は「未知の引数」ではないので `GassmaInvalidValueError` にしています。Prisma も同じケースをエラーにします。

### 差し込み位置

- **`distinct` / `cursor`**: `findMany` / `findFirst` と、リレーション `orderBy` 併用時の2経路の**計4箇所**。`count` も `findManyFunc` 経由なので `cursor` の検証が効きます
- **`orderBy`**: controller の分岐前に1箇所ずつ(各6行)。`applyDistinct` / `applyCursor` / `orderByFunc` 自体のシグネチャは変えていないので、**それらの既存ユニットテストは無修正**です

値の形(リレーション指定かスカラーか)の判定は、**dispatcher と同じ関数を import** して分類のズレを防いでいます。検証は一時キー生成の**前**に行うため、リレーション `orderBy` の内部処理には干渉しません。

## 壊していないことの確認

- **内部呼び出し**: `injectRelations` の `findManyOnSheet` は `where` / `include` / `omit` しか渡さず、`orderBy` / `cursor` / `distinct` を渡しません(実装で確認)
- **既存2,277件が無修正で全 green**(transaction 系・extends 系・relation orderBy 系・include 系を含む)
- `$transaction` 内の `orderBy` typo、`$extends` の**算出フィールドを `orderBy` / `distinct` に書いた場合**のエラー化もテストで固定(Prisma も算出フィールドはクエリ不可)

## 検証結果

- `npm test`: **2,304件 全 green**(2,277 → +27、**既存テストの変更0件**)
- `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル57件)すべて pass

追加テスト27件のうち10件は**従来動作の維持**を固定するものです(リレーション `orderBy`・`sort`/`nulls` 形式・複数キー混在・`_count`・正常な `distinct`/`cursor`・値が一致しない `cursor` が0行を返すこと)。

## 補足: 事前調査の訂正

調査時に「`{ nmae: { name: "asc" } }` が生の `TypeError` でクラッシュする」と記録していましたが、**現在の main では再現しませんでした**。#194 が `resolveRelationOrderBy` にガードを入れた結果、クラッシュではなく**誤誘導エラー**(typo した外側のキーではなく内側のキーを指す)に変わっていたためです。本 PR で外側のキーを正しく指すようになります。

## 判断が要る点

**`di` → `id` にサジェストが出ません。** `suggestClosest` が「距離 < 文字数」を要求するため、2文字の転置(距離2 = 文字数2)が閾値の外になります。#192 で入れた既存の仕組みの仕様なので**変更していません**。エラー自体は `Available:` 付きで出ます。短い列名でのサジェスト精度を上げたい場合は別途調整が要ります。

## スコープ外にしたもの

- リレーション `orderBy` の**内側**のフィールド typo(`{ author: { nmae: "asc" } }`)— 関連シート側の列検証が必要
- `count` / `aggregate` / `groupBy` の `orderBy` キー検証
- `include` 内の `orderBy`
- `distinct: []` が1行に潰れる既存の挙動

🤖 Generated with [Claude Code](https://claude.com/claude-code)