### PR TITLE
fix: where の未知の列名をエラーにし、to-one の短縮形を受け付ける(typo 対策 3-1)

### DIFF
--- a/src/__test__/util/create/nestedWrite/connectBatch/emptySheetConnect.test.ts
+++ b/src/__test__/util/create/nestedWrite/connectBatch/emptySheetConnect.test.ts
@@ -1,0 +1,130 @@
+import { GassmaClient } from "../../../../../gassma";
+import { GassmaController } from "../../../../../gassmaController";
+import { NestedWriteConnectNotFoundError } from "../../../../../errors/relation/nestedWriteError";
+import { GassmaUnknownArgumentError } from "../../../../../errors/argument/argumentError";
+
+const makeSheet = (name: string, initial: unknown[][]) => {
+  const data = initial.map((row) => [...row]);
+  return {
+    getName: () => name,
+    getLastRow: () => data.length,
+    getLastColumn: () => data[0].length,
+    getRange: (row: number, col: number, numRows: number, numCols: number) => ({
+      getValues: () =>
+        data
+          .slice(row - 1, row - 1 + numRows)
+          .map((r) => r.slice(col - 1, col - 1 + numCols)),
+      setValues: (values: unknown[][]) => {
+        values.forEach((rowValues, i) => {
+          while (data.length < row + i) {
+            data.push(Array(data[0].length).fill(""));
+          }
+          rowValues.forEach((value, j) => {
+            data[row - 1 + i][col - 1 + j] = value;
+          });
+        });
+      },
+    }),
+    getDataRange: () => ({ getValues: () => data }),
+    deleteRow: (rowIndex: number) => {
+      data.splice(rowIndex - 1, 1);
+    },
+    deleteRows: (rowPosition: number, howMany: number) => {
+      data.splice(rowPosition - 1, howMany);
+    },
+  };
+};
+
+const buildClientWithEmptyUsers = (): GassmaClient => {
+  const sheets = [
+    makeSheet("Users", [["id", "name", "age"]]),
+    makeSheet("Posts", [["id", "authorId", "title"]]),
+  ];
+  const mockSpreadsheet = {
+    getId: () => "test-spreadsheet",
+    getSheets: () => sheets,
+    getSheetByName: (name: string) =>
+      sheets.find((sheet) => sheet.getName() === name) ?? null,
+  };
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+  });
+  return new GassmaClient({
+    relations: {
+      Users: {
+        posts: {
+          type: "oneToMany",
+          to: "Posts",
+          field: "id",
+          reference: "authorId",
+        },
+      },
+      Posts: {
+        author: {
+          type: "manyToOne",
+          to: "Users",
+          field: "authorId",
+          reference: "id",
+        },
+      },
+    },
+  });
+};
+
+const controllerOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!(controller instanceof GassmaController)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+afterEach(() => {
+  Object.assign(globalThis, { SpreadsheetApp: undefined });
+});
+
+describe("空シート(0件)への connect / connectOrCreate", () => {
+  test("connectOrCreate は空シートでも従来どおり create 側に倒れる", () => {
+    const client = buildClientWithEmptyUsers();
+    const posts = controllerOf(client, "Posts");
+    const users = controllerOf(client, "Users");
+
+    const loosePosts: any = posts;
+    const created = loosePosts.create({
+      data: {
+        id: 201,
+        title: "First",
+        author: {
+          connectOrCreate: {
+            where: { id: 1 },
+            create: { id: 1, name: "Zoe", age: 5 },
+          },
+        },
+      },
+    });
+
+    expect(created).toEqual({ id: 201, authorId: 1, title: "First" });
+    expect(users.findMany({})).toEqual([{ id: 1, name: "Zoe", age: 5 }]);
+  });
+
+  test("connect は空シートでは従来どおり not found (unknown argument ではない)", () => {
+    const client = buildClientWithEmptyUsers();
+    const loosePosts: any = controllerOf(client, "Posts");
+
+    const fn = () =>
+      loosePosts.create({
+        data: {
+          id: 202,
+          title: "Second",
+          author: { connect: { id: 1 } },
+        },
+      });
+
+    expect(fn).not.toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(NestedWriteConnectNotFoundError);
+  });
+});

