### PR TITLE
fix: 設定に書いた列名の typo をクライアント生成時に検出する

### DIFF
--- a/src/__test__/util/config/configColumnsIntegration.test.ts
+++ b/src/__test__/util/config/configColumnsIntegration.test.ts
@@ -1,0 +1,192 @@
+import { GassmaUnknownArgumentError } from "../../../errors/argument/argumentError";
+import { GassmaClient } from "../../../gassma";
+import type { GassmaController } from "../../../gassmaController";
+import type { RelationsConfig } from "../../../types/relationTypes";
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => { getValues: () => unknown[][] };
+  getDataRange: () => { getValues: () => unknown[][] };
+};
+
+const titleReadCounts: Record<string, number> = {};
+
+const makeSheet = (name: string, data: unknown[][]): MockSheet => ({
+  getName: () => name,
+  getLastRow: () => data.length,
+  getLastColumn: () => data[0].length,
+  getRange: (row, col, numRows, numCols) => {
+    if (row === 1 && numRows === 1) {
+      titleReadCounts[name] = (titleReadCounts[name] ?? 0) + 1;
+    }
+    return {
+      getValues: () =>
+        data
+          .slice(row - 1, row - 1 + numRows)
+          .map((r) => r.slice(col - 1, col - 1 + numCols)),
+    };
+  },
+  getDataRange: () => ({ getValues: () => data }),
+});
+
+const sheets = [
+  makeSheet("Users", [
+    ["id", "名前", "年齢", "住所"],
+    [1, "Alice", 20, "Tokyo"],
+  ]),
+  makeSheet("Posts", [
+    ["id", "authorId", "title"],
+    [101, 1, "Alice post"],
+  ]),
+];
+
+const mockSpreadsheet = {
+  getId: () => "test-spreadsheet",
+  getSheets: () => sheets,
+  getSheetByName: (name: string) =>
+    sheets.find((sheet) => sheet.getName() === name) ?? null,
+};
+
+const relations: RelationsConfig = {
+  Users: {
+    posts: {
+      type: "oneToMany",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+    },
+  },
+};
+
+const isGassmaController = (value: unknown): value is GassmaController =>
+  typeof value === "object" &&
+  value !== null &&
+  "findMany" in value &&
+  typeof value.findMany === "function";
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!isGassmaController(controller)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+describe("設定に書かれた列名の起動時検証（統合）", () => {
+  beforeAll(() => {
+    Object.assign(globalThis, {
+      SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+    });
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, { SpreadsheetApp: undefined });
+  });
+
+  beforeEach(() => {
+    Object.keys(titleReadCounts).forEach((key) => {
+      delete titleReadCounts[key];
+    });
+  });
+
+  it("defaults の列名 typo はクライアント構築時にエラーを投げる", () => {
+    expect(
+      () => new GassmaClient({ defaults: { Users: { 年齢: 0, 住処: "" } } }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  it("updatedAt の列名 typo はクライアント構築時にエラーを投げる", () => {
+    expect(() => new GassmaClient({ updatedAt: { Users: "住処" } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+  });
+
+  it("autoincrement の列名 typo はクライアント構築時にエラーを投げる", () => {
+    expect(() => new GassmaClient({ autoincrement: { Posts: "iid" } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+  });
+
+  it("ignore の列名 typo はクライアント構築時にエラーを投げる", () => {
+    expect(() => new GassmaClient({ ignore: { Posts: "titel" } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+  });
+
+  it("omit の列名 typo はクライアント構築時にエラーを投げる", () => {
+    expect(
+      () => new GassmaClient({ omit: { Users: { 名前まえ: true } } }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  it("map の値(シート実列名)の typo はクライアント構築時にエラーを投げる", () => {
+    expect(
+      () => new GassmaClient({ map: { Users: { address: "住処" } } }),
+    ).toThrow("Unknown argument `住処`. Did you mean `住所`?");
+  });
+
+  it("正しい設定ならクライアントを構築でき、defaults が効く", () => {
+    const client = new GassmaClient({
+      defaults: { Users: { 年齢: 0 } },
+      updatedAt: { Posts: "title" },
+      autoincrement: { Users: "id" },
+    });
+
+    const users = sheetOf(client, "Users").findMany({});
+
+    expect(users).toEqual([{ id: 1, 名前: "Alice", 年齢: 20, 住所: "Tokyo" }]);
+  });
+
+  it("map 使用時はコード名で設定を書ける", () => {
+    expect(
+      () =>
+        new GassmaClient({
+          map: { Users: { address: "住所" } },
+          defaults: { Users: { address: "" } },
+        }),
+    ).not.toThrow();
+  });
+
+  it("ignore された列でも実在すれば defaults に書ける", () => {
+    expect(
+      () =>
+        new GassmaClient({
+          ignore: { Users: "年齢" },
+          defaults: { Users: { 年齢: 0 } },
+        }),
+    ).not.toThrow();
+  });
+
+  it("設定なしなら検証は走らずクライアントを構築できる", () => {
+    expect(() => new GassmaClient()).not.toThrow();
+    expect(titleReadCounts).toEqual({});
+  });
+
+  it("relations と設定が同じシートを指しても起動時の見出し読みは各シート1回", () => {
+    const client = new GassmaClient({
+      relations,
+      defaults: { Users: { 年齢: 0 } },
+      autoincrement: { Posts: "id" },
+    });
+
+    expect(titleReadCounts).toEqual({ Users: 1, Posts: 1 });
+    expect(sheetOf(client, "Users")).toBeDefined();
+  });
+
+  it("設定に登場しないシートの見出しは起動時に読まない", () => {
+    new GassmaClient({ defaults: { Users: { 年齢: 0 } } });
+
+    expect(titleReadCounts).toEqual({ Users: 1 });
+  });
+});

--- a/src/__test__/util/config/validateConfigColumns.test.ts
+++ b/src/__test__/util/config/validateConfigColumns.test.ts
@@ -1,0 +1,226 @@
+import { GassmaUnknownArgumentError } from "../../../errors/argument/argumentError";
+import { validateConfigColumns } from "../../../util/config/validateConfigColumns";
+
+const headersBySheet: Record<string, string[]> = {
+  Users: ["id", "名前", "年齢", "住所"],
+  Posts: ["id", "authorId", "title", "updatedAt"],
+};
+
+const sheets: Record<string, unknown> = { Users: {}, Posts: {} };
+
+const makeGetColumnHeaders = () =>
+  jest.fn((sheetName: string) => headersBySheet[sheetName] ?? []);
+
+describe("validateConfigColumns", () => {
+  describe("defaults", () => {
+    it("存在しない列名のキーがあるとエラーを投げる", () => {
+      expect(() =>
+        validateConfigColumns(
+          { defaults: { Users: { 年齢: 0, 住処: "" } } },
+          sheets,
+          makeGetColumnHeaders(),
+        ),
+      ).toThrow(GassmaUnknownArgumentError);
+    });
+
+    it("エラーメッセージにサジェストが含まれる", () => {
+      expect(() =>
+        validateConfigColumns(
+          { defaults: { Users: { 住処: "" } } },
+          sheets,
+          makeGetColumnHeaders(),
+        ),
+      ).toThrow("Unknown argument `住処`. Did you mean `住所`?");
+    });
+
+    it("すべて実在する列名なら通る", () => {
+      expect(() =>
+        validateConfigColumns(
+          { defaults: { Users: { 年齢: 0, 住所: "" } } },
+          sheets,
+          makeGetColumnHeaders(),
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe("updatedAt / autoincrement / ignore(値が列名)", () => {
+    it("updatedAt の文字列指定の typo でエラーを投げる", () => {
+      expect(() =>
+        validateConfigColumns(
+          { updatedAt: { Posts: "updatedat" } },
+          sheets,
+          makeGetColumnHeaders(),
+        ),
+      ).toThrow(GassmaUnknownArgumentError);
+    });
+
+    it("updatedAt の配列指定の中の typo でエラーを投げる", () => {
+      expect(() =>
+        validateConfigColumns(
+          { updatedAt: { Posts: ["updatedAt", "updatedat"] } },
+          sheets,
+          makeGetColumnHeaders(),
+        ),
+      ).toThrow(GassmaUnknownArgumentError);
+    });
+
+    it("autoincrement の typo でエラーを投げる", () => {
+      expect(() =>
+        validateConfigColumns(
+          { autoincrement: { Posts: "iid" } },
+          sheets,
+          makeGetColumnHeaders(),
+        ),
+      ).toThrow(GassmaUnknownArgumentError);
+    });
+
+    it("ignore の typo でエラーを投げる", () => {
+      expect(() =>
+        validateConfigColumns(
+          { ignore: { Posts: ["titel"] } },
+          sheets,
+          makeGetColumnHeaders(),
+        ),
+      ).toThrow(GassmaUnknownArgumentError);
+    });
+
+    it("実在する列名なら通る", () => {
+      expect(() =>
+        validateConfigColumns(
+          {
+            updatedAt: { Posts: "updatedAt" },
+            autoincrement: { Posts: "id" },
+            ignore: { Posts: ["title"] },
+          },
+          sheets,
+          makeGetColumnHeaders(),
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe("omit(キーが列名)", () => {
+    it("存在しない列名のキーがあるとエラーを投げる", () => {
+      expect(() =>
+        validateConfigColumns(
+          { omit: { Users: { 名前まえ: true } } },
+          sheets,
+          makeGetColumnHeaders(),
+        ),
+      ).toThrow(GassmaUnknownArgumentError);
+    });
+
+    it("実在する列名なら通る", () => {
+      expect(() =>
+        validateConfigColumns(
+          { omit: { Users: { 名前: true } } },
+          sheets,
+          makeGetColumnHeaders(),
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe("map(値がシート実列名)", () => {
+    const mappedHeaders: Record<string, string[]> = {
+      Users: ["id", "name", "年齢", "address"],
+    };
+    const getMappedHeaders = jest.fn(
+      (sheetName: string) => mappedHeaders[sheetName] ?? [],
+    );
+
+    it("マッピングが正しければ通る(見出しはコード名に変換済み)", () => {
+      expect(() =>
+        validateConfigColumns(
+          { map: { Users: { name: "名前", address: "住所" } } },
+          sheets,
+          getMappedHeaders,
+        ),
+      ).not.toThrow();
+    });
+
+    it("値の typo でエラーを投げ、生の見出しからサジェストする", () => {
+      expect(() =>
+        validateConfigColumns(
+          { map: { Users: { address: "住処" } } },
+          sheets,
+          makeGetColumnHeaders(),
+        ),
+      ).toThrow("Unknown argument `住処`. Did you mean `住所`?");
+    });
+
+    it("map 使用時、他の設定はコード名で照合される", () => {
+      expect(() =>
+        validateConfigColumns(
+          {
+            map: { Users: { name: "名前", address: "住所" } },
+            defaults: { Users: { address: "" } },
+          },
+          sheets,
+          getMappedHeaders,
+        ),
+      ).not.toThrow();
+    });
+
+    it("map 使用時、マッピング前のシート実列名で他の設定を書くとエラーを投げる", () => {
+      expect(() =>
+        validateConfigColumns(
+          {
+            map: { Users: { name: "名前", address: "住所" } },
+            defaults: { Users: { 住所: "" } },
+          },
+          sheets,
+          getMappedHeaders,
+        ),
+      ).toThrow(GassmaUnknownArgumentError);
+    });
+  });
+
+  describe("見出し読みの範囲", () => {
+    it("設定に登場しないシートの見出しは読まない", () => {
+      const getColumnHeaders = makeGetColumnHeaders();
+      validateConfigColumns(
+        { defaults: { Users: { 年齢: 0 } } },
+        sheets,
+        getColumnHeaders,
+      );
+      expect(getColumnHeaders).toHaveBeenCalledTimes(1);
+      expect(getColumnHeaders).toHaveBeenCalledWith("Users");
+    });
+
+    it("同じシートに複数の設定があっても見出し読みは1回", () => {
+      const getColumnHeaders = makeGetColumnHeaders();
+      validateConfigColumns(
+        {
+          defaults: { Users: { 年齢: 0 } },
+          updatedAt: { Users: "住所" },
+          omit: { Users: { 名前: true } },
+        },
+        sheets,
+        getColumnHeaders,
+      );
+      expect(getColumnHeaders).toHaveBeenCalledTimes(1);
+    });
+
+    it("存在しないシート名のキーは黙って無視する(見出しも読まない)", () => {
+      const getColumnHeaders = makeGetColumnHeaders();
+      expect(() =>
+        validateConfigColumns(
+          { defaults: { Userz: { 何か: 1 } } },
+          sheets,
+          getColumnHeaders,
+        ),
+      ).not.toThrow();
+      expect(getColumnHeaders).not.toHaveBeenCalled();
+    });
+
+    it("設定が何もなければ何も読まない", () => {
+      const getColumnHeaders = makeGetColumnHeaders();
+      expect(() =>
+        validateConfigColumns({}, sheets, getColumnHeaders),
+      ).not.toThrow();
+      expect(getColumnHeaders).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/gassma.ts
+++ b/src/gassma.ts
@@ -10,6 +10,7 @@ import type {
   GassmaTransactionOptions,
   SheetIo,
 } from "./types/transactionTypes";
+import { validateConfigColumns } from "./util/config/validateConfigColumns";
 import { buildExtendedClient } from "./util/extends/buildExtendedClient";
 import { isSheetIgnored } from "./util/ignore/isSheetIgnored";
 import { resolveCodeName } from "./util/map/mapSheetName";
@@ -113,8 +114,23 @@ class GassmaClient {
 
     Object.assign(this, controllers);
 
+    const headerCache = new Map<string, string[]>();
+    const getColumnHeaders = (sheetName: string): string[] => {
+      const cached = headerCache.get(sheetName);
+      if (cached) return cached;
+      const headers = controllers[sheetName].getColumnHeaders();
+      headerCache.set(sheetName, headers);
+      return headers;
+    };
+
+    validateConfigColumns(
+      { omit: globalOmit, defaults, updatedAt, autoincrement, ignore, map },
+      controllers,
+      getColumnHeaders,
+    );
+
     if (relations) {
-      injectRelations(relations, controllers);
+      injectRelations(relations, controllers, getColumnHeaders);
     }
   }
 

--- a/src/util/config/validateConfigColumns.ts
+++ b/src/util/config/validateConfigColumns.ts
@@ -1,0 +1,103 @@
+import { GassmaUnknownArgumentError } from "../../errors/argument/argumentError";
+import type {
+  AutoincrementConfig,
+  DefaultsConfig,
+  GlobalOmitConfig,
+  IgnoreConfig,
+  MapConfig,
+  UpdatedAtConfig,
+} from "../../types/relationTypes";
+
+type GetColumnHeaders = (sheetName: string) => string[];
+
+type ConfigForColumnCheck = {
+  omit?: GlobalOmitConfig;
+  defaults?: DefaultsConfig;
+  updatedAt?: UpdatedAtConfig;
+  autoincrement?: AutoincrementConfig;
+  ignore?: IgnoreConfig;
+  map?: MapConfig;
+};
+
+const toArray = (value: string | string[]): string[] =>
+  Array.isArray(value) ? value : [value];
+
+const assertColumnsExist = (columnNames: string[], headers: string[]): void => {
+  columnNames.forEach((columnName) => {
+    if (!headers.includes(columnName)) {
+      throw new GassmaUnknownArgumentError(columnName, headers);
+    }
+  });
+};
+
+const validateMapColumns = (
+  mapping: { [codeName: string]: string },
+  headers: string[],
+): void => {
+  const codeNames = new Set(Object.keys(mapping));
+  const rawHeaders = headers.map((header) =>
+    codeNames.has(header) ? mapping[header] : header,
+  );
+  Object.keys(mapping).forEach((codeName) => {
+    if (!rawHeaders.includes(mapping[codeName])) {
+      throw new GassmaUnknownArgumentError(mapping[codeName], rawHeaders);
+    }
+  });
+};
+
+const collectSheetNames = (config: ConfigForColumnCheck): string[] => {
+  const sections = [
+    config.map,
+    config.defaults,
+    config.updatedAt,
+    config.autoincrement,
+    config.ignore,
+    config.omit,
+  ];
+  const names: string[] = [];
+  sections.forEach((section) => {
+    if (!section) return;
+    Object.keys(section).forEach((sheetName) => {
+      if (!names.includes(sheetName)) names.push(sheetName);
+    });
+  });
+  return names;
+};
+
+const validateSheetConfigColumns = (
+  config: ConfigForColumnCheck,
+  sheetName: string,
+  headers: string[],
+): void => {
+  const mapping = config.map?.[sheetName];
+  if (mapping) validateMapColumns(mapping, headers);
+
+  const defaults = config.defaults?.[sheetName];
+  if (defaults) assertColumnsExist(Object.keys(defaults), headers);
+
+  const updatedAt = config.updatedAt?.[sheetName];
+  if (updatedAt) assertColumnsExist(toArray(updatedAt), headers);
+
+  const autoincrement = config.autoincrement?.[sheetName];
+  if (autoincrement) assertColumnsExist(toArray(autoincrement), headers);
+
+  const ignore = config.ignore?.[sheetName];
+  if (ignore) assertColumnsExist(toArray(ignore), headers);
+
+  const omit = config.omit?.[sheetName];
+  if (omit) assertColumnsExist(Object.keys(omit), headers);
+};
+
+const validateConfigColumns = (
+  config: ConfigForColumnCheck,
+  sheets: Record<string, unknown>,
+  getColumnHeaders: GetColumnHeaders,
+): void => {
+  collectSheetNames(config).forEach((sheetName) => {
+    if (!(sheetName in sheets)) return;
+    validateSheetConfigColumns(config, sheetName, getColumnHeaders(sheetName));
+  });
+};
+
+export { validateConfigColumns };
+export type { ConfigForColumnCheck, GetColumnHeaders };

--- a/src/util/relation/injectRelations.ts
+++ b/src/util/relation/injectRelations.ts
@@ -1,21 +1,14 @@
 import type { AnyUse, QueryOmit, WhereUse } from "../../types/coreTypes";
 import type { GassmaSheet } from "../../types/gassmaTypes";
 import type { IncludeData, RelationsConfig } from "../../types/relationTypes";
+import type { GetColumnHeaders } from "./validation/validateColumnExistence";
 import { validateRelationsConfig } from "./validation/validateRelationsConfig";
 
 const injectRelations = (
   relations: RelationsConfig,
   controllers: GassmaSheet,
+  getColumnHeaders: GetColumnHeaders,
 ) => {
-  const cache = new Map<string, string[]>();
-  const getColumnHeaders = (sheetName: string): string[] => {
-    const cached = cache.get(sheetName);
-    if (cached) return cached;
-    const headers = controllers[sheetName].getColumnHeaders();
-    cache.set(sheetName, headers);
-    return headers;
-  };
-
   const getIgnoredFields = (sheetName: string): string[] =>
     controllers[sheetName]._getIgnoredFields();
 


### PR DESCRIPTION
typo 対策の一環です。ご指示のとおり **`create` のたびではなく起動時に1度だけ**失敗させる形にしました。

## 問題

設定に書いた列名が**シートと照合されていませんでした**。

```js
new GassmaClient({
  Users: { defaults: { 年齢: 0, 住処: "" } }
  //                          ↑ "住所" の typo。黙って無視され、既定値が入らない
})
```

エラーも警告も出ないため、**行が想定と違う値で作られるまで気づけません**。

## 対象は6つでした

型定義(`GassmaClientOptions`)の全キーを走査した結果、**列名を受け取るのは当初想定していた3つではなく6つ**でした。

| 設定 | 列名の位置 |
|---|---|
| `defaults` | 内側オブジェクトの**キー** |
| `updatedAt` | **値** |
| `autoincrement` | **値** |
| `ignore` | **値** |
| `omit` | 内側オブジェクトの**キー** |
| `map` | **値**(シートの実列名) |

`relations` の `field` / `reference` / `through` は既存の `validateColumnExistence` が検証済みです。列名を含まない残りは `id` / `ignoreSheets` / `mapSheets` / `strictUndefinedChecks` でした。

## 修正

リレーションの検証と同じ場所(クライアント構築時)で検証します。

```
Unknown argument `住処`. Did you mean `住所`?

Available: 名前, 年齢, 住所, 郵便番号, 職業
```

### 見出しの読みは増えていません

**ここが設計上の要点**でした。起動時に検証するには見出しを読む必要がありますが、**リレーションの検証が既に読んでいる**ため、その結果をメモ化して共有しています。

- **リレーションと設定が同じシートを指しても、起動時の見出し読みは各シート1回**であることをテストで固定(このテストは修正前のコードでも通ります = リレーション検証が既に読んでいた回数と同一)
- 設定に登場しないシートは読まない、設定が無ければ一切読まないこともテストで固定
- **往復回数の契約テスト3スイート26件も green**

設定だけがあってリレーションが無いシートは起動時に1回読むようになりますが、これは「起動時検証」に不可避なコストです。

## `@@map` の扱い

`getTitle` は `@@map` を**適用済み(コード名空間)**の見出しを返し、`applyDefaults` などの実行時解釈もコード名空間です。したがって `defaults` / `updatedAt` / `autoincrement` / `ignore` / `omit` は**マッピング後の名前で照合**します。

`map` 自体はその値が**シートの実列名**なので、マッピング適用済み見出しから生見出しを復元して照合し、サジェストも生見出しから出します(`{address: "住処"}` → `Did you mean \`住所\`?`)。**`map` の検証を他より先に行う**ので、`map` が壊れている場合はまず `map` のエラーが出ます(依存する設定側が芋づる式にエラーを出すのを避けるため)。

## `@ignore` 列は許可しています

**実在すれば通す**(存在チェックのみ)としました。`getTitle` は `@ignore` 列をフィルタしないので見出しに実在し、**typo ではない**ためです。

「`@ignore` 列への `defaults` は結局 strip されるので無意味」という**設定間の矛盾を拒否するかどうかは別の仕様判断**です(#177 でリレーション側の同種の判断に専用エラークラスと説明文を要したのと同じ性質)。フォローアップ候補として残します。

## 実証

同じ統合テスト12件を修正前のコードでも実行しました。

- **修正前**: 6つの typo すべてが**素通り**(6件 fail)、起動時の読みはゼロ
- **修正後**: 12件すべて green。typo は `new GassmaClient(...)` の時点でエラー

## 検証結果

- `npm test`: **2,375件 全 green**(2,345 → +30、**既存テストの変更0件**)
- 往復契約テスト3スイート26件 green
- `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル57件)pass

新しいエラークラスは追加していないので **cli 側の追随は不要**です。

## フォローアップ候補(今回は見送り)

1. **エラーメッセージに設定名・シート名の文脈がない** — `GassmaUnknownArgumentError(列名, 見出し)` は #196 の `where` 検証と同じ流儀ですが、起動時エラーでは「どの設定のどのシートか」が出ません(`Available` の見出し一覧でおおむね判別できます)。既存クラスのコンストラクタ拡張は仕様変更になるため見送りました
2. **設定のシート名キーの typo**(`defaults: { Userz: ... }`)は従来どおり黙って無視されます。列名ではないのでスコープ外としましたが、同じ場所で検出できます
3. 上記の `@ignore` 列との矛盾検出

🤖 Generated with [Claude Code](https://claude.com/claude-code)