### PR TITLE
fix: data の未知の列名とスカラー set をエラーにする(typo 対策 3-2・最終)

### DIFF
--- a/src/__test__/util/dataColumnValidation.test.ts
+++ b/src/__test__/util/dataColumnValidation.test.ts
@@ -1,0 +1,305 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../errors/argument/argumentError";
+import { buildTestClient, sheetOf } from "./extends/extendsTestClient";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "./transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const looseUsers = (options?: {
+  relations?: boolean;
+}): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const typed = sheetOf(buildTestClient(options), "Users");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+const loosePosts = (): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const typed = sheetOf(buildTestClient({ relations: true }), "Posts");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+const aliceUnchanged = (typed: ReturnType<typeof sheetOf>) => {
+  expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+    id: 1,
+    name: "Alice",
+    age: 20,
+  });
+};
+
+describe("data の列名 typo で書き込みが誤爆しない", () => {
+  test("create: nmae はサジェスト付きエラーになり空行が追加されない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () => loose.create({ data: { id: 9, nmae: "Zed", age: 1 } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `nmae`. Did you mean `name`?\n\nAvailable: id, name, age",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("create: relations ありなら Available にリレーション名も並ぶ", () => {
+    const { loose, typed } = looseUsers({ relations: true });
+    expect(() =>
+      loose.create({ data: { id: 9, nmae: "Zed", age: 1 } }),
+    ).toThrow("Available: id, name, age, posts");
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("createMany: 2行目の typo もエラーになり1行も追加されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.createMany({
+        data: [
+          { id: 8, name: "Yui", age: 2 },
+          { id: 9, nmae: "Zed", age: 1 },
+        ],
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("createManyAndReturn: typo はエラーになり追加されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.createManyAndReturn({ data: [{ id: 9, nmae: "Zed", age: 1 }] }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("updateMany: 未知列はエラーになり count だけ返る no-op にならない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.updateMany({ where: { age: { gte: 0 } }, data: { 住処: "Kobe" } }),
+    ).toThrow(GassmaUnknownArgumentError);
+    aliceUnchanged(typed);
+  });
+
+  test("update: 未知列はエラーになり行が更新されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.update({ where: { id: 1 }, data: { nmae: "X" } }),
+    ).toThrow(GassmaUnknownArgumentError);
+    aliceUnchanged(typed);
+  });
+
+  test("upsert(更新分岐): update 側の typo はエラーになり更新されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.upsert({
+        where: { id: 1 },
+        create: { id: 1, name: "Alice", age: 20 },
+        update: { nmae: "X" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    aliceUnchanged(typed);
+  });
+
+  test("upsert(作成分岐): create 側の typo はエラーになり追加されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.upsert({
+        where: { id: 99 },
+        create: { id: 99, nmae: "Zed", age: 1 },
+        update: { name: "X" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(typed.count({})).toBe(3);
+  });
+});
+
+describe("スカラー列の set はエラー", () => {
+  test("update: age に set はエラーになりセルが壊れない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () =>
+      loose.update({ where: { id: 1 }, data: { age: { set: 5 } } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow(
+      "Unknown argument `set`.\n\nAvailable: increment, decrement, multiply, divide",
+    );
+    aliceUnchanged(typed);
+  });
+
+  test("update: relations ありでもスカラー列の set はエラー", () => {
+    const { loose, typed } = loosePosts();
+    expect(() =>
+      loose.update({ where: { id: 101 }, data: { title: { set: "X" } } }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(typed.findFirst({ where: { id: 101 } })).toEqual({
+      id: 101,
+      authorId: 1,
+      title: "Post A",
+    });
+  });
+
+  test("updateMany: スカラー列の set はエラーになり全行無変化", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.updateMany({
+        where: { age: { gte: 0 } },
+        data: { age: { set: 5 } },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    aliceUnchanged(typed);
+  });
+});
+
+describe("リレーション名に不正な値", () => {
+  test("update: リレーション名にスカラー値は専用メッセージでエラー", () => {
+    const { loose, typed } = looseUsers({ relations: true });
+    const fn = () => loose.update({ where: { id: 1 }, data: { posts: "abc" } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Invalid value for argument `posts`.");
+    aliceUnchanged(typed);
+  });
+
+  test("create: リレーション名にスカラー値は専用メッセージでエラー", () => {
+    const { loose, typed } = looseUsers({ relations: true });
+    expect(() =>
+      loose.create({ data: { id: 9, name: "Zed", age: 1, posts: "abc" } }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("createMany: nested write 非対応なのでリレーション名はエラー", () => {
+    const { loose, typed } = looseUsers({ relations: true });
+    const fn = () =>
+      loose.createMany({
+        data: [
+          {
+            id: 9,
+            name: "Zed",
+            age: 1,
+            posts: { create: { id: 200, authorId: 9, title: "New" } },
+          },
+        ],
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Available: id, name, age");
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("updateMany: nested write 非対応なのでリレーション名はエラー", () => {
+    const { loose, typed } = looseUsers({ relations: true });
+    expect(() =>
+      loose.updateMany({
+        where: { id: 1 },
+        data: { posts: { connect: { id: 102 } } },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    aliceUnchanged(typed);
+  });
+});
+
+describe("従来どおり動くこと", () => {
+  test("正しい列名の create は通る", () => {
+    const { typed } = looseUsers();
+    expect(typed.create({ data: { id: 9, name: "Zed", age: 1 } })).toEqual({
+      id: 9,
+      name: "Zed",
+      age: 1,
+    });
+    expect(typed.count({})).toBe(4);
+  });
+
+  test("数値演算 increment は通る", () => {
+    const { loose, typed } = looseUsers();
+    loose.update({ where: { id: 1 }, data: { age: { increment: 5 } } });
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 25,
+    });
+  });
+
+  test("undefined 値の未知キーは無視される", () => {
+    const { loose, typed } = looseUsers();
+    loose.create({ data: { id: 9, name: "Zed", age: 1, nmae: undefined } });
+    expect(typed.count({})).toBe(4);
+  });
+
+  test("nested write の create は通る", () => {
+    const client = buildTestClient({ relations: true });
+    const users: any = sheetOf(client, "Users");
+    const posts = sheetOf(client, "Posts");
+    users.create({
+      data: {
+        id: 9,
+        name: "Zed",
+        age: 1,
+        posts: { create: { id: 200, title: "New" } },
+      },
+    });
+    expect(posts.findFirst({ where: { id: 200 } })).toEqual({
+      id: 200,
+      authorId: 9,
+      title: "New",
+    });
+  });
+
+  test("nested write の connect / set / disconnect は通る", () => {
+    const { loose } = looseUsers({ relations: true });
+    expect(() =>
+      loose.update({
+        where: { id: 1 },
+        data: { posts: { connect: { id: 102 } } },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      loose.update({
+        where: { id: 1 },
+        data: { posts: { set: [{ id: 101 }] } },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      loose.update({
+        where: { id: 1 },
+        data: { posts: { disconnect: { id: 101 } } },
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("$transaction 経由", () => {
+  test("tx 内の create typo もエラーになりシートが変化しない", () => {
+    const env = buildTxTestEnv();
+    const tx = (env.client as any).$transaction.bind(env.client);
+    expect(() =>
+      tx((txClient: any) => {
+        txClient.Users.create({ data: { id: 9, nmae: "Zed", age: 1 } });
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+    ]);
+  });
+});
+
+describe("$extends 経由", () => {
+  test("query フックを素通しした data の未知列もエラー", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      query: {
+        Users: {
+          create({ args, query }) {
+            return query(args);
+          },
+        },
+      },
+    });
+    const loose: any = extended.Users;
+    expect(() =>
+      loose.create({ data: { id: 9, nmae: "Zed", age: 1 } }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(extended.Users.count({})).toBe(3);
+  });
+});

--- a/src/util/create/create.ts
+++ b/src/util/create/create.ts
@@ -4,6 +4,7 @@ import { getTitle } from "../core/getTitle";
 import { getWantUpdateIndexFromTitles } from "../core/getWantUpdateIndex";
 import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
 import { unwrapRawCell } from "../raw/raw";
+import { validateDataColumns } from "../validate/validateDataColumns";
 import { resolveWriter } from "../write/sheetWriter";
 
 const createFunc = (
@@ -14,6 +15,15 @@ const createFunc = (
 
   const data = createdData.data;
   const titles = getTitle(gassmaControllerUtil);
+
+  if (gassmaControllerUtil.whereValidation) {
+    validateDataColumns(
+      data,
+      titles,
+      gassmaControllerUtil.whereValidation,
+      "create",
+    );
+  }
 
   const wantCreateIndex = getWantUpdateIndexFromTitles(titles, data);
 

--- a/src/util/create/createManyFunc.ts
+++ b/src/util/create/createManyFunc.ts
@@ -4,6 +4,7 @@ import { getTitle } from "../core/getTitle";
 import { getWantUpdateIndexFromTitles } from "../core/getWantUpdateIndex";
 import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
 import { unwrapRawCell } from "../raw/raw";
+import { validateDataColumns } from "../validate/validateDataColumns";
 import { resolveWriter } from "../write/sheetWriter";
 
 function createManyFunc(
@@ -29,6 +30,13 @@ function createManyFunc(
   }
 
   const titles = getTitle(gassmaControllerUtil);
+
+  const validation = gassmaControllerUtil.whereValidation;
+  if (validation) {
+    data.forEach((row) => {
+      validateDataColumns(row, titles, validation, "createMany");
+    });
+  }
 
   const newData = data.map((row) => {
     const wantCreateIndex = getWantUpdateIndexFromTitles(titles, row);

--- a/src/util/update/nestedWrite/resolveNestedUpdate.ts
+++ b/src/util/update/nestedWrite/resolveNestedUpdate.ts
@@ -23,6 +23,7 @@ import {
 } from "../resolveNumberOperation";
 import { escapeFormulaInjectionRow } from "../../core/escapeFormulaInjection";
 import { unwrapRawCell } from "../../raw/raw";
+import { validateDataColumns } from "../../validate/validateDataColumns";
 import { resolveWriter } from "../../write/sheetWriter";
 
 type UpdateInput = {
@@ -66,9 +67,21 @@ const resolveNestedUpdate = (
   if (!hasUpdateNestedWriteFields(updateInput.data, relationContext)) {
     if (
       !relationContext &&
-      Object.values(updateInput.data).some(isUpdateNestedWriteOperation)
+      Object.entries(updateInput.data).some(
+        ([key, value]) =>
+          !titles.includes(key) && isUpdateNestedWriteOperation(value),
+      )
     ) {
       throw new NestedWriteWithoutRelationsError();
+    }
+
+    if (util.whereValidation) {
+      validateDataColumns(
+        updateInput.data,
+        titles,
+        util.whereValidation,
+        "update",
+      );
     }
 
     const wantUpdateIndex = getWantUpdateIndexFromTitles(
@@ -103,6 +116,10 @@ const resolveNestedUpdate = (
     updateInput.data,
     relationContext!.relations,
   );
+
+  if (util.whereValidation) {
+    validateDataColumns(scalarData, titles, util.whereValidation, "update");
+  }
 
   const enrichedData = processBeforeCreate(
     scalarData,

--- a/src/util/update/updateMany.ts
+++ b/src/util/update/updateMany.ts
@@ -6,6 +6,7 @@ import { getTitle } from "../core/getTitle";
 import { getWantUpdateIndexFromTitles } from "../core/getWantUpdateIndex";
 import { whereFilter } from "../core/whereFilter";
 import { unwrapRawCell } from "../raw/raw";
+import { validateDataColumns } from "../validate/validateDataColumns";
 import { groupUpdateRuns } from "../write/rowRuns";
 import { resolveWriter } from "../write/sheetWriter";
 import {
@@ -36,6 +37,16 @@ function updateManyFunc(
   const limit = updateData.limit;
 
   const titles = getTitle(gassmaControllerUtil);
+
+  if (gassmaControllerUtil.whereValidation) {
+    validateDataColumns(
+      data,
+      titles,
+      gassmaControllerUtil.whereValidation,
+      "updateMany",
+    );
+  }
+
   let findedData = whereFilter(where, gassmaControllerUtil, titles);
 
   if (limit !== undefined && limit !== null) {

--- a/src/util/validate/validateDataColumns.ts
+++ b/src/util/validate/validateDataColumns.ts
@@ -1,0 +1,74 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../errors/argument/argumentError";
+import type { WhereValidation } from "../../types/gassmaControllerUtilType";
+import { NESTED_WRITE_KEYS } from "../create/nestedWrite/extractRelationData";
+import { isDateValue } from "../other/isDateValue";
+import { isDict } from "../other/isDict";
+import { isRawValue } from "../raw/raw";
+import { UPDATE_NESTED_WRITE_KEYS } from "../update/nestedWrite/extractRelationDataForUpdate";
+import { NUMBER_OPERATION_KEYS } from "../update/resolveNumberOperation";
+
+type DataColumnMode = "create" | "createMany" | "update" | "updateMany";
+
+const RELATION_OPERATION_KEYS: Record<DataColumnMode, string[] | null> = {
+  create: NESTED_WRITE_KEYS,
+  createMany: null,
+  update: UPDATE_NESTED_WRITE_KEYS,
+  updateMany: null,
+};
+
+const isPlainObjectValue = (value: unknown): value is Record<string, unknown> =>
+  isDict(value) && !isDateValue(value) && !isRawValue(value);
+
+const validateColumnOperations = (
+  value: unknown,
+  mode: DataColumnMode,
+): void => {
+  if (mode !== "update" && mode !== "updateMany") return;
+  if (!isPlainObjectValue(value)) return;
+  Object.keys(value).forEach((operationKey) => {
+    if (!NUMBER_OPERATION_KEYS.includes(operationKey)) {
+      throw new GassmaUnknownArgumentError(operationKey, NUMBER_OPERATION_KEYS);
+    }
+  });
+};
+
+const validateDataColumns = (
+  data: Record<string, unknown>,
+  titles: string[],
+  validation: WhereValidation,
+  mode: DataColumnMode,
+): void => {
+  const allowedColumns = titles.filter(
+    (title) => !validation.ignoredFields.includes(title),
+  );
+  const allowed = new Set(allowedColumns);
+  const relationOperationKeys = RELATION_OPERATION_KEYS[mode];
+
+  Object.entries(data).forEach(([key, value]) => {
+    if (value === undefined) return;
+    if (allowed.has(key)) {
+      validateColumnOperations(value, mode);
+      return;
+    }
+    if (
+      relationOperationKeys !== null &&
+      validation.relationNames.includes(key)
+    ) {
+      throw new GassmaInvalidValueError(
+        key,
+        `a nested write operation object with one of: ${relationOperationKeys.join(", ")}`,
+      );
+    }
+    const availableArguments =
+      relationOperationKeys === null
+        ? allowedColumns
+        : [...allowedColumns, ...validation.relationNames];
+    throw new GassmaUnknownArgumentError(key, availableArguments);
+  });
+};
+
+export { validateDataColumns };
+export type { DataColumnMode };


### PR DESCRIPTION
typo 対策の**最後の1本**です。#192 / #193 / #194 / #195 / #196 / #197 / #198 の続きで、これで `LLM/typo-silence.html` に挙げた黙殺経路がほぼ全て塞がります。

> [!WARNING]
> **破壊的変更です。**

## 問題

`data` のキーを書き間違えると、**キーごと値が捨てられます**。

```js
create({ data: { nmae: "Y", 年令: 99 } })
// → 全セル空の行が1行追加され、エラーは出ない
// → 返り値からは typo キー自体が消える

updateMany({ where: {...}, data: { 住処: "Kobe" } })
// → {"count":3} が返るのにシートは無変化
```

**`count > 0` なら保存成功、という自然な解釈が成立しません。**

さらに、**唯一残っていたデータ破壊**もここにありました。

```js
update({ data: { 年齢: { set: 5 } } })
// → セルに {"set":5} が書かれ、元の 20 が失われる
```

#194 で数値演算子の検証を入れたとき、**`set` は nested write のキーでもあるため「リレーション名の typo なのか列名なのか」を区別できず**、素通しにするしかありませんでした。**列名検証が入って初めて直せます。**

## 修正

**titles が既に手元にある4つの合流点**で検証します。`getTitle` の追加呼び出しはゼロです。

- `create.ts` / `createManyFunc.ts` / `updateMany.ts` / `resolveNestedUpdate.ts`(2箇所)

`whereValidation` ガード付き(#196 と同じ手法)なので、util を手組みする内部経路は従来どおり動きます。

### リレーション名は届きません

`extractRelationData` / `extractRelationDataForUpdate` が「relations に存在 **かつ** 正規の op キーを含む dict」を先に分離するため、検証地点に届くリレーション名は **(a) 非 op 値を持つもの (b) nested 非対応の操作(`createMany` / `updateMany`)に書かれたもの**だけで、どちらも不正です。

- (a) は専用メッセージ(`create, connect, ...` のいずれかを含むオブジェクトが必要)
- (b) は列名のみを `Available` に載せる

nested 対応モードでだけ `Available` にリレーション名を含める、という出し分けをしています。

### スカラー `set`

update 系で「**列名キー + 素の dict 値**」(Date と `Gassma.raw` は realm 安全な判定で除外)なら、全キーが数値演算子であることを要求します。

```
Unknown argument `set`.

Available: increment, decrement, multiply, divide
```

付随して `resolveNestedUpdate` の `NestedWriteWithoutRelationsError` の判定を「**列でないキー**が op 値を持つ場合」に絞りました。リレーション未定義のシートで `age: { set: 5 }` を書くと、そちらの誤ったエラーになっていたためです(既存テスト3件は全て通過)。

## 実証(修正前を実測して比較)

| 経路 | 修正前 | 修正後 |
|---|---|---|
| `create({ data: { nmae } })` | 正常終了・全 null 返却・**空行が追加** | エラー + **行が増えない** |
| `updateMany({ data: { 住処 } })` | **`{count:3}` を返してシート無変化** | エラー + シート無変化 |
| `update({ data: { 年齢: { set: 5 } } })` | **セルに `{"set":5}` が書かれ破壊** | エラー + **シート不変** |

## 検証結果

**#197 / #198 をマージ済みの main の上でリベースして再検証しています。**

- `npm test`: **2,411件 全 green**(**既存テストの変更0件**)
- **往復回数の契約テスト3スイート26件 green**(見出し読みが増えていない実証)
- `tsc --noEmit` / lint(警告数は変更前と同数)/ format / `verify:bundle`(公開シンボル57件)pass

追加テスト22件は、8操作の typo 遮断・`set` の3系統・リレーション名の不正値4系統に加え、**従来動作の維持**(`increment`・`undefined` キーの無視・nested の `create`/`connect`/`set`/`disconnect`・`$transaction`・`$extends`)を固定しています。

## 設定注入キーとの関係

**`defaults` / `updatedAt` / `autoincrement` で設定された列名は、この検証に引っかかります**(実測確認済み)。

ただし **#198(設定の起動時検証)がマージ済み**なので、typo は**クライアント生成時に先に落ちます**。この操作時エラーはフォールバックとして残る形で、ご指示の「起動時に検証」という挙動は満たされています。除外は実装していません。

## 判断が要る点

**1. `@ignore` 列への書き込みが create と update で非対称です。**

update / updateMany は #196 の `where` と同様に許可リストから除外したため、**今回からエラー**になります(Prisma 整合)。一方 **create は controller の strip が検証より前に落とす**ため、従来どおり黙って無視されます。揃えるなら別途対応が要ります。

**2. nested create と typo を併用したときの部分書き込み。**

`create` の before フェーズ(関連レコードの作成)が `createFunc` 内の検証より先に走るため、**関連側が作られてからエラー**になります。update 側は副作用の前に検証して回避済みです。create 側も塞ぐには `createFunc` / `resolveNestedCreate` のシグネチャ変更が必要で、差分が大きくなるため見送りました。

**3. `create` の「列名キー + dict 値」は値を検証していません**(`create({ data: { 年齢: { set: 5 } } })` など)。Prisma の `create` にスカラー `set` 構文は無く、ご承認いただいた範囲は update 系の `set` エラー化と解釈しました。

## 補足

`whereValidation` というフィールド名が `data` の検証にも使われていて実態とずれますが、リネームは #196 のコードに触るため見送っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)