### PR TITLE
fix: create の入力を書き込み前に検証する(残り3つの穴)

### DIFF
--- a/src/__test__/util/create/createDataValidation.test.ts
+++ b/src/__test__/util/create/createDataValidation.test.ts
@@ -1,0 +1,350 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../../errors/argument/argumentError";
+import { GassmaClient } from "../../../gassma";
+import { GassmaController } from "../../../gassmaController";
+import { raw } from "../../../util/raw/raw";
+import {
+  clearGasGlobals,
+  makeLoggedSheet,
+} from "../transaction/transactionTestClient";
+
+type EnvOptions = {
+  relations?: boolean;
+  ignore?: { [sheetName: string]: string };
+};
+
+const buildEnv = (options?: EnvOptions) => {
+  const users = makeLoggedSheet("Users", [
+    ["id", "name", "age"],
+    [1, "Alice", 20],
+    [2, "Bob", 30],
+  ]);
+  const posts = makeLoggedSheet("Posts", [
+    ["id", "authorId", "title"],
+    [101, 1, "Post A"],
+  ]);
+  const comments = makeLoggedSheet("Comments", [
+    ["id", "postId", "body"],
+    [1001, 101, "Hello"],
+  ]);
+  const sheets = [users.sheet, posts.sheet, comments.sheet];
+  const spreadsheet: any = {
+    getId: () => "create-data-validation-test",
+    getSheets: () => sheets,
+    getSheetByName: (name: string) =>
+      sheets.find((sheet: any) => sheet.getName() === name) ?? null,
+  };
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => spreadsheet },
+  });
+  const relations = options?.relations
+    ? {
+        Posts: {
+          comments: {
+            type: "oneToMany" as const,
+            to: "Comments",
+            field: "id",
+            reference: "postId",
+          },
+        },
+        Comments: {
+          post: {
+            type: "manyToOne" as const,
+            to: "Posts",
+            field: "postId",
+            reference: "id",
+          },
+        },
+      }
+    : undefined;
+  const client = new GassmaClient({
+    ...(relations ? { relations } : {}),
+    ...(options?.ignore ? { ignore: options.ignore } : {}),
+  });
+  return { client, users, posts, comments };
+};
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!(controller instanceof GassmaController)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+describe("create: 列名キーへの素の dict 値はエラー", () => {
+  test("create: age に set はエラーになりセルにオブジェクトが書かれない", () => {
+    const env = buildEnv();
+    const before = env.users.snapshot();
+    const loose: any = sheetOf(env.client, "Users");
+    const fn = () =>
+      loose.create({ data: { id: 8, name: "S", age: { set: 5 } } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Invalid value for argument `age`.");
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("create: age に increment はエラーになり行が追加されない", () => {
+    const env = buildEnv();
+    const before = env.users.snapshot();
+    const loose: any = sheetOf(env.client, "Users");
+    expect(() =>
+      loose.create({ data: { id: 7, name: "I", age: { increment: 1 } } }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("createMany: 2行目の dict 値もエラーになり1行も追加されない", () => {
+    const env = buildEnv();
+    const before = env.users.snapshot();
+    const loose: any = sheetOf(env.client, "Users");
+    expect(() =>
+      loose.createMany({
+        data: [
+          { id: 8, name: "S", age: 1 },
+          { id: 9, name: "T", age: { set: 5 } },
+        ],
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("createManyAndReturn: dict 値はエラーになり追加されない", () => {
+    const env = buildEnv();
+    const before = env.users.snapshot();
+    const loose: any = sheetOf(env.client, "Users");
+    expect(() =>
+      loose.createManyAndReturn({
+        data: [{ id: 8, name: "S", age: { increment: 1 } }],
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("upsert(作成分岐): create 側の dict 値はエラーになり追加されない", () => {
+    const env = buildEnv();
+    const before = env.users.snapshot();
+    const loose: any = sheetOf(env.client, "Users");
+    expect(() =>
+      loose.upsert({
+        where: { id: 99 },
+        create: { id: 99, name: "Z", age: { set: 5 } },
+        update: { name: "Z" },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("Date 値は従来どおり書き込める", () => {
+    const env = buildEnv();
+    const typed = sheetOf(env.client, "Users");
+    const birthday = new Date(2024, 0, 1);
+    const loose: any = typed;
+    expect(() =>
+      loose.create({ data: { id: 8, name: birthday, age: 1 } }),
+    ).not.toThrow();
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("Gassma.raw は従来どおり書き込める", () => {
+    const env = buildEnv();
+    const typed = sheetOf(env.client, "Users");
+    const loose: any = typed;
+    expect(() =>
+      loose.create({ data: { id: 8, name: raw("=1+1"), age: 1 } }),
+    ).not.toThrow();
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("配列値は従来どおり素通しされる", () => {
+    const env = buildEnv();
+    const typed = sheetOf(env.client, "Users");
+    const loose: any = typed;
+    expect(() =>
+      loose.create({ data: { id: 8, name: "A", age: [1, 2] } }),
+    ).not.toThrow();
+    expect(typed.count({})).toBe(3);
+  });
+});
+
+describe("nested create と typo の併用で部分書き込みしない", () => {
+  test("create: 親の typo は関連レコード作成より先にエラーになる", () => {
+    const env = buildEnv({ relations: true });
+    const postsBefore = env.posts.snapshot();
+    const commentsBefore = env.comments.snapshot();
+    const loose: any = sheetOf(env.client, "Comments");
+    expect(() =>
+      loose.create({
+        data: {
+          id: 2000,
+          bdy: "X",
+          post: { create: { id: 300, title: "New" } },
+        },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.posts.snapshot()).toEqual(postsBefore);
+    expect(env.comments.snapshot()).toEqual(commentsBefore);
+  });
+
+  test("create: connectOrCreate 併用でも typo で関連側が作られない", () => {
+    const env = buildEnv({ relations: true });
+    const postsBefore = env.posts.snapshot();
+    const loose: any = sheetOf(env.client, "Comments");
+    expect(() =>
+      loose.create({
+        data: {
+          id: 2000,
+          bdy: "X",
+          post: {
+            connectOrCreate: {
+              where: { id: 999 },
+              create: { id: 300, title: "New" },
+            },
+          },
+        },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.posts.snapshot()).toEqual(postsBefore);
+  });
+
+  test("upsert(作成分岐): typo で関連側が作られない", () => {
+    const env = buildEnv({ relations: true });
+    const postsBefore = env.posts.snapshot();
+    const commentsBefore = env.comments.snapshot();
+    const loose: any = sheetOf(env.client, "Comments");
+    expect(() =>
+      loose.upsert({
+        where: { id: 9999 },
+        create: {
+          id: 2000,
+          bdy: "X",
+          post: { create: { id: 300, title: "New" } },
+        },
+        update: { body: "Y" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.posts.snapshot()).toEqual(postsBefore);
+    expect(env.comments.snapshot()).toEqual(commentsBefore);
+  });
+
+  test("正常な nested create(manyToOne の create)は従来どおり通る", () => {
+    const env = buildEnv({ relations: true });
+    const comments = sheetOf(env.client, "Comments");
+    const posts = sheetOf(env.client, "Posts");
+    const loose: any = comments;
+    const result = loose.create({
+      data: {
+        id: 2000,
+        body: "ok",
+        post: { create: { id: 300, title: "New" } },
+      },
+    });
+    expect(result).toEqual({ id: 2000, postId: 300, body: "ok" });
+    expect(posts.findFirst({ where: { id: 300 } })).toEqual({
+      id: 300,
+      authorId: null,
+      title: "New",
+    });
+  });
+});
+
+describe("@ignore 列への書き込みは create でもエラー", () => {
+  test("create: @ignore 列はエラーになり黙って無視されない", () => {
+    const env = buildEnv({ ignore: { Users: "age" } });
+    const before = env.users.snapshot();
+    const loose: any = sheetOf(env.client, "Users");
+    const fn = () => loose.create({ data: { id: 8, name: "Z", age: 1 } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Available: id, name");
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("createMany: @ignore 列はエラーになり1行も追加されない", () => {
+    const env = buildEnv({ ignore: { Users: "age" } });
+    const before = env.users.snapshot();
+    const loose: any = sheetOf(env.client, "Users");
+    expect(() =>
+      loose.createMany({
+        data: [
+          { id: 8, name: "Y" },
+          { id: 9, name: "Z", age: 1 },
+        ],
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("createManyAndReturn: @ignore 列はエラーになり追加されない", () => {
+    const env = buildEnv({ ignore: { Users: "age" } });
+    const before = env.users.snapshot();
+    const loose: any = sheetOf(env.client, "Users");
+    expect(() =>
+      loose.createManyAndReturn({ data: [{ id: 8, name: "Z", age: 1 }] }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("upsert(作成分岐): create 側の @ignore 列はエラー", () => {
+    const env = buildEnv({ ignore: { Users: "age" } });
+    const before = env.users.snapshot();
+    const loose: any = sheetOf(env.client, "Users");
+    expect(() =>
+      loose.upsert({
+        where: { id: 99 },
+        create: { id: 99, name: "Z", age: 1 },
+        update: { name: "Z" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("upsert(更新分岐): update 側の @ignore 列はエラー", () => {
+    const env = buildEnv({ ignore: { Users: "age" } });
+    const before = env.users.snapshot();
+    const loose: any = sheetOf(env.client, "Users");
+    expect(() =>
+      loose.upsert({
+        where: { id: 1 },
+        create: { id: 1, name: "Alice" },
+        update: { age: 99 },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.users.snapshot()).toEqual(before);
+  });
+
+  test("@ignore 列を含まない create は従来どおり通る", () => {
+    const env = buildEnv({ ignore: { Users: "age" } });
+    const typed = sheetOf(env.client, "Users");
+    const result = typed.create({ data: { id: 8, name: "Z" } });
+    expect(result).toEqual({ id: 8, name: "Z" });
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("nested create の子データの @ignore 列もエラーになり両シート無変化", () => {
+    const env = buildEnv({ relations: true, ignore: { Posts: "title" } });
+    const postsBefore = env.posts.snapshot();
+    const commentsBefore = env.comments.snapshot();
+    const loose: any = sheetOf(env.client, "Comments");
+    expect(() =>
+      loose.create({
+        data: {
+          id: 2000,
+          body: "x",
+          post: { create: { id: 300, title: "T" } },
+        },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(env.posts.snapshot()).toEqual(postsBefore);
+    expect(env.comments.snapshot()).toEqual(commentsBefore);
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -233,6 +233,16 @@ class GassmaController {
     return applyDefaults(data, this.defaults);
   }
 
+  private prepareCreateData(
+    data: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return this.stripIgnored(
+      this.applyUpdatedAtToData(
+        this.applyDefaultsToData(this.applyAutoincrementToData(data)),
+      ),
+    );
+  }
+
   private applyAutoincrementToData(
     data: Record<string, unknown>,
   ): Record<string, unknown> {
@@ -379,7 +389,9 @@ class GassmaController {
     validateCreateDataOperations(createdData.data, this.relationNames());
     return createManyFunc(
       this.getGassmaControllerUtil(),
-      this.applyCreateManyPreprocess(createdData),
+      createdData,
+      false,
+      (data) => this.applyCreateManyPreprocess(data),
     );
   }
 
@@ -405,8 +417,9 @@ class GassmaController {
 
     const results = createManyFunc(
       this.getGassmaControllerUtil(),
-      this.applyCreateManyPreprocess(createdData),
+      createdData,
       true,
+      (data) => this.applyCreateManyPreprocess(data),
     );
     if (!Array.isArray(results)) return results;
 
@@ -451,19 +464,17 @@ class GassmaController {
     }
 
     const util = this.getGassmaControllerUtil();
-    const processed = this.stripIgnored(
-      this.applyUpdatedAtToData(
-        this.applyDefaultsToData(
-          this.applyAutoincrementToData(createdData.data),
-        ),
-      ),
-    );
-    const wrappedCreate = (data: Record<string, unknown>) =>
-      createFunc(util, { data: data as AnyUse });
+    const wrappedCreate = (data: Record<string, unknown>, titles?: string[]) =>
+      createFunc(util, { data: data as AnyUse }, titles);
     const result = resolveNestedCreate(
-      processed,
+      createdData.data,
       wrappedCreate,
       this.relationContext ?? undefined,
+      {
+        getTitles: () => getTitle(util),
+        validation: util.whereValidation,
+        prepare: (data) => this.prepareCreateData(data),
+      },
     );
 
     const mapped = this.stripIgnored(result);
@@ -1050,12 +1061,7 @@ class GassmaController {
       upsertData.omit,
     );
 
-    const createWithDefaults = this.stripIgnored(
-      this.applyUpdatedAtToData(this.applyDefaultsToData(upsertData.create)),
-    );
-    const updateWithTimestamp = this.stripIgnored(
-      this.applyUpdatedAtToData(upsertData.update),
-    );
+    const updateWithTimestamp = this.applyUpdatedAtToData(upsertData.update);
     const upsertOmitWithIgnore = this.mergeIgnoreIntoOmit(upsertOmit);
 
     return upsertFunc(
@@ -1063,12 +1069,11 @@ class GassmaController {
       {
         ...upsertData,
         where: resolvedWhere,
-        create: createWithDefaults as AnyUse,
         update: updateWithTimestamp as AnyUse,
         omit: upsertOmitWithIgnore,
       },
       this.relationContext,
-      (data) => this.applyAutoincrementToData(data),
+      (data) => this.prepareCreateData(data),
     );
   }
 

--- a/src/util/create/create.ts
+++ b/src/util/create/create.ts
@@ -10,11 +10,12 @@ import { resolveWriter } from "../write/sheetWriter";
 const createFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
   createdData: CreateData,
+  precomputedTitles?: string[],
 ) => {
   const { sheet, startColumnNumber, endColumnNumber } = gassmaControllerUtil;
 
   const data = createdData.data;
-  const titles = getTitle(gassmaControllerUtil);
+  const titles = precomputedTitles ?? getTitle(gassmaControllerUtil);
 
   if (gassmaControllerUtil.whereValidation) {
     validateDataColumns(

--- a/src/util/create/createManyFunc.ts
+++ b/src/util/create/createManyFunc.ts
@@ -7,25 +7,29 @@ import { unwrapRawCell } from "../raw/raw";
 import { validateDataColumns } from "../validate/validateDataColumns";
 import { resolveWriter } from "../write/sheetWriter";
 
+type PrepareCreateManyData = (data: CreateManyData) => CreateManyData;
+
 function createManyFunc(
   gassmaControllerUtil: GassmaControllerUtil,
   createManyData: CreateManyData,
   withReturn: true,
+  prepareData?: PrepareCreateManyData,
 ): Record<string, unknown>[];
 function createManyFunc(
   gassmaControllerUtil: GassmaControllerUtil,
   createManyData: CreateManyData,
   withReturn?: false,
+  prepareData?: PrepareCreateManyData,
 ): CreateManyReturn;
 function createManyFunc(
   gassmaControllerUtil: GassmaControllerUtil,
   createManyData: CreateManyData,
   withReturn?: boolean,
+  prepareData?: PrepareCreateManyData,
 ): Record<string, unknown>[] | CreateManyReturn {
   const { sheet, startColumnNumber, endColumnNumber } = gassmaControllerUtil;
 
-  const data = createManyData.data;
-  if (data.length === 0) {
+  if (createManyData.data.length === 0) {
     return withReturn ? [] : { count: 0 };
   }
 
@@ -33,10 +37,13 @@ function createManyFunc(
 
   const validation = gassmaControllerUtil.whereValidation;
   if (validation) {
-    data.forEach((row) => {
+    createManyData.data.forEach((row) => {
       validateDataColumns(row, titles, validation, "createMany");
     });
   }
+
+  const data = (prepareData ? prepareData(createManyData) : createManyData)
+    .data;
 
   const newData = data.map((row) => {
     const wantCreateIndex = getWantUpdateIndexFromTitles(titles, row);

--- a/src/util/create/nestedWrite/resolveNestedCreate.ts
+++ b/src/util/create/nestedWrite/resolveNestedCreate.ts
@@ -1,5 +1,7 @@
 import type { RelationContext } from "../../../types/relationTypes";
+import type { WhereValidation } from "../../../types/gassmaControllerUtilType";
 import { NestedWriteWithoutRelationsError } from "../../../errors/relation/nestedWriteError";
+import { validateDataColumns } from "../../validate/validateDataColumns";
 import {
   extractRelationData,
   isNestedWriteOperation,
@@ -8,6 +10,17 @@ import { processBeforeCreate } from "./processBeforeCreate";
 import { processAfterCreate } from "./processAfterCreate";
 import { processOneToOne } from "./processOneToOne";
 import { processManyToMany } from "./processManyToMany";
+
+type CreateExecutor = (
+  data: Record<string, unknown>,
+  titles?: string[],
+) => Record<string, unknown>;
+
+type NestedCreateDeps = {
+  getTitles: () => string[];
+  validation?: WhereValidation;
+  prepare?: (data: Record<string, unknown>) => Record<string, unknown>;
+};
 
 const hasNestedWriteFields = (
   data: Record<string, unknown>,
@@ -22,34 +35,49 @@ const hasNestedWriteFields = (
 
 const resolveNestedCreate = (
   data: Record<string, unknown>,
-  createFunc: (scalarData: Record<string, unknown>) => Record<string, unknown>,
+  createFunc: CreateExecutor,
   relationContext: RelationContext | undefined,
+  deps?: NestedCreateDeps,
 ): Record<string, unknown> => {
-  if (!hasNestedWriteFields(data, relationContext)) {
+  const titles = deps ? deps.getTitles() : undefined;
+  const validate = (target: Record<string, unknown>) => {
+    if (!deps?.validation || !titles) return;
+    validateDataColumns(target, titles, deps.validation, "create");
+  };
+  const prepare = (target: Record<string, unknown>) =>
+    deps?.prepare ? deps.prepare(target) : target;
+  const exec = (target: Record<string, unknown>) =>
+    titles === undefined ? createFunc(target) : createFunc(target, titles);
+
+  if (!relationContext || !hasNestedWriteFields(data, relationContext)) {
     if (!relationContext && Object.values(data).some(isNestedWriteOperation)) {
       throw new NestedWriteWithoutRelationsError();
     }
-    return createFunc(data);
+    validate(data);
+    return exec(prepare(data));
   }
 
   const { scalarData, relationOps } = extractRelationData(
     data,
-    relationContext!.relations,
+    relationContext.relations,
   );
+
+  validate(scalarData);
 
   const enrichedData = processBeforeCreate(
-    scalarData,
+    prepare(scalarData),
     relationOps,
-    relationContext!,
+    relationContext,
   );
 
-  const createdRecord = createFunc(enrichedData);
+  const createdRecord = exec(enrichedData);
 
-  processAfterCreate(createdRecord, relationOps, relationContext!);
-  processOneToOne(createdRecord, relationOps, relationContext!);
-  processManyToMany(createdRecord, relationOps, relationContext!);
+  processAfterCreate(createdRecord, relationOps, relationContext);
+  processOneToOne(createdRecord, relationOps, relationContext);
+  processManyToMany(createdRecord, relationOps, relationContext);
 
   return createdRecord;
 };
 
 export { resolveNestedCreate };
+export type { NestedCreateDeps };

--- a/src/util/upsert/upsert.ts
+++ b/src/util/upsert/upsert.ts
@@ -2,6 +2,7 @@ import type { AnyUse } from "../../types/coreTypes";
 import type { UpsertSingleData } from "../../types/findTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import type { RelationContext } from "../../types/relationTypes";
+import { getTitle } from "../core/getTitle";
 import { createFunc } from "../create/create";
 import { resolveNestedCreate } from "../create/nestedWrite/resolveNestedCreate";
 import { findFirstFunc } from "../find/findFirst";
@@ -44,15 +45,17 @@ const upsertFunc = (
   });
 
   if (!record) {
-    const wrappedCreate = (data: Record<string, unknown>) =>
-      createFunc(gassmaControllerUtil, { data: data as AnyUse });
-    const createData = prepareCreate
-      ? prepareCreate(upsertData.create)
-      : upsertData.create;
+    const wrappedCreate = (data: Record<string, unknown>, titles?: string[]) =>
+      createFunc(gassmaControllerUtil, { data: data as AnyUse }, titles);
     const created = resolveNestedCreate(
-      createData,
+      upsertData.create,
       wrappedCreate,
       relationContext ?? undefined,
+      {
+        getTitles: () => getTitle(gassmaControllerUtil),
+        validation: gassmaControllerUtil.whereValidation,
+        ...(prepareCreate ? { prepare: prepareCreate } : {}),
+      },
     );
     return applyOptions(created, upsertData, relationContext);
   }

--- a/src/util/validate/validateDataColumns.ts
+++ b/src/util/validate/validateDataColumns.ts
@@ -23,11 +23,14 @@ const isPlainObjectValue = (value: unknown): value is Record<string, unknown> =>
   isDict(value) && !isDateValue(value) && !isRawValue(value);
 
 const validateColumnOperations = (
+  key: string,
   value: unknown,
   mode: DataColumnMode,
 ): void => {
-  if (mode !== "update" && mode !== "updateMany") return;
   if (!isPlainObjectValue(value)) return;
+  if (mode === "create" || mode === "createMany") {
+    throw new GassmaInvalidValueError(key, "a scalar value");
+  }
   Object.keys(value).forEach((operationKey) => {
     if (!NUMBER_OPERATION_KEYS.includes(operationKey)) {
       throw new GassmaUnknownArgumentError(operationKey, NUMBER_OPERATION_KEYS);
@@ -50,7 +53,7 @@ const validateDataColumns = (
   Object.entries(data).forEach(([key, value]) => {
     if (value === undefined) return;
     if (allowed.has(key)) {
-      validateColumnOperations(value, mode);
+      validateColumnOperations(key, value, mode);
       return;
     }
     if (


### PR DESCRIPTION
#199 のレビューで挙げた3点への対応です。**うち1つはデータ破壊が残っていました。**

## 1. `create` の dict 値がセルに書かれる(**データ破壊**)

#199 で update 系は塞ぎましたが、**create 側は素通り**でした。実測です。

```js
create({ data: { id: 8, name: "S", age: { set: 5 } } })
// → 通ってしまう。追加された行: [8,"S",{"set":5}]   age セルの typeof=object

create({ data: { id: 7, name: "I", age: { increment: 1 } } })
// → 追加された行: [7,"I",{"increment":1}]
```

`increment` は create に増やす対象が無いので無意味ですが、それもそのまま書かれていました。

**create には数値演算を適用する対象が存在しない**ので、列名キーに素の dict 値が来たらすべてエラーにします。Date と `Gassma.raw` は従来どおり素通しです(#194 / #199 と同じ realm 安全な判定を再利用)。

```
Invalid value for argument `age`. Expected a scalar value.
```

## 2. nested create + typo の部分書き込み

```js
posts.create({ data: { id: 2, titel: "B", tags: { create: [{ name: "n1" }] } } })
// 修正前: Tags に n1 が作られた後でエラー。中途半端な状態が残る
```

**Prisma は nested write をトランザクションで包み、検証もクエリ送信前に走るので何も書かれません。**

検証を**ユーザー入力そのものに対して、全副作用より前**に実行する形に統一しました。副作用とは autoincrement カウンタ・`defaults`・`@ignore` の strip・before フェーズの関連作成・行の書き込みです。

`createMany` / `createManyAndReturn` / `upsert` の create 枝も同じ防御に揃えました。`createMany` は**従来 autoincrement カウンタが検証前に進んでいた**のも解消しています。

## 3. `@ignore` 列の非対称を解消

controller の `stripIgnored` が検証より前に走っていたため、update はエラーなのに create は黙って無視していました。**strip を検証より後に移動**して揃えています。

対象は create / createMany / createManyAndReturn / **`upsert` の create 枝と update 枝の両方** / nested create の子データです。

## `getTitle` は増えていません

titles を1回だけ読んで `createFunc` に引き渡す形にしました。**`titleRowReadTrips` が無修正で通過**していることが証拠です(「create 1件 = 見出し読み1回」「createMany 10件 = 1回」を固定している契約テスト)。

## 検証結果

- `npm test`: **2,430件 全 green**(2,411 → +19、**既存テストの変更0件**)
- **往復契約テスト**: `titleRowReadTrips` 5/5 / `perCallReadCache` 15/15 / `manyToManyWriteRoundTrips` 6/6
- `tsc --noEmit` / format / `verify:bundle`(公開シンボル57件)pass
- lint 警告は **52 → 47 に5件減**(旧コードの `!` を除去したため)

新規テスト19本を**修正前のコードで実行して14本が失敗**することを確認しています(= 3つの穴の再現)。残り5本(Date / `Gassma.raw` / 配列 / 正常系2本)は修正前から通るもので、素通しすべき挙動の固定です。

## 残っている穴(報告)

**1. after フェーズ(oneToMany 等)の子データ typo では、親が既に書かれて残ります。**

子側では正しくエラーになり子は1行も書かれませんが、親は残ります。塞ぐには**子シートの見出しを事前に読む**(往復が増えて契約テストに違反)か**全体のトランザクション化**が必要なため、スコープ外としました。`$transaction` で包めば rollback できます。

before フェーズ(manyToOne)の子は、子 controller の入口検証が親の書き込みより先に走るので**両シートとも無変化**です(テストで固定)。

**2. 調査中に update 側の既存の穴を発見しました。**

`update` でリレーションが定義されていると **`resolveOnUpdate`(カスケード)が検証より前に走る**ため、「参照キーの変更 + typo」を同時に渡すと**カスケードだけ先に書かれ得ます**。#199 のスコープ(update 側)なので本 PR では未着手です。**別途対応するか判断をお願いします。**

## 判断が要る点

エラーメッセージを「Expected a scalar value」としました。Prisma は `Expected Int, provided Object.` と型名を出しますが、**gassma は列の型情報を持たない**ため出せません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)