### PR TITLE
feat: count の select と updateManyAndReturn の select/omit/include を実装する

### DIFF
--- a/src/__test__/util/count/countSelect.test.ts
+++ b/src/__test__/util/count/countSelect.test.ts
@@ -1,0 +1,201 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../../errors/argument/argumentError";
+import { countFunc } from "../../../util/count/count";
+import {
+  getExtendedMockControllerUtil,
+  getNullableMockControllerUtil,
+} from "../../consts/mockControllerUtil";
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "../extends/extendsTestClient";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "../transaction/transactionTestClient";
+
+afterEach(() => {
+  clearSpreadsheetApp();
+  clearGasGlobals();
+});
+
+describe("countFunc の select", () => {
+  test("_all: true は全行数をオブジェクトで返す", () => {
+    const result = countFunc(getExtendedMockControllerUtil(), {
+      select: { _all: true },
+    });
+    expect(result).toEqual({ _all: 8 });
+  });
+
+  test("nullable 列は null 行を除外して数える", () => {
+    const result = countFunc(getNullableMockControllerUtil(), {
+      select: { メモ: true },
+    });
+    expect(result).toEqual({ メモ: 2 });
+  });
+
+  test("全行 null の列は 0", () => {
+    const result = countFunc(getNullableMockControllerUtil(), {
+      select: { 備考: true },
+    });
+    expect(result).toEqual({ 備考: 0 });
+  });
+
+  test("非 null 列は全行数になる", () => {
+    const result = countFunc(getNullableMockControllerUtil(), {
+      select: { カテゴリ: true },
+    });
+    expect(result).toEqual({ カテゴリ: 3 });
+  });
+
+  test("_all と列名の混在は各キーが独立に数えられる", () => {
+    const result = countFunc(getNullableMockControllerUtil(), {
+      select: { _all: true, メモ: true },
+    });
+    expect(result).toEqual({ _all: 3, メモ: 2 });
+  });
+
+  test("where と併用できる", () => {
+    const result = countFunc(getExtendedMockControllerUtil(), {
+      where: { 住所: "Tokyo" },
+      select: { _all: true },
+    });
+    expect(result).toEqual({ _all: 4 });
+  });
+
+  test("select: true は素の数値を返す", () => {
+    expect(countFunc(getExtendedMockControllerUtil(), { select: true })).toBe(
+      8,
+    );
+  });
+
+  test("select なしは従来どおり素の数値", () => {
+    expect(countFunc(getExtendedMockControllerUtil(), {})).toBe(8);
+  });
+
+  test("false のキーは結果から除外される", () => {
+    const result = countFunc(getNullableMockControllerUtil(), {
+      select: { メモ: false, カテゴリ: true },
+    });
+    expect(result).toEqual({ カテゴリ: 3 });
+  });
+
+  test("falsy のみはエラー(truthy が1つ必要)", () => {
+    const fn = () =>
+      countFunc(getNullableMockControllerUtil(), {
+        select: { メモ: false },
+      });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Expected at least one truthy value");
+  });
+
+  test("空オブジェクトはエラー", () => {
+    const fn = () => countFunc(getNullableMockControllerUtil(), { select: {} });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Expected a non-empty object");
+  });
+
+  test("_al (typo) は偽のゼロを返さずエラーになりサジェストが出る", () => {
+    const fn = () =>
+      countFunc(getExtendedMockControllerUtil(), {
+        select: { _al: true },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `_al`. Did you mean `_all`?");
+  });
+
+  test("存在しない列はエラー", () => {
+    const fn = () =>
+      countFunc(getExtendedMockControllerUtil(), {
+        select: { 存在しない列: true },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("_count は select 内では使えない(Prisma と同じ)", () => {
+    const fn = () =>
+      countFunc(getExtendedMockControllerUtil(), {
+        select: { _count: true },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `_count`.");
+  });
+
+  test("false のキーでも未知キーはエラー", () => {
+    const fn = () =>
+      countFunc(getExtendedMockControllerUtil(), {
+        select: { _al: false, _all: true },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("ignore された列は select できない", () => {
+    const util = {
+      ...getNullableMockControllerUtil(),
+      whereValidation: { ignoredFields: ["メモ"], relationNames: [] },
+    };
+    const fn = () => countFunc(util, { select: { メモ: true } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+});
+
+describe("GassmaController 経由の count select", () => {
+  test("select: { _all: true } がオブジェクトを返す", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    expect(users.count({ select: { _all: true } })).toEqual({ _all: 3 });
+  });
+
+  test("select: { 列名: true } が非 null 件数を返す", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    expect(users.count({ select: { name: true } })).toEqual({ name: 3 });
+  });
+
+  test("where と併用できる", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    expect(
+      users.count({ where: { age: { gte: 30 } }, select: { _all: true } }),
+    ).toEqual({ _all: 2 });
+  });
+
+  test("引数なしの count() は従来どおり数値", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    expect(users.count()).toBe(3);
+    expect(users.count({})).toBe(3);
+  });
+
+  test("typo キーは偽のゼロでなくエラー", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    const loose: any = users;
+    const fn = () => loose.count({ select: { nmae: true } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `nmae`. Did you mean `name`?");
+  });
+
+  test("$transaction 経由でも select が効く", () => {
+    const env = buildTxTestEnv();
+    const tx = (env.client as any).$transaction.bind(env.client);
+    const result = tx((txClient: any) =>
+      txClient.Users.count({ select: { _all: true, name: true } }),
+    );
+    expect(result).toEqual({ _all: 2, name: 2 });
+  });
+
+  test("$extends の query フック経由でも select が効く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      query: {
+        Users: {
+          count({ args, query }) {
+            return query(args);
+          },
+        },
+      },
+    });
+    expect(extended.Users.count({ select: { _all: true } })).toEqual({
+      _all: 3,
+    });
+  });
+});

--- a/src/__test__/util/unknownArguments.test.ts
+++ b/src/__test__/util/unknownArguments.test.ts
@@ -77,15 +77,6 @@ describe("各操作の未知のトップレベルキー", () => {
     expectUnknown(() => loose.count({ wheer: { id: 1 } }), "wheer");
   });
 
-  test("count: select は許可されない", () => {
-    const { loose } = looseUsers();
-    const fn = () => loose.count({ select: { _all: true } });
-    expect(fn).toThrow(GassmaUnknownArgumentError);
-    expect(fn).toThrow(
-      "Unknown argument `select`.\n\nAvailable: where, orderBy, take, skip, cursor",
-    );
-  });
-
   test("count: omit は許可されない", () => {
     const { loose } = looseUsers();
     expectUnknown(() => loose.count({ omit: { name: true } }), "omit");

--- a/src/__test__/util/update/updateManyAndReturnSelect.test.ts
+++ b/src/__test__/util/update/updateManyAndReturnSelect.test.ts
@@ -1,0 +1,171 @@
+import { GassmaFindSelectOmitConflictError } from "../../../errors/find/findError";
+import { GassmaIncludeSelectConflictError } from "../../../errors/relation/relationError";
+import { IncludeWithoutRelationsError } from "../../../errors/relation/relationValidationError";
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "../extends/extendsTestClient";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "../transaction/transactionTestClient";
+
+afterEach(() => {
+  clearSpreadsheetApp();
+  clearGasGlobals();
+});
+
+describe("updateManyAndReturn の select / omit / include", () => {
+  test("select は指定列だけを返す", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    const result = users.updateManyAndReturn({
+      where: {},
+      data: { age: 99 },
+      select: { id: true, name: true },
+    });
+    expect(result).toEqual([
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
+      { id: 3, name: "Carol" },
+    ]);
+  });
+
+  test("select を使ってもシートは更新される", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    users.updateManyAndReturn({
+      where: { id: 1 },
+      data: { age: 99 },
+      select: { id: true },
+    });
+    expect(users.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 99,
+    });
+  });
+
+  test("omit は指定列を除いて返す", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    const result = users.updateManyAndReturn({
+      where: {},
+      data: { name: "X" },
+      omit: { age: true },
+    });
+    expect(result).toEqual([
+      { id: 1, name: "X" },
+      { id: 2, name: "X" },
+      { id: 3, name: "X" },
+    ]);
+  });
+
+  test("include はリレーション先を付けて返す", () => {
+    const posts = sheetOf(buildTestClient({ relations: true }), "Posts");
+    const result = posts.updateManyAndReturn({
+      where: { id: 101 },
+      data: { title: "Edited" },
+      include: { author: true },
+    });
+    expect(result).toEqual([
+      {
+        id: 101,
+        authorId: 1,
+        title: "Edited",
+        author: { id: 1, name: "Alice", age: 20 },
+      },
+    ]);
+  });
+
+  test("include と omit は併用できる", () => {
+    const posts = sheetOf(buildTestClient({ relations: true }), "Posts");
+    const result = posts.updateManyAndReturn({
+      where: { id: 101 },
+      data: { title: "Edited" },
+      include: { author: true },
+      omit: { title: true },
+    });
+    expect(result).toEqual([
+      {
+        id: 101,
+        authorId: 1,
+        author: { id: 1, name: "Alice", age: 20 },
+      },
+    ]);
+  });
+
+  test("include と select の同時指定はエラー", () => {
+    const posts = sheetOf(buildTestClient({ relations: true }), "Posts");
+    expect(() =>
+      posts.updateManyAndReturn({
+        where: {},
+        data: { title: "X" },
+        include: { author: true },
+        select: { id: true },
+      }),
+    ).toThrow(GassmaIncludeSelectConflictError);
+  });
+
+  test("select と omit の同時指定はエラー", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    expect(() =>
+      users.updateManyAndReturn({
+        where: {},
+        data: { age: 1 },
+        select: { id: true },
+        omit: { name: true },
+      }),
+    ).toThrow(GassmaFindSelectOmitConflictError);
+  });
+
+  test("リレーション未設定のクライアントで include はエラー", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    expect(() =>
+      users.updateManyAndReturn({
+        where: {},
+        data: { age: 1 },
+        include: { posts: true },
+      }),
+    ).toThrow(IncludeWithoutRelationsError);
+  });
+
+  test("select 等を渡さない従来の形は全列を返す", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    const result = users.updateManyAndReturn({
+      where: { id: 1 },
+      data: { age: 21 },
+    });
+    expect(result).toEqual([{ id: 1, name: "Alice", age: 21 }]);
+  });
+
+  test("$transaction 経由でも select が効く", () => {
+    const env = buildTxTestEnv();
+    const tx = (env.client as any).$transaction.bind(env.client);
+    const result = tx((txClient: any) =>
+      txClient.Users.updateManyAndReturn({
+        where: {},
+        data: { age: 0 },
+        select: { name: true },
+      }),
+    );
+    expect(result).toEqual([{ name: "Alice" }, { name: "Bob" }]);
+  });
+
+  test("$extends の query フック経由でも omit が効く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      query: {
+        Users: {
+          updateManyAndReturn({ args, query }) {
+            return query(args);
+          },
+        },
+      },
+    });
+    const result = extended.Users.updateManyAndReturn({
+      where: { id: 1 },
+      data: { age: 21 },
+      omit: { age: true },
+    });
+    expect(result).toEqual([{ id: 1, name: "Alice" }]);
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -25,6 +25,7 @@ import type {
   FindData,
   FindFirstData,
   UpdateData,
+  UpdateManyAndReturnData,
   UpdateSingleData,
   UpsertSingleData,
 } from "./types/findTypes";
@@ -980,16 +981,25 @@ class GassmaController {
     return updateManyFunc(this.getGassmaControllerUtil(), updateData);
   }
 
-  public updateManyAndReturn(updateData: UpdateData) {
+  public updateManyAndReturn(updateData: UpdateManyAndReturnData) {
     return runWithoutReadCache(() => this.updateManyAndReturnRaw(updateData));
   }
 
-  private updateManyAndReturnRaw(updateData: UpdateData) {
+  private updateManyAndReturnRaw(updateData: UpdateManyAndReturnData) {
     updateData = this.normalizeInput(updateData, "updateManyAndReturn");
     if (updateData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
     validateUpdateDataOperations(updateData.data, this.relationNames());
+    if (updateData.include && updateData.select) {
+      throw new GassmaIncludeSelectConflictError();
+    }
+    if (updateData.include && !this.relationContext) {
+      throw new IncludeWithoutRelationsError();
+    }
+    if (updateData.select && updateData.omit) {
+      throw new GassmaFindSelectOmitConflictError();
+    }
     updateData = {
       ...updateData,
       where: this.resolveWhere(updateData.where),
@@ -1021,10 +1031,24 @@ class GassmaController {
       true,
     );
     if (!Array.isArray(results)) return results;
-    return results.map((r) => {
-      const stripped = this.stripIgnored(r);
-      return this.applyOmitToResult(stripped, this.globalOmit);
-    });
+    const stripped = results.map((r) => this.stripIgnored(r));
+
+    if (updateData.include && this.relationContext) {
+      const resolved = resolveInclude(
+        stripped,
+        updateData.include,
+        this.relationContext,
+      );
+      const includeOmit = this.resolveEffectiveOmit(null, updateData.omit);
+      return resolved.map((r) => this.applyOmitToResult(r, includeOmit));
+    }
+
+    if (updateData.select) {
+      return stripped.map((r) => findedDataSelect(updateData.select!, r));
+    }
+
+    const effectiveOmit = this.resolveEffectiveOmit(null, updateData.omit);
+    return stripped.map((r) => this.applyOmitToResult(r, effectiveOmit));
   }
 
   public upsert(upsertData: UpsertSingleData) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -109,12 +109,20 @@ declare namespace Gassma {
     findMany(findData?: FindData): Record<string, any>[];
     update(updateData: UpdateSingleData): Record<string, unknown> | null;
     updateMany(updateData: UpdateData): UpdateManyReturn;
-    updateManyAndReturn(updateData: UpdateData): Record<string, unknown>[];
+    updateManyAndReturn(
+      updateData: UpdateManyAndReturnData,
+    ): Record<string, unknown>[];
     upsert(upsertData: UpsertSingleData): Record<string, unknown>;
     delete(deleteData: DeleteSingleData): Record<string, unknown> | null;
     deleteMany(deleteData?: DeleteData): DeleteManyReturn;
     aggregate(aggregateData: AggregateData): Record<string, any>;
-    count(countData?: CountData): number;
+    count<T extends CountData>(
+      countData?: T,
+    ): T extends { select: infer S }
+      ? S extends true
+        ? number
+        : { [K in keyof S]: number }
+      : number;
     groupBy(groupByData: GroupByData): Record<string, any>[];
     _setRelationContext(context: RelationContext): void;
     _setGlobalOmit(omit: Omit): void;
@@ -460,6 +468,15 @@ declare namespace Gassma {
     limit?: number | SkipValue;
   };
 
+  type UpdateManyAndReturnData = {
+    where?: WhereUse | SkipValue;
+    data: UpdateAnyUse;
+    limit?: number | SkipValue;
+    select?: Select | SkipValue;
+    omit?: Record<string, boolean> | SkipValue;
+    include?: IncludeData | SkipValue;
+  };
+
   type AggregateData = {
     where?: WhereUse | SkipValue;
     orderBy?: OrderBy | OrderBy[] | SkipValue;
@@ -473,12 +490,17 @@ declare namespace Gassma {
     _sum?: Select | SkipValue;
   };
 
+  type CountAggregateSelect = {
+    [key: string]: true | SkipValue;
+  };
+
   type CountData = {
     where?: WhereUse | SkipValue;
     orderBy?: OrderBy | OrderBy[] | SkipValue;
     take?: number | SkipValue;
     skip?: number | SkipValue;
     cursor?: Record<string, unknown> | SkipValue;
+    select?: CountAggregateSelect | true | SkipValue;
   };
 
   type NumberFilterConditions = {

--- a/src/types/countType.ts
+++ b/src/types/countType.ts
@@ -1,11 +1,16 @@
 import type { OrderBy, WhereUse } from "./coreTypes";
 
+type CountAggregateSelect = {
+  [key: string]: boolean;
+};
+
 type CountData = {
   where?: WhereUse;
   orderBy?: OrderBy | OrderBy[];
   take?: number;
   skip?: number;
   cursor?: Record<string, unknown>;
+  select?: CountAggregateSelect | true;
 };
 
-export type { CountData };
+export type { CountData, CountAggregateSelect };

--- a/src/types/findTypes.ts
+++ b/src/types/findTypes.ts
@@ -55,6 +55,15 @@ type UpdateData = {
   limit?: number;
 };
 
+type UpdateManyAndReturnData = {
+  where?: WhereUse;
+  data: UpdateAnyUse;
+  limit?: number;
+  select?: Select;
+  omit?: QueryOmit;
+  include?: IncludeData;
+};
+
 type UpsertSingleData = {
   where: WhereUse;
   create: AnyUse;
@@ -84,6 +93,7 @@ export type {
   FindData,
   UpdateSingleData,
   UpdateData,
+  UpdateManyAndReturnData,
   UpsertSingleData,
   DeleteSingleData,
   DeleteData,

--- a/src/util/count/count.ts
+++ b/src/util/count/count.ts
@@ -1,17 +1,33 @@
 import type { CountData } from "../../types/countType";
 import type { FindData } from "../../types/findTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
+import { getCount } from "../aggregate/aggregateUtil/count";
+import { getTitle } from "../core/getTitle";
 import { findManyFunc } from "../find/findMany";
+import { validateCountSelect } from "../validate/validateCountSelect";
 
 const countFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
   countData: CountData,
 ) => {
-  const findData: FindData = {
-    ...countData,
-  };
+  const { select, ...rest } = countData;
+  const findData: FindData = { ...rest };
 
-  return findManyFunc(gassmaControllerUtil, findData).length;
+  const rows = findManyFunc(gassmaControllerUtil, findData);
+
+  if (select === undefined || select === true) return rows.length;
+
+  const titles = getTitle(gassmaControllerUtil);
+  const ignoredFields =
+    gassmaControllerUtil.whereValidation?.ignoredFields ?? [];
+  const truthyKeys = validateCountSelect(select, titles, ignoredFields);
+
+  const truthySelect: Record<string, true> = {};
+  truthyKeys.forEach((key) => {
+    truthySelect[key] = true;
+  });
+
+  return getCount(rows, truthySelect);
 };
 
 export { countFunc };

--- a/src/util/validate/validateCountSelect.ts
+++ b/src/util/validate/validateCountSelect.ts
@@ -1,0 +1,35 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../errors/argument/argumentError";
+import type { CountAggregateSelect } from "../../types/countType";
+
+const validateCountSelect = (
+  select: CountAggregateSelect,
+  titles: string[],
+  ignoredFields: string[],
+): string[] => {
+  const availableArguments = titles
+    .filter((title) => !ignoredFields.includes(title))
+    .concat("_all");
+
+  const keys = Object.keys(select);
+  if (keys.length === 0) {
+    throw new GassmaInvalidValueError("select", "a non-empty object");
+  }
+
+  keys.forEach((key) => {
+    if (!availableArguments.includes(key)) {
+      throw new GassmaUnknownArgumentError(key, availableArguments);
+    }
+  });
+
+  const truthyKeys = keys.filter((key) => select[key]);
+  if (truthyKeys.length === 0) {
+    throw new GassmaInvalidValueError("select", "at least one truthy value");
+  }
+
+  return truthyKeys;
+};
+
+export { validateCountSelect };

--- a/src/util/validate/validateTopLevelKeys.ts
+++ b/src/util/validate/validateTopLevelKeys.ts
@@ -16,7 +16,7 @@ const FIND_KEYS = [
 const ALLOWED_TOP_LEVEL_KEYS = {
   findMany: FIND_KEYS,
   findFirst: FIND_KEYS,
-  count: ["where", "orderBy", "take", "skip", "cursor"],
+  count: ["where", "orderBy", "take", "skip", "cursor", "select"],
   aggregate: [
     "where",
     "orderBy",
@@ -47,7 +47,7 @@ const ALLOWED_TOP_LEVEL_KEYS = {
   createManyAndReturn: ["data", "select", "omit", "include"],
   update: ["where", "data", "select", "omit", "include"],
   updateMany: ["where", "data", "limit"],
-  updateManyAndReturn: ["where", "data", "limit"],
+  updateManyAndReturn: ["where", "data", "limit", "select", "omit", "include"],
   upsert: ["where", "create", "update", "select", "omit", "include"],
   delete: ["where", "select", "omit", "include"],
   deleteMany: ["where", "limit"],


### PR DESCRIPTION
typo 対策(#192〜#200)の過程で見つかった**実装漏れ2件**の実装です。どちらも「引数を受け取るのに黙って無視する」状態だったため、#192 / #193 で**いったんエラーで塞いで**いたものです。

Prisma 生成型から操作別の引数を機械抽出して全操作を突き合わせた結果、**黙殺されていた引数はこの2件だけ**と確認済みでした。**これで実装漏れは解消します。**

## 1. `count` の `select`

```js
count()                              // → 2            従来どおり素の数値
count({ select: { _all: true } })    // → { _all: 2 }
count({ select: { name: true } })    // → { name: 2 }  非 null の件数
```

**意味論はすでに実装済みでした。** `getCount`(`aggregate` の `_count` 用、#186 で `_all` 対応)が「`_all` は行数、フィールドは非 null 件数」という Prisma と同じ動きをするので、**新規に書かず再利用**しています。`getCount` 自体は無変更です。

### 偽のゼロを作らないこと

**ここが実装上の要点**でした。素直に実装すると `count({ select: { nmae: true } })` が **`{ nmae: 0 }`** を返します。これは typo 調査で「実在しそうな偽のゼロ」として問題視した `_count: { _al: true }` と同じ形で、**塞いだ穴を新機能で開け直す**ことになります。

`select` のキーを列名(+ `_all`)と照合し、存在しないキーは既存の `GassmaUnknownArgumentError` で弾きます。

```
Unknown argument `nmae`. Did you mean `name`?
Unknown argument `_al`. Did you mean `_all`?
```

**新しいエラークラスは追加していません**(`GassmaAggregateSelectionRequiredError` はメッセージが `_avg`, `_count`... を列挙する aggregate 固有のものだったので流用せず、`GassmaInvalidValueError` を使っています)。

### Prisma の境界を実測して合わせた点

| ケース | Prisma | 本 PR |
|---|---|---|
| `{ _all: true, name: true }` 混在 | 各キー独立にカウント | 同じ |
| **`{ name: false, id: true }`** | 通る。**falsy キーは結果から消える**(`{id:5}` のみ。`name: 0` にすらならない) | 同じ |
| `{}`(空) | エラー「must not be empty」 | `Expected a non-empty object.` |
| **falsy のみ** | エラー「**needs at least one truthy value**」 | `Expected at least one truthy value.` |
| `select: true` | 素の数値 | 同じ |

**Prisma が空と falsy-only で別メッセージを出す**ので、こちらも区別しています。

## 2. `updateManyAndReturn` の `select` / `omit` / `include`

**Prisma は3つとも公式サポート**していることを実測で確認しました(従来 gassma は全列を返していました)。

実装は **`createManyAndReturn` を踏襲**しています。配列を返す書き込み操作という点で同型で、あちらには既に3つの処理と競合チェックが入っているためです。

- `include` × `select` → `GassmaIncludeSelectConflictError`
- `include` かつリレーション未定義 → `IncludeWithoutRelationsError`
- `select` × `omit` → `GassmaFindSelectOmitConflictError`

従来の globalOmit 適用は `resolveEffectiveOmit(null, undefined)` と同値なので、**引数を渡さない従来の使い方は挙動不変**です。

## 検証結果

- `npm test`: **2,463件 全 green**(2,430 → +34 / -1)
- **往復回数の契約テスト**: `titleRowReadTrips` 5件 / `perCallReadCache` 15件 / `manyToManyWriteRoundTrips` 6件 — **すべて無変更で通過**。検証は既に読んだ titles を使うので**追加の往復はありません**
- `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル57件)pass

### 変更した既存テスト

**1件のみ**です。#193 で入れた「`count` の `select` は許可されない」を削除しました(正当な引数になったため)。正方向の検証は新規テストに移しています。

## 判断が要る点

**1. `include` のリレーション制限を入れていません。**

Prisma の `*ManyAndReturn` の `include` は生成型で **FK 保有側のリレーションに限定**されます(逆側は `{}` になる)。ただし **gassma の `createManyAndReturn` は従来から全リレーションを受ける**ため、gassma 内の一貫性を優先して `updateManyAndReturn` も制限なしにしました。**制限を入れるなら cli の型生成側の判断**になります。

**2. `false` 値の未知キーも拒否しています**(`{ _al: false, _all: true }` はエラー)。Prisma のこの境界は未実測ですが、typo 対策の趣旨を優先しました。

**3. `@ignore` 列の `select` は拒否**しています(#196 の `where` と同じ方針。Prisma は `@ignore` を API から消す方式)。

## 続き

**cli の型生成の追随が必要です**(別 PR で対応します)。

- `CountData` に `select?: CountAggregateSelect | true`(既存のリレーション用 `CountSelect` と名前が衝突するため `CountAggregateSelect`)
- `count` の戻り値を条件型に: `T extends { select: infer S } ? (S extends true ? number : { [K in keyof S]: number }) : number`
- `UpdateManyAndReturnData` に `select` / `omit` / `include`(`CreateManyAndReturnData` と同構成)

**`aggregate` の `_count` にも同じキー検証を流用できます**(Prisma 側も生成型が同一)。`{ _al: true }` が `{ _al: 0 }` を返す既存の問題が同じ仕組みで直せますが、既存挙動の変更になるため本 PR には含めていません。**別途判断をお願いします。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)