### PR TITLE
fix: リレーションフィルタの空オブジェクトを Prisma と同じ no-op にする

### DIFF
--- a/src/__test__/util/relation/whereRelation/emptyRelationFilter.test.ts
+++ b/src/__test__/util/relation/whereRelation/emptyRelationFilter.test.ts
@@ -1,0 +1,289 @@
+import { GassmaClient } from "../../../../gassma";
+import type { GassmaController } from "../../../../gassmaController";
+import type {
+  RelationContext,
+  RelationDefinition,
+  RelationsConfig,
+} from "../../../../types/relationTypes";
+import { resolveWhereRelation } from "../../../../util/relation/whereRelation/resolveWhereRelation";
+
+const unitRelations: { [relationName: string]: RelationDefinition } = {
+  posts: {
+    type: "oneToMany",
+    to: "Posts",
+    field: "id",
+    reference: "authorId",
+  },
+  author: {
+    type: "manyToOne",
+    to: "Users",
+    field: "authorId",
+    reference: "id",
+  },
+  profile: {
+    type: "oneToOne",
+    to: "Profiles",
+    field: "id",
+    reference: "userId",
+  },
+  tags: {
+    type: "manyToMany",
+    to: "Tags",
+    field: "id",
+    reference: "id",
+    through: {
+      sheet: "PostTags",
+      field: "postId",
+      reference: "tagId",
+    },
+  },
+};
+
+const mockFindMany = jest.fn();
+
+const unitContext: RelationContext = {
+  relations: unitRelations,
+  findManyOnSheet: mockFindMany,
+};
+
+beforeEach(() => {
+  mockFindMany.mockReset();
+});
+
+describe("リレーション名への裸の空オブジェクトは no-op", () => {
+  test("oneToMany: { posts: {} } は条件を発行しない", () => {
+    expect(resolveWhereRelation({ posts: {} }, unitContext)).toEqual({});
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  test("manyToOne: { author: {} } は暗黙 is で包まれない", () => {
+    expect(resolveWhereRelation({ author: {} }, unitContext)).toEqual({});
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  test("oneToOne: { profile: {} } も no-op", () => {
+    expect(resolveWhereRelation({ profile: {} }, unitContext)).toEqual({});
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  test("manyToMany: { tags: {} } も no-op", () => {
+    expect(resolveWhereRelation({ tags: {} }, unitContext)).toEqual({});
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  test("他の条件と併用したら空リレーションだけ取り除かれる", () => {
+    expect(
+      resolveWhereRelation({ author: {}, title: "Hello" }, unitContext),
+    ).toEqual({ title: "Hello" });
+  });
+
+  test("論理キー配下でも取り除かれる", () => {
+    expect(resolveWhereRelation({ OR: [{ author: {} }] }, unitContext)).toEqual(
+      { OR: [{}] },
+    );
+  });
+
+  test("{ author: {} } と { author: { is: {} } } は解決結果が異なる", () => {
+    const bare = resolveWhereRelation({ author: {} }, unitContext);
+
+    mockFindMany.mockReturnValue([
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
+      { id: 3, name: "Carol" },
+    ]);
+    const explicit = resolveWhereRelation({ author: { is: {} } }, unitContext);
+
+    expect(bare).toEqual({});
+    expect(explicit).toEqual({ AND: [{ authorId: { in: [1, 2, 3] } }] });
+  });
+});
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => { getValues: () => unknown[][] };
+  getDataRange: () => { getValues: () => unknown[][] };
+};
+
+const makeSheet = (name: string, data: unknown[][]): MockSheet => ({
+  getName: () => name,
+  getLastRow: () => data.length,
+  getLastColumn: () => data[0].length,
+  getRange: (row, col, numRows, numCols) => ({
+    getValues: () =>
+      data
+        .slice(row - 1, row - 1 + numRows)
+        .map((r) => r.slice(col - 1, col - 1 + numCols)),
+  }),
+  getDataRange: () => ({ getValues: () => data }),
+});
+
+const sheets = [
+  makeSheet("Users", [
+    ["id", "name"],
+    [1, "Alice"],
+    [2, "Bob"],
+    [3, "Carol"],
+  ]),
+  makeSheet("Posts", [
+    ["id", "authorId", "title"],
+    [11, 1, "Hello"],
+    [12, 2, "Spam"],
+    [13, "", "Orphan"],
+  ]),
+  makeSheet("Profiles", [
+    ["id", "userId", "bio"],
+    [301, 1, "Alice bio"],
+    [302, 2, "Bob bio"],
+  ]),
+];
+
+const mockSpreadsheet = {
+  getId: () => "test-spreadsheet",
+  getSheets: () => sheets,
+  getSheetByName: (name: string) =>
+    sheets.find((sheet) => sheet.getName() === name) ?? null,
+};
+
+const relations: RelationsConfig = {
+  Users: {
+    posts: {
+      type: "oneToMany",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+    },
+    profile: {
+      type: "oneToOne",
+      to: "Profiles",
+      field: "id",
+      reference: "userId",
+    },
+  },
+  Posts: {
+    author: {
+      type: "manyToOne",
+      to: "Users",
+      field: "authorId",
+      reference: "id",
+    },
+  },
+  Profiles: {
+    user: {
+      type: "manyToOne",
+      to: "Users",
+      field: "userId",
+      reference: "id",
+    },
+  },
+};
+
+const isGassmaController = (value: unknown): value is GassmaController =>
+  typeof value === "object" &&
+  value !== null &&
+  "findMany" in value &&
+  typeof value.findMany === "function";
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!isGassmaController(controller)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+describe("空オブジェクトフィルタの件数が Prisma 実測と一致する（統合）", () => {
+  let client: GassmaClient;
+
+  beforeAll(() => {
+    Object.assign(globalThis, {
+      SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+    });
+    client = new GassmaClient({ relations });
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, { SpreadsheetApp: undefined });
+  });
+
+  describe("to-many（Users.posts）", () => {
+    it("posts: {} は全件（3件）", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { posts: {} },
+      });
+      expect(result).toHaveLength(3);
+    });
+
+    it("posts: { some: {} } は子を1件以上持つ親（2件）", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { posts: { some: {} } },
+      });
+      expect(result).toEqual([
+        { id: 1, name: "Alice" },
+        { id: 2, name: "Bob" },
+      ]);
+    });
+
+    it("posts: { none: {} } は子ゼロの親（1件）", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { posts: { none: {} } },
+      });
+      expect(result).toEqual([{ id: 3, name: "Carol" }]);
+    });
+
+    it("posts: { every: {} } は vacuous truth で全件（3件）", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { posts: { every: {} } },
+      });
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe("to-one（Posts.author）", () => {
+    it("author: {} は Orphan も含む全件（3件）", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { author: {} },
+      });
+      expect(result).toHaveLength(3);
+    });
+
+    it("author: { is: {} } は関連が存在する行のみ（2件）", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { author: { is: {} } },
+      });
+      expect(result).toEqual([
+        { id: 11, authorId: 1, title: "Hello" },
+        { id: 12, authorId: 2, title: "Spam" },
+      ]);
+    });
+  });
+
+  describe("to-one（Users.profile、FK を持たない側）", () => {
+    it("profile: {} は全件（3件）", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { profile: {} },
+      });
+      expect(result).toHaveLength(3);
+    });
+
+    it("profile: { is: {} } は関連が存在する行のみ（2件）", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { profile: { is: {} } },
+      });
+      expect(result).toEqual([
+        { id: 1, name: "Alice" },
+        { id: 2, name: "Bob" },
+      ]);
+    });
+  });
+});