--- a/src/__test__/util/ignore/ignoredFieldInWhere.test.ts
+++ b/src/__test__/util/ignore/ignoredFieldInWhere.test.ts
@@ -1,0 +1,105 @@
+import { GassmaClient } from "../../../gassma";
+import { GassmaController } from "../../../gassmaController";
+import { GassmaUnknownArgumentError } from "../../../errors/argument/argumentError";
+
+const makeSheet = (name: string, initial: unknown[][]) => {
+  const data = initial.map((row) => [...row]);
+  return {
+    getName: () => name,
+    getLastRow: () => data.length,
+    getLastColumn: () => data[0].length,
+    getRange: (row: number, col: number, numRows: number, numCols: number) => ({
+      getValues: () =>
+        data
+          .slice(row - 1, row - 1 + numRows)
+          .map((r) => r.slice(col - 1, col - 1 + numCols)),
+      setValues: (values: unknown[][]) => {
+        values.forEach((rowValues, i) => {
+          while (data.length < row + i) {
+            data.push(Array(data[0].length).fill(""));
+          }
+          rowValues.forEach((value, j) => {
+            data[row - 1 + i][col - 1 + j] = value;
+          });
+        });
+      },
+    }),
+    getDataRange: () => ({ getValues: () => data }),
+    deleteRow: (rowIndex: number) => {
+      data.splice(rowIndex - 1, 1);
+    },
+    deleteRows: (rowPosition: number, howMany: number) => {
+      data.splice(rowPosition - 1, howMany);
+    },
+  };
+};
+
+const buildIgnoreClient = (): GassmaClient => {
+  const sheets = [
+    makeSheet("Users", [
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+      [3, "Carol", 40],
+    ]),
+  ];
+  const mockSpreadsheet = {
+    getId: () => "test-spreadsheet",
+    getSheets: () => sheets,
+    getSheetByName: (name: string) =>
+      sheets.find((sheet) => sheet.getName() === name) ?? null,
+  };
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+  });
+  return new GassmaClient({ ignore: { Users: "age" } });
+};
+
+const looseUsers = (): { loose: any; typed: GassmaController } => {
+  const client = buildIgnoreClient();
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record.Users;
+  if (!(controller instanceof GassmaController)) {
+    throw new Error("controller not found");
+  }
+  return { loose: controller, typed: controller };
+};
+
+afterEach(() => {
+  Object.assign(globalThis, { SpreadsheetApp: undefined });
+});
+
+describe("@ignore 列を where に書くとエラー", () => {
+  test("findMany: 黙って除去せず unknown argument", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ where: { age: 20 } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `age`.");
+    expect(fn).toThrow("Available: id, name");
+  });
+
+  test("deleteMany: 条件が消えて全件削除にならない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() => loose.deleteMany({ where: { age: 20 } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("AND の内側の @ignore 列もエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { AND: [{ age: 20 }] } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+  });
+
+  test("@ignore でない列の where は従来どおり動く", () => {
+    const { typed } = looseUsers();
+    expect(typed.findMany({ where: { name: "Alice" } })).toEqual([
+      { id: 1, name: "Alice" },
+    ]);
+  });
+});