--- a/src/__test__/util/relation/whereRelation/implicitIsShorthand.test.ts
+++ b/src/__test__/util/relation/whereRelation/implicitIsShorthand.test.ts
@@ -102,12 +102,6 @@ describe("to-many の短縮形は専用エラー", () => {
       resolveWhereRelation({ tags: { label: "tech" } }, context),
     ).toThrow(GassmaUnknownArgumentError);
   });
-
-  test("空オブジェクトは GassmaInvalidValueError", () => {
-    expect(() => resolveWhereRelation({ posts: {} }, context)).toThrow(
-      GassmaInvalidValueError,
-    );
-  });
 });
 
 describe("リレーション名に不正な値", () => {

--- a/src/util/relation/whereRelation/resolveWhereRelation.ts
+++ b/src/util/relation/whereRelation/resolveWhereRelation.ts
@@ -37,17 +37,11 @@ const toRelationFilter = (
       "a relation filter object or null",
     );
   }
-  if (Object.keys(dict).some(isFilterKey)) return dict;
+  const keys = Object.keys(dict);
+  if (keys.length === 0) return dict;
+  if (keys.some(isFilterKey)) return dict;
   if (!isListRelationType(relation.type)) return { is: dict };
-
-  const firstKey = Object.keys(dict)[0];
-  if (firstKey === undefined) {
-    throw new GassmaInvalidValueError(
-      relationName,
-      "an object with `some`, `every`, or `none`",
-    );
-  }
-  throw new GassmaUnknownArgumentError(firstKey, LIST_FILTER_KEYS);
+  throw new GassmaUnknownArgumentError(keys[0], LIST_FILTER_KEYS);
 };
 
 const resolveWhereRelation = (
@@ -65,6 +59,7 @@ const resolveWhereRelation = (
 
   const normalConditions: WhereUse = {};
   const relationConditions: WhereUse[] = [];
+  let emptyRelationDropped = false;
 
   Object.entries(where).forEach(([key, value]) => {
     if (LOGICAL_KEYS.has(key)) return;
@@ -89,6 +84,10 @@ const resolveWhereRelation = (
     }
 
     const filterObj = toRelationFilter(relation, key, value);
+    if (Object.keys(filterObj).length === 0) {
+      emptyRelationDropped = true;
+      return;
+    }
 
     Object.entries(filterObj).forEach(([filterKey, filterValue]) => {
       validateFilterType(relation, key, filterKey);
@@ -126,7 +125,13 @@ const resolveWhereRelation = (
     }
   });
 
-  if (relationConditions.length === 0 && !logicalChanged) return where;
+  if (
+    relationConditions.length === 0 &&
+    !logicalChanged &&
+    !emptyRelationDropped
+  ) {
+    return where;
+  }
   if (relationConditions.length === 0) return normalConditions;
 
   const allConditions: WhereUse[] = [];


### PR DESCRIPTION
#196 のレビューで「`{ posts: {} }` を `GassmaInvalidValueError` にしたが Prisma の実挙動は未確認」と書いた件の追従です。**Prisma 7.4.1 + SQLite で実測したところ、2点で不一致でした。**

## Prisma の実挙動(発行 SQL つき)

データ: Author = Alice / Bob / Carol、Post = Hello(→Alice)/ Spam(→Bob)/ **Orphan(authorId = NULL)**

| クエリ | 件数 | 発行 SQL |
|---|---|---|
| `posts: {}` | **3件(全件)= no-op** | `WHERE 1=1`(**サブクエリすら出ない**) |
| `posts: { some: {} }` | 2件(子が1件以上) | `EXISTS(... 1=1 ...)` |
| `posts: { none: {} }` | 1件(子ゼロ) | `NOT EXISTS` |
| `posts: { every: {} }` | 3件(**子ゼロの親も含む**) | vacuous truth |
| `author: {}` | **3件(全件)= no-op**。Orphan も含む | `WHERE 1=1`(**JOIN なし**) |
| `author: { is: {} }` | 2件(**関連が存在する行のみ**) | `LEFT JOIN ... 1=1 AND j0.id IS NOT NULL` |

**空オブジェクトはどこに現れても「条件ゼロ個 = 恒真」**で、意味はラッパーが決める、という一貫した論理でした。`NOT: {}` が全件になるのも同じ原理です。

## gassma の現状と、見落としていた点

```
[posts: {} (to-many)]  GassmaInvalidValueError: Expected an object with `some`, `every`, or `none`.
[author: {} (to-one)]  通った: {"AND":[{"authorId":{"in":[]}}]}   ← 存在チェックになっている
```

to-many は**エラーにしていたのが誤り**でした。

そして to-one は、**#196 で入れた暗黙 `is` が空 dict まで包んでしまった**ことによる副作用です。

> **裸の `{}` は `is: {}` の省略形ではありません。**
> フィールドがある場合は `{author:{name:"x"}}` と `{author:{is:{name:"x"}}}` の発行 SQL が1文字も違いませんが、**空の場合だけ等価が崩れます**。存在チェックの `IS NOT NULL` は **`is` ラッパー自体が付ける**ためです。

#196 でこの非自明さを見落としていました。

## 修正

「空オブジェクトを特別扱いする」のではなく、**条件が0個なら条件を1つも発行しない**という形にしています(Prisma の SQL がまさにその構造なので)。to-many のエラー分岐と to-one の暗黙 `is` ラップの**前**にキー数0の判定を置くだけで、上記の「裸と `is` は等価でない」がそのまま表現されます。

1点だけ追加の仕掛けが要りました。`resolveWhereRelation` は「リレーション条件が0個なら元の `where` をそのまま返す」早期リターンを持つため、そのままだと `{ posts: {} }` が残留して **#196 の列名検証が `posts` を未知の列として弾きます**。空リレーションを消費した場合はリレーションキーを除いた条件を返すようにしています。

## `every: {}` は元から一致していました

Prisma と同じく**子ゼロの親も含む全件**でした。`everyFilter` が「マッチ数 < 全数のキーを `notIn` に入れる」実装なので、空フィルタでは `notIn: []` = 全件となり、**偶然ながら vacuous truth になっていました**。テストで固定しています。

## 検証結果

- `npm test`: **2,359件 全 green**(2,318 → 正味 +14)
- **往復回数の契約テスト3スイート26件 green**
- `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル57件)pass

追加テスト15件は Prisma の実測表と1対1で対応させており、`{ author: {} }` と `{ author: { is: {} } }` が**異なる結果になること**を1つのテスト内で対比しています(最も間違えやすい点なので)。`AND` / `OR` 配下でも空リレーションだけが取り除かれることも固定しました。

### 変更した既存テスト

**1件のみ**です。#196 で追加した「空オブジェクトは `GassmaInvalidValueError`」を削除しました(Prisma 実測に基づく訂正のため)。他の既存テストは無変更です。

## 判断が要る点(別件として残っています)

**`isNot: {}` は Prisma と不一致のままです。** Prisma は Orphan 1件を返しますが、gassma は **0件**です。

原因は manyToOne の `isNot` が `{ authorId: { notIn: [...] } }` に翻訳され、**FK が null の行が `notIn` で落ちる**ことです。Prisma は `... OR j0.id IS NULL` で null 行を含めます。

これは**空に限らない一般的な差異**で、`isNot: { name: "Alice" }` でも同じことが起きます。実は `LLM/semantics-bugs.html` に「E. `isNot` が FK null の行を落とす」として記録済みのものと同一です。

修正には `{ OR: [{ FK: null }, { FK: { notIn: keys } }] }` への変更が必要で、`resolveWhereRelation.test.ts` と `isNotFilter.test.ts` の**既存テストが現在の出力を明示的に固定**しています。本 PR のスコープ外として手を付けていません。**直すかどうかの判断をお願いします。**

なお `some: {}` / `none: {}` / `is: {}` / `every: {}` は Prisma と完全一致でした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)