--- a/src/__test__/util/relation/whereRelation/implicitIsShorthand.test.ts
+++ b/src/__test__/util/relation/whereRelation/implicitIsShorthand.test.ts
@@ -1,0 +1,150 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../../../errors/argument/argumentError";
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../../types/relationTypes";
+import type { WhereUse } from "../../../../types/coreTypes";
+import { resolveWhereRelation } from "../../../../util/relation/whereRelation/resolveWhereRelation";
+import { buildTestClient, sheetOf } from "../../extends/extendsTestClient";
+
+const relations: { [relationName: string]: RelationDefinition } = {
+  posts: {
+    type: "oneToMany",
+    to: "Posts",
+    field: "id",
+    reference: "authorId",
+  },
+  author: {
+    type: "manyToOne",
+    to: "Users",
+    field: "authorId",
+    reference: "id",
+  },
+  profile: {
+    type: "oneToOne",
+    to: "Profiles",
+    field: "id",
+    reference: "userId",
+  },
+  tags: {
+    type: "manyToMany",
+    to: "Tags",
+    field: "id",
+    reference: "id",
+    through: {
+      sheet: "PostTags",
+      field: "postId",
+      reference: "tagId",
+    },
+  },
+};
+
+const mockFindMany = jest.fn();
+
+const context: RelationContext = {
+  relations,
+  findManyOnSheet: mockFindMany,
+};
+
+beforeEach(() => {
+  mockFindMany.mockReset();
+});
+
+describe("to-one の短縮形は暗黙の is として解決される", () => {
+  test("manyToOne: { author: { name } } は { author: { is: { name } } } と同じ", () => {
+    mockFindMany.mockReturnValue([{ id: 1, name: "Alice" }]);
+    const shorthand = resolveWhereRelation(
+      { author: { name: "Alice" } },
+      {
+        ...context,
+      },
+    );
+
+    mockFindMany.mockReturnValue([{ id: 1, name: "Alice" }]);
+    const explicit = resolveWhereRelation(
+      { author: { is: { name: "Alice" } } },
+      { ...context },
+    );
+
+    expect(shorthand).toEqual(explicit);
+    expect(shorthand).toEqual({ AND: [{ authorId: { in: [1] } }] });
+  });
+
+  test("oneToOne: { profile: { bio } } も暗黙の is", () => {
+    mockFindMany.mockReturnValue([{ id: 301, userId: 1, bio: "dev" }]);
+    const result = resolveWhereRelation({ profile: { bio: "dev" } }, context);
+    expect(result).toEqual({ AND: [{ id: { in: [1] } }] });
+  });
+});
+
+describe("to-many の短縮形は専用エラー", () => {
+  test("oneToMany: { posts: { title } } は some/every/none を案内する", () => {
+    const fn = () =>
+      resolveWhereRelation({ posts: { title: "Post A" } }, context);
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `title`.\n\nAvailable: some, every, none",
+    );
+  });
+
+  test("フィルタキーの typo (som) はサジェスト付き", () => {
+    const fn = () =>
+      resolveWhereRelation({ posts: { som: { title: "x" } } }, context);
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `som`. Did you mean `some`?");
+  });
+
+  test("manyToMany の短縮形も同じエラー", () => {
+    expect(() =>
+      resolveWhereRelation({ tags: { label: "tech" } }, context),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("空オブジェクトは GassmaInvalidValueError", () => {
+    expect(() => resolveWhereRelation({ posts: {} }, context)).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+});
+
+describe("リレーション名に不正な値", () => {
+  test("非 dict 値は GassmaInvalidValueError", () => {
+    expect(() => resolveWhereRelation({ author: 5 }, context)).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+
+  test("null は従来どおり null ショートハンド", () => {
+    const where: WhereUse = { author: null };
+    expect(resolveWhereRelation(where, context)).toEqual({
+      AND: [{ authorId: null }],
+    });
+  });
+});
+
+describe("クライアント経由の実挙動", () => {
+  test("短縮形と is 明示で同じ結果になる", () => {
+    const posts = sheetOf(buildTestClient({ relations: true }), "Posts");
+    const shorthand = posts.findMany({
+      where: { author: { name: "Alice" } },
+    });
+    const explicit = posts.findMany({
+      where: { author: { is: { name: "Alice" } } },
+    });
+    expect(shorthand).toEqual(explicit);
+    expect(shorthand).toEqual([{ id: 101, authorId: 1, title: "Post A" }]);
+  });
+
+  test("to-many の短縮形はエラーになりシートが変化しない", () => {
+    const client = buildTestClient({ relations: true });
+    const users = sheetOf(client, "Users");
+    const loose: any = users;
+    expect(() =>
+      loose.deleteMany({ where: { posts: { title: "Post A" } } }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(users.count({})).toBe(3);
+  });
+});

--- a/src/__test__/util/whereColumnValidation.test.ts
+++ b/src/__test__/util/whereColumnValidation.test.ts
@@ -1,0 +1,259 @@
+import { GassmaUnknownArgumentError } from "../../errors/argument/argumentError";
+import { buildTestClient, sheetOf } from "./extends/extendsTestClient";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "./transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const looseUsers = (options?: {
+  relations?: boolean;
+}): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const typed = sheetOf(buildTestClient(options), "Users");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+const loosePosts = (): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const typed = sheetOf(buildTestClient({ relations: true }), "Posts");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+describe("where の列名 typo で書き込みが誤爆しない", () => {
+  test("deleteMany: nmae (name の typo) はエラーになり全件削除されない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () => loose.deleteMany({ where: { nmae: "Alice" } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `nmae`. Did you mean `name`?\n\nAvailable: id, name, age",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("delete: nmae はエラーになり先頭行が削除されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() => loose.delete({ where: { nmae: "Zed" } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+    expect(typed.count({})).toBe(3);
+    expect(typed.findFirst({ where: { name: "Alice" } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+    });
+  });
+
+  test("upsert: nmae はエラーになり作成も更新もされない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.upsert({
+        where: { nmae: "Zed" },
+        create: { id: 9, name: "Zed", age: 1 },
+        update: { name: "X" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(typed.count({})).toBe(3);
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+    });
+  });
+
+  test("update: 未知列はエラーになり行が更新されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.update({ where: { nmae: "Alice" }, data: { age: 0 } }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+    });
+  });
+
+  test("updateMany: 未知列はエラーになり行が更新されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.updateMany({ where: { nmae: "Alice" }, data: { age: 0 } }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(typed.findMany({ where: { age: 0 } })).toEqual([]);
+  });
+});
+
+describe("読み取り系でも where の未知列はエラー", () => {
+  test("findMany", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { nmae: "Alice" } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+  });
+
+  test("findFirst", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findFirst({ where: { nmae: "Alice" } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+  });
+
+  test("count", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.count({ where: { nmae: "Alice" } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+  });
+
+  test("aggregate", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.aggregate({ _sum: { age: true }, where: { nmae: "Alice" } }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("groupBy", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.groupBy({ by: ["name"], where: { nmae: "Alice" } }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+});
+
+describe("AND/OR/NOT の内側でも未知列はエラー", () => {
+  test("AND 配列の中", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.findMany({ where: { AND: [{ nmae: "Alice" }] } }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("OR 配列の中", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.findMany({ where: { OR: [{ nmae: "Alice" }] } }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("NOT (dict 形) の中", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { NOT: { nmae: "Alice" } } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+  });
+
+  test("深いネストの中", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.deleteMany({
+        where: { OR: [{ AND: [{ NOT: { nmae: "Alice" } }] }] },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+});
+
+describe("リレーション名の typo", () => {
+  test("autor (author の typo) はサジェスト付きエラー", () => {
+    const { loose } = loosePosts();
+    const fn = () =>
+      loose.findMany({ where: { autor: { is: { name: "A" } } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `autor`. Did you mean `author`?");
+  });
+
+  test("Available にはリレーション名も並ぶ", () => {
+    const { loose } = loosePosts();
+    expect(() => loose.findMany({ where: { autor: { is: {} } } })).toThrow(
+      "Available: id, authorId, title, author, comments",
+    );
+  });
+
+  test("is フィルタの内側の未知列は相手シート基準でエラー", () => {
+    const { loose } = loosePosts();
+    const fn = () =>
+      loose.findMany({ where: { author: { is: { nmae: "Alice" } } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `nmae`. Did you mean `name`?");
+  });
+});
+
+describe("従来どおり動くこと", () => {
+  test("正しい列名の where は通る", () => {
+    const { typed } = looseUsers();
+    expect(typed.findMany({ where: { name: "Alice" } })).toEqual([
+      { id: 1, name: "Alice", age: 20 },
+    ]);
+  });
+
+  test("演算子付き条件も通る", () => {
+    const { typed } = looseUsers();
+    expect(typed.findMany({ where: { age: { gte: 30 } } })).toHaveLength(2);
+  });
+
+  test("リレーションフィルタ some も通る", () => {
+    const { typed } = looseUsers({ relations: true });
+    expect(
+      typed.findMany({ where: { posts: { some: { title: "Post A" } } } }),
+    ).toEqual([{ id: 1, name: "Alice", age: 20 }]);
+  });
+
+  test("リレーションフィルタ is も通る", () => {
+    const { typed } = loosePosts();
+    expect(
+      typed.findMany({ where: { author: { is: { name: "Alice" } } } }),
+    ).toEqual([{ id: 101, authorId: 1, title: "Post A" }]);
+  });
+
+  test("AND/OR/NOT の正しい条件も通る", () => {
+    const { typed } = looseUsers();
+    expect(
+      typed.findMany({
+        where: { AND: [{ age: { gte: 20 } }], NOT: { name: "Bob" } },
+      }),
+    ).toHaveLength(2);
+  });
+
+  test("where: {} は全件マッチのまま", () => {
+    const { typed } = looseUsers();
+    expect(typed.findMany({ where: {} })).toHaveLength(3);
+  });
+});
+
+describe("$transaction 経由", () => {
+  test("tx 内の deleteMany({where:{nmae}}) もエラーになりシートが変化しない", () => {
+    const env = buildTxTestEnv();
+    const tx = (env.client as any).$transaction.bind(env.client);
+    expect(() =>
+      tx((txClient: any) => {
+        txClient.Users.deleteMany({ where: { nmae: "Alice" } });
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+    ]);
+  });
+});
+
+describe("$extends 経由", () => {
+  test("query フックを素通しした未知列もエラー", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      query: {
+        Users: {
+          deleteMany({ args, query }) {
+            return query(args);
+          },
+        },
+      },
+    });
+    const loose: any = extended.Users;
+    expect(() => loose.deleteMany({ where: { nmae: "Alice" } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+    expect(extended.Users.count({})).toBe(3);
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -288,6 +288,10 @@ class GassmaController {
     if (this.fieldMapping) {
       util.fieldMapping = this.fieldMapping;
     }
+    util.whereValidation = {
+      ignoredFields: this.ignoredFields ?? [],
+      relationNames: this.relationNames(),
+    };
     return applyReadCache(util);
   }
 
@@ -308,10 +312,7 @@ class GassmaController {
 
   private resolveWhere(where: WhereUse | undefined): WhereUse | undefined {
     if (!where) return where;
-    const stripped = this.ignoredFields
-      ? (stripIgnoredFields(where, this.ignoredFields) as WhereUse)
-      : where;
-    return resolveWhereRelation(stripped, this.relationContext);
+    return resolveWhereRelation(where, this.relationContext);
   }
 
   private buildScalarSelect(select: Record<string, unknown>): Select | null {

--- a/src/types/gassmaControllerUtilType.ts
+++ b/src/types/gassmaControllerUtilType.ts
@@ -2,6 +2,11 @@ import type { FieldMapping } from "../util/map/mapFields";
 import type { SheetReader } from "../util/read/sheetReader";
 import type { SheetWriter } from "../util/write/sheetWriter";
 
+type WhereValidation = {
+  ignoredFields: string[];
+  relationNames: string[];
+};
+
 type GassmaControllerUtil = {
   sheet: GoogleAppsScript.Spreadsheet.Sheet;
   startRowNumber: number;
@@ -10,6 +15,7 @@ type GassmaControllerUtil = {
   fieldMapping?: FieldMapping;
   writer?: SheetWriter;
   reader?: SheetReader;
+  whereValidation?: WhereValidation;
 };
 
-export type { GassmaControllerUtil };
+export type { GassmaControllerUtil, WhereValidation };

--- a/src/util/core/whereFilter.ts
+++ b/src/util/core/whereFilter.ts
@@ -1,6 +1,7 @@
 import type { WhereUse } from "../../types/coreTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import type { HitRowData } from "../../types/hitRowDataType";
+import { validateWhereColumns } from "../validate/validateWhereColumns";
 import { filterRowsByWhere } from "./filterRowsByWhere";
 import { getAllData } from "./getAllData";
 import { getTitle } from "./getTitle";
@@ -12,6 +13,14 @@ const whereFilter = (
 ): HitRowData[] => {
   const allDataList = getAllData(gassmaControllerUtil);
   const resolvedTitles = titles ?? getTitle(gassmaControllerUtil);
+
+  if (gassmaControllerUtil.whereValidation) {
+    validateWhereColumns(
+      where,
+      resolvedTitles,
+      gassmaControllerUtil.whereValidation,
+    );
+  }
 
   return filterRowsByWhere(allDataList, resolvedTitles, where);
 };

--- a/src/util/relation/whereRelation/filters/dispatchFilter.ts
+++ b/src/util/relation/whereRelation/filters/dispatchFilter.ts
@@ -20,6 +20,11 @@ const SINGLE_RELATION_TYPES = new Set(["oneToOne", "manyToOne"]);
 const isFilterKey = (k: string): boolean =>
   LIST_FILTER_SET.has(k) || SINGLE_FILTER_SET.has(k);
 
+const isListRelationType = (type: string): boolean =>
+  LIST_RELATION_TYPES.has(type);
+
+const LIST_FILTER_KEYS = ["some", "every", "none"];
+
 const validateFilterType = (
   relation: RelationDefinition,
   relationName: string,
@@ -96,4 +101,10 @@ const dispatchFilter = (
   );
 };
 
-export { isFilterKey, validateFilterType, dispatchFilter };
+export {
+  isFilterKey,
+  isListRelationType,
+  validateFilterType,
+  dispatchFilter,
+  LIST_FILTER_KEYS,
+};

--- a/src/util/relation/whereRelation/resolveWhereRelation.ts
+++ b/src/util/relation/whereRelation/resolveWhereRelation.ts
@@ -4,10 +4,16 @@ import type {
 } from "../../../types/relationTypes";
 import type { WhereUse } from "../../../types/coreTypes";
 import { WhereRelationWithoutContextError } from "../../../errors/relation/whereRelationError";
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../../errors/argument/argumentError";
 import { isDict } from "../../other/isDict";
 import {
+  LIST_FILTER_KEYS,
   dispatchFilter,
   isFilterKey,
+  isListRelationType,
   validateFilterType,
 } from "./filters/dispatchFilter";
 import { applyNullShorthand } from "./filters/nullShorthandFilter";
@@ -19,15 +25,29 @@ const toDict = (value: unknown): Record<string, unknown> | null => {
   return null;
 };
 
-const isRelationFilter = (
-  key: string,
+const toRelationFilter = (
+  relation: RelationDefinition,
+  relationName: string,
   value: unknown,
-  relations: { [name: string]: RelationDefinition },
-): boolean => {
-  if (!(key in relations)) return false;
+): Record<string, unknown> => {
   const dict = toDict(value);
-  if (!dict) return false;
-  return Object.keys(dict).some(isFilterKey);
+  if (!dict) {
+    throw new GassmaInvalidValueError(
+      relationName,
+      "a relation filter object or null",
+    );
+  }
+  if (Object.keys(dict).some(isFilterKey)) return dict;
+  if (!isListRelationType(relation.type)) return { is: dict };
+
+  const firstKey = Object.keys(dict)[0];
+  if (firstKey === undefined) {
+    throw new GassmaInvalidValueError(
+      relationName,
+      "an object with `some`, `every`, or `none`",
+    );
+  }
+  throw new GassmaUnknownArgumentError(firstKey, LIST_FILTER_KEYS);
 };
 
 const resolveWhereRelation = (
@@ -49,9 +69,18 @@ const resolveWhereRelation = (
   Object.entries(where).forEach(([key, value]) => {
     if (LOGICAL_KEYS.has(key)) return;
 
-    if (value === null && key in context.relations) {
+    if (!(key in context.relations)) {
+      normalConditions[key] = value;
+      return;
+    }
+
+    if (value === undefined) return;
+
+    const relation = context.relations[key];
+
+    if (value === null) {
       const resolved = applyNullShorthand(
-        context.relations[key],
+        relation,
         key,
         context.findManyOnSheet,
       );
@@ -59,13 +88,7 @@ const resolveWhereRelation = (
       return;
     }
 
-    if (!isRelationFilter(key, value, context.relations)) {
-      normalConditions[key] = value;
-      return;
-    }
-
-    const relation = context.relations[key];
-    const filterObj = toDict(value)!;
+    const filterObj = toRelationFilter(relation, key, value);
 
     Object.entries(filterObj).forEach(([filterKey, filterValue]) => {
       validateFilterType(relation, key, filterKey);

--- a/src/util/validate/validateWhereColumns.ts
+++ b/src/util/validate/validateWhereColumns.ts
@@ -1,0 +1,42 @@
+import { GassmaUnknownArgumentError } from "../../errors/argument/argumentError";
+import type { WhereValidation } from "../../types/gassmaControllerUtilType";
+import { isDict } from "../other/isDict";
+
+const LOGICAL_KEYS = new Set(["AND", "OR", "NOT"]);
+
+const walk = (
+  where: Record<string, unknown>,
+  allowed: Set<string>,
+  availableArguments: string[],
+): void => {
+  Object.entries(where).forEach(([key, value]) => {
+    if (LOGICAL_KEYS.has(key)) {
+      const branches = Array.isArray(value) ? value : [value];
+      branches.forEach((branch) => {
+        if (!isDict(branch)) return;
+        walk(branch, allowed, availableArguments);
+      });
+      return;
+    }
+    if (value === undefined) return;
+    if (!allowed.has(key)) {
+      throw new GassmaUnknownArgumentError(key, availableArguments);
+    }
+  });
+};
+
+const validateWhereColumns = (
+  where: Record<string, unknown>,
+  titles: string[],
+  validation: WhereValidation,
+): void => {
+  const allowedColumns = titles.filter(
+    (title) => !validation.ignoredFields.includes(title),
+  );
+  walk(where, new Set(allowedColumns), [
+    ...allowedColumns,
+    ...validation.relationNames,
+  ]);
+};
+
+export { validateWhereColumns };


### PR DESCRIPTION
typo 対策の**本丸**です。1段目 #192、`count` 縮小 #193、2段目 #194、別経路の 3-3 は #195。

> [!WARNING]
> **破壊的変更です。** これまで黙って通っていた入力がエラーになります。

## 問題

`where` の列名を書き間違えると条件が消え、**全行マッチ**になります。

```js
deleteMany({ where: { 名まえ: "Alice" } })   // "名前" の typo
// → {"count":8}  全件削除

delete({ where: { 名まえ: "Zed" } })          // 存在しない行を消すつもり
// → 返り値 {"名前":"Alice",...}   Alice を削除したと報告し、実際に Alice が消える

upsert({ where: { 名まえ: "Zed" }, create: {...}, update: {...} })
// → Zed は作られず、先頭行 Alice が書き換わる
```

単発操作は**先頭行を「見つけた」ことにする**ため、「無ければ作る」が「別人を書き換える」に化けます。

## 修正

### 検査位置(**指示から変更しています**)

事前調査では「controller の `resolveWhere` の出力を検査する」方針でしたが、実装したエージェントが**それでは往復回数の契約が壊れる**ことを実測で示しました。

`resolveWhere` 内で `getTitle` を呼ぶと、読みキャッシュが無効な書き込み系で**見出し読みが1回増え**、**#180 / #175 / #179 で固定した往復回数のテスト4件が落ちます**。titles を書き込み関数へ引き回す案も試したものの、書き込み中の内部 `findMany` の +1 が消せず断念したとのことです。

そこで **`whereFilter`** に置いています。ここは **`findMany` / `findFirst` / `count` / `aggregate` / `groupBy` / `updateMany` / `deleteMany` / nested update の全 where 経路の合流点**で、**titles が既に手元にある**ため追加の読み取りがゼロです。この時点で `resolveWhere` は適用済みなので、**検査の意味論は当初方針と同じ**です。

`@ignore` 列とリレーション名は `GassmaControllerUtil` の新フィールドで運びます。`getGassmaControllerUtil()` が唯一の組み立て箇所で**無条件にセット**するため全公開経路で効き、util を手組みする内部経路(`targetTable` 経由など)はスキップされます。これが**空シートへの `connect` を壊さない**仕組みでもあります。

### 4つの変更

1. **列名の検証** — 存在しない列は `GassmaUnknownArgumentError`(サジェスト + 利用可能な列の一覧)
2. **to-one の短縮形を暗黙の `is` として受け付ける** — `{ author: { name: "Alice" } }` は Prisma では正規の書き方で、**発行 SQL が `is` と1文字も違いません**。`relation.type` で to-one(`manyToOne` / `oneToOne`)を判定し、フィルタキーが無ければ `{ is: ... }` に包んで既存経路へ流します
3. **to-many の短縮形は専用エラー** — `{ posts: { title: "x" } }` は `Available: some, every, none` を案内します。`{ posts: { som: {...} } }` は `Did you mean \`some\`?`
4. **`@ignore` 列はエラー** — 従来は黙って除去され、その結果として全行マッチ(= `deleteMany` で全件削除)になっていました。Prisma は `@ignore` したフィールドを API から消すので unknown argument になります。**`AND` の内側も検出**します(従来は除去すらされず素通りでした)

## 実証

| ケース | 修正前 | 修正後 |
|---|---|---|
| `deleteMany({ where: { nmae } })` | 全8件削除 | エラー + **シート不変** |
| `delete({ where: { nmae: "Zed" } })` | 先頭行 Alice が消える | エラー + **Alice 残存** |
| `upsert({ where: { nmae: "Zed" } })` | Alice が書き換わる | エラー + 作成も更新もなし |
| `{ posts: { title: "x" } }` | 全行マッチ | `Available: some, every, none` |
| `@ignore` 列 | 黙って除去 → 全行マッチ | unknown argument |

暗黙 `is` は、**`{ author: { name } }` と `{ author: { is: { name } } }` の解決結果とクエリ結果が完全一致**することをテストで固定しています。`{ author: null }` の null ショートハンドも従来どおりです。

## 壊していないことの確認

- **往復回数の契約テスト3スイート26件が green**。これは内部の N+1 経路を件数で監視しているもので、**内部呼び出しの回数・挙動が変わっていない実証**になります
- **空シートへの `connect` / `connectOrCreate`** が従来どおり動くことを新規テストで固定(調査で特定された唯一の危険箇所)。`connect` が `NestedWriteConnectNotFoundError` のままであることも確認
- `$transaction` 内の typo がエラー + スナップショット不変、`$extends` の query フック経由も同様
- リレーションフィルタの**内側**の `where` は相手シートの controller 経由で検証されます

## 検証結果

- `npm test`: **2,318件 全 green**(2,277 → +40、**既存テストの変更0件**)
- `tsc --noEmit` / format / `verify:bundle`(公開シンボル57件・不変)pass
- lint は警告が **53 → 52 に1件減**(旧コードの `!` と `as` を除去したため)

新エラークラスは追加していないので、**cli 側の追随は不要**です。

## 判断が要る点

**1. `{ posts: {} }`(to-many に空オブジェクト)を `GassmaInvalidValueError` にしました。** 報告すべきキーが無いためです。**Prisma の実挙動は未確認**です。

**2. `{ author: 5 }`(リレーション名に非 dict 値)も `GassmaInvalidValueError` にしました。** 指示した4項目の外ですが、従来は素通りして全行マッチだった同じ穴です。

**3. 値が `undefined` のキーは検証をスキップします。** Prisma が `undefined` を「未指定」として扱うのに合わせました(`strictUndefinedChecks` 有効時は従来どおり別エラーです)。

## 補足

#195 と同じ `gassmaController.ts` に触れますが、**行が離れている**(こちらは 291 付近、#195 は 531 / 732)ため自動マージできるはずです。競合した場合は私がリベースして出し直します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)