### PR TITLE
fix: カスケード書き込みより前に update の列名を検証する(宙に浮いた FK の防止)

### DIFF
--- a/src/__test__/util/relation/onUpdate/validateBeforeCascade.test.ts
+++ b/src/__test__/util/relation/onUpdate/validateBeforeCascade.test.ts
@@ -1,0 +1,168 @@
+import { GassmaUnknownArgumentError } from "../../../../errors/argument/argumentError";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "../../transaction/transactionTestClient";
+
+const initialUsers = [
+  ["id", "name", "age"],
+  [1, "Alice", 20],
+  [2, "Bob", 30],
+];
+
+const initialPosts = [
+  ["id", "authorId", "title"],
+  [101, 1, "Post A"],
+  [102, 2, "Post B"],
+];
+
+const buildCascadeEnv = () => {
+  const env = buildTxTestEnv({ relations: true, cascade: true });
+  const users = Reflect.get(env.client, "Users");
+  return { env, users };
+};
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+describe("列名の検証は Cascade より先に行われる", () => {
+  it("update: 参照キー変更 + typo はエラーになり両シートが無変化", () => {
+    const { env, users } = buildCascadeEnv();
+
+    expect(() =>
+      users.update({ where: { id: 1 }, data: { id: 100, nmae: "X" } }),
+    ).toThrow(GassmaUnknownArgumentError);
+
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.posts.snapshot()).toEqual(initialPosts);
+  });
+
+  it("updateMany: 参照キー変更 + typo はエラーになり両シートが無変化", () => {
+    const { env, users } = buildCascadeEnv();
+
+    expect(() =>
+      users.updateMany({ where: { id: 1 }, data: { id: 100, nmae: "X" } }),
+    ).toThrow(GassmaUnknownArgumentError);
+
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.posts.snapshot()).toEqual(initialPosts);
+  });
+
+  it("updateManyAndReturn: 参照キー変更 + typo はエラーになり両シートが無変化", () => {
+    const { env, users } = buildCascadeEnv();
+
+    expect(() =>
+      users.updateManyAndReturn({
+        where: { id: 1 },
+        data: { id: 100, nmae: "X" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.posts.snapshot()).toEqual(initialPosts);
+  });
+
+  it("upsert(update枝): 参照キー変更 + typo はエラーになり両シートが無変化", () => {
+    const { env, users } = buildCascadeEnv();
+
+    expect(() =>
+      users.upsert({
+        where: { id: 1 },
+        create: { id: 1, name: "Alice", age: 20 },
+        update: { id: 100, nmae: "X" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.posts.snapshot()).toEqual(initialPosts);
+  });
+
+  it("updateMany: relation キー + 参照キー変更もエラーになり両シートが無変化", () => {
+    const { env, users } = buildCascadeEnv();
+
+    expect(() =>
+      users.updateMany({
+        where: { id: 1 },
+        data: { id: 100, posts: { set: [] } },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.posts.snapshot()).toEqual(initialPosts);
+  });
+});
+
+describe("前倒し検証が正当な操作を壊さない", () => {
+  it("update: 参照キー変更の Cascade は従来どおり子に伝播する", () => {
+    const { env, users } = buildCascadeEnv();
+
+    const result = users.update({ where: { id: 1 }, data: { id: 100 } });
+
+    expect(result).toEqual({ id: 100, name: "Alice", age: 20 });
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [100, "Alice", 20],
+      [2, "Bob", 30],
+    ]);
+    expect(env.posts.snapshot()).toEqual([
+      ["id", "authorId", "title"],
+      [101, 100, "Post A"],
+      [102, 2, "Post B"],
+    ]);
+  });
+
+  it("update: scalar + nested update の混在が従来どおり通る", () => {
+    const { env, users } = buildCascadeEnv();
+
+    const result = users.update({
+      where: { id: 1 },
+      data: {
+        name: "Alice2",
+        posts: { update: { where: { id: 101 }, data: { title: "New A" } } },
+      },
+    });
+
+    expect(result).toEqual({ id: 1, name: "Alice2", age: 20 });
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice2", 20],
+      [2, "Bob", 30],
+    ]);
+    expect(env.posts.snapshot()).toEqual([
+      ["id", "authorId", "title"],
+      [101, 1, "New A"],
+      [102, 2, "Post B"],
+    ]);
+  });
+
+  it("upsert(update枝): 参照キー変更の Cascade は従来どおり子に伝播する", () => {
+    const { env, users } = buildCascadeEnv();
+
+    const result = users.upsert({
+      where: { id: 1 },
+      create: { id: 1, name: "Alice", age: 20 },
+      update: { id: 100 },
+    });
+
+    expect(result).toEqual({ id: 100, name: "Alice", age: 20 });
+    expect(env.posts.snapshot()).toEqual([
+      ["id", "authorId", "title"],
+      [101, 100, "Post A"],
+      [102, 2, "Post B"],
+    ]);
+  });
+
+  it("update: where が一致しない場合は typo があっても従来どおり null を返す", () => {
+    const { env, users } = buildCascadeEnv();
+
+    const result = users.update({
+      where: { id: 999 },
+      data: { id: 100, nmae: "X" },
+    });
+
+    expect(result).toBeNull();
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.posts.snapshot()).toEqual(initialPosts);
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -84,6 +84,7 @@ import {
   validateCreateDataOperations,
   validateUpdateDataOperations,
 } from "./util/validate/validateDataOperations";
+import { validateUpdateColumnsEarly } from "./util/validate/validateUpdateColumnsEarly";
 import { resolveNestedUpdate } from "./util/update/nestedWrite/resolveNestedUpdate";
 import { resolveNumberOperations } from "./util/update/resolveNumberOperation";
 import { updateManyFunc } from "./util/update/updateMany";
@@ -899,12 +900,19 @@ class GassmaController {
     const resolvedWhere =
       this.resolveWhere(updateData.where) ?? updateData.where;
 
+    let precomputedTitles: string[] | undefined;
     if (this.relationContext) {
       const beforeRecords = findManyFunc(this.getGassmaControllerUtil(), {
         where: resolvedWhere,
         take: 1,
       });
       if (beforeRecords.length > 0) {
+        precomputedTitles = validateUpdateColumnsEarly(
+          this.getGassmaControllerUtil(),
+          updateData.data,
+          this.relationContext,
+          "update",
+        );
         const predictedAfter = resolveNumberOperations(
           beforeRecords[0],
           updateData.data,
@@ -919,6 +927,7 @@ class GassmaController {
       this.getGassmaControllerUtil(),
       { where: resolvedWhere, data: updateDataProcessed },
       this.relationContext ?? undefined,
+      precomputedTitles,
     );
     if (!result) return null;
 
@@ -958,7 +967,14 @@ class GassmaController {
       data: this.applyUpdatedAtToData(updateData.data),
     };
 
+    let precomputedTitles: string[] | undefined;
     if (this.relationContext) {
+      precomputedTitles = validateUpdateColumnsEarly(
+        this.getGassmaControllerUtil(),
+        updateData.data,
+        this.relationContext,
+        "updateMany",
+      );
       const findData: FindData = { where: updateData.where };
       if (updateData.limit !== undefined && updateData.limit !== null) {
         findData.take = updateData.limit;
@@ -977,7 +993,12 @@ class GassmaController {
       );
     }
 
-    return updateManyFunc(this.getGassmaControllerUtil(), updateData);
+    return updateManyFunc(
+      this.getGassmaControllerUtil(),
+      updateData,
+      false,
+      precomputedTitles,
+    );
   }
 
   public updateManyAndReturn(updateData: UpdateData) {
@@ -996,7 +1017,14 @@ class GassmaController {
       data: this.applyUpdatedAtToData(updateData.data),
     };
 
+    let precomputedTitles: string[] | undefined;
     if (this.relationContext) {
+      precomputedTitles = validateUpdateColumnsEarly(
+        this.getGassmaControllerUtil(),
+        updateData.data,
+        this.relationContext,
+        "updateMany",
+      );
       const findData: FindData = { where: updateData.where };
       if (updateData.limit !== undefined && updateData.limit !== null) {
         findData.take = updateData.limit;
@@ -1019,6 +1047,7 @@ class GassmaController {
       this.getGassmaControllerUtil(),
       updateData,
       true,
+      precomputedTitles,
     );
     if (!Array.isArray(results)) return results;
     return results.map((r) => {

--- a/src/util/update/nestedWrite/resolveNestedUpdate.ts
+++ b/src/util/update/nestedWrite/resolveNestedUpdate.ts
@@ -46,9 +46,10 @@ const resolveNestedUpdate = (
   util: GassmaControllerUtil,
   updateInput: UpdateInput,
   relationContext: RelationContext | undefined,
+  precomputedTitles?: string[],
 ): Record<string, unknown> | null => {
   const { sheet, startRowNumber, startColumnNumber, endColumnNumber } = util;
-  const titles = getTitle(util);
+  const titles = precomputedTitles ?? getTitle(util);
   const matchedRows = whereFilter(updateInput.where, util, titles);
 
   if (matchedRows.length === 0) return null;

--- a/src/util/update/updateMany.ts
+++ b/src/util/update/updateMany.ts
@@ -18,16 +18,19 @@ function updateManyFunc(
   gassmaControllerUtil: GassmaControllerUtil,
   updateData: UpdateData,
   withReturn: true,
+  precomputedTitles?: string[],
 ): Record<string, unknown>[];
 function updateManyFunc(
   gassmaControllerUtil: GassmaControllerUtil,
   updateData: UpdateData,
   withReturn?: false,
+  precomputedTitles?: string[],
 ): UpdateManyReturn;
 function updateManyFunc(
   gassmaControllerUtil: GassmaControllerUtil,
   updateData: UpdateData,
   withReturn?: boolean,
+  precomputedTitles?: string[],
 ): Record<string, unknown>[] | UpdateManyReturn {
   const { sheet, startRowNumber, startColumnNumber, endColumnNumber } =
     gassmaControllerUtil;
@@ -36,7 +39,7 @@ function updateManyFunc(
   const data = updateData.data;
   const limit = updateData.limit;
 
-  const titles = getTitle(gassmaControllerUtil);
+  const titles = precomputedTitles ?? getTitle(gassmaControllerUtil);
 
   if (gassmaControllerUtil.whereValidation) {
     validateDataColumns(

--- a/src/util/upsert/upsert.ts
+++ b/src/util/upsert/upsert.ts
@@ -13,6 +13,7 @@ import { resolveInclude } from "../relation/resolveInclude";
 import { resolveOnUpdate } from "../relation/onUpdate/resolveOnUpdate";
 import { resolveNestedUpdate } from "../update/nestedWrite/resolveNestedUpdate";
 import { resolveNumberOperations } from "../update/resolveNumberOperation";
+import { validateUpdateColumnsEarly } from "../validate/validateUpdateColumnsEarly";
 
 const applyOptions = (
   result: Record<string, unknown>,
@@ -60,7 +61,14 @@ const upsertFunc = (
     return applyOptions(created, upsertData, relationContext);
   }
 
+  let precomputedTitles: string[] | undefined;
   if (relationContext) {
+    precomputedTitles = validateUpdateColumnsEarly(
+      gassmaControllerUtil,
+      upsertData.update,
+      relationContext,
+      "update",
+    );
     const beforeRecords = findManyFunc(gassmaControllerUtil, {
       where: upsertData.where,
       take: 1,
@@ -78,6 +86,7 @@ const upsertFunc = (
     gassmaControllerUtil,
     { where: upsertData.where, data: upsertData.update },
     relationContext ?? undefined,
+    precomputedTitles,
   );
   if (!updated) return record;
 

--- a/src/util/validate/validateUpdateColumnsEarly.ts
+++ b/src/util/validate/validateUpdateColumnsEarly.ts
@@ -1,0 +1,23 @@
+import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
+import type { RelationContext } from "../../types/relationTypes";
+import { getTitle } from "../core/getTitle";
+import { extractRelationDataForUpdate } from "../update/nestedWrite/extractRelationDataForUpdate";
+import { validateDataColumns } from "./validateDataColumns";
+
+const validateUpdateColumnsEarly = (
+  util: GassmaControllerUtil,
+  data: Record<string, unknown>,
+  relationContext: RelationContext,
+  mode: "update" | "updateMany",
+): string[] => {
+  const titles = getTitle(util);
+  if (!util.whereValidation) return titles;
+  const scalarData =
+    mode === "update"
+      ? extractRelationDataForUpdate(data, relationContext.relations).scalarData
+      : data;
+  validateDataColumns(scalarData, titles, util.whereValidation, mode);
+  return titles;
+};
+
+export { validateUpdateColumnsEarly };


### PR DESCRIPTION
#200 のレビューで報告した「update 側の既存の穴」への対応です。**typo という日常的なミスから、無言でデータが壊れていました。**

## 問題(実測)

`update` でリレーションが定義されていると、**カスケードが列名の検証より前に走ります**。

```js
Users.update({ where: { id: 1 }, data: { id: 100, nmae: "X" } })
//                                                 ↑ typo
```

結果(`posts` に `onUpdate: "Cascade"`):

```
Posts: [101, 100, "Post A"]   ← authorId が 1→100 に書き換え済み
Users: [1, "Alice", 20]       ← 旧値のまま
```

**エラーは正しく投げられます。しかし id=100 の親は存在せず、宙に浮いた FK が残ります。**

エラーが出ているのにシートが壊れるという点で、#192〜#200 で徹底してきた「誤爆を防ぐ」という趣旨に真っ向から反する状態でした。`update` / `updateMany` / `updateManyAndReturn` / `upsert` の update 枝の**4経路すべて**で再現しています。

## 修正

見出しを**1回だけ読んで**列名を検証し、その結果をカスケードより前に置きました。検証済みの titles は下流に省略可能な引数で渡して再読を防いでいます(#200 で `createFunc` に対してやったのと同じ形)。

### `update` と `updateMany` で扱いが違う

- **`update`**: 先に `extractRelationDataForUpdate` でリレーションを分離してから scalar 部分を検証します。**正当な nested write を「未知の列」として誤爆させない**ため
- **`updateMany`**: 分離せず生の `data` を検証します。**そもそも `updateMany` に relation キーを書くこと自体が不正**なので、弾かれるのが正しい挙動です

この違いを取り違えると正当な nested update が壊れるので、テストで両方を固定しています。

## 見出しの読みは増えていません

往復契約テスト3スイート26件が**期待値変更なしで通過**しています。

- `titleRowReadTrips` 5/5(relations 無し経路の「見出し1回」固定を含む)
- `perCallReadCache` 15/15
- `manyToManyWriteRoundTrips` 6/6

構造上も、relations 無しの経路はヘルパー自体を呼ばず、relations 有りの経路は「ヘルパーで1回読む + 下流で0回」と**読む場所が移動しただけ**です。

## 検証結果

- `npm test`: **2,439件 全 green**(2,430 → +9、**既存テストの変更0件**)
- `tsc --noEmit` / lint(警告数は main と同数)/ format / `verify:bundle`(公開シンボル57件)pass

追加テスト9件のうち**4件は正常系のガード**です(正常なカスケード伝播、scalar と nested の混在、`upsert` のカスケード、no-match 時の `null` 維持)。

## 判断が要る点

**`where` が一致しないときは、typo があってもエラーになりません。**

`update` は従来「`where` 不一致なら `null` を返す」挙動で、検証が `whereFilter` の後にあったため typo も無視されていました。前倒しを無条件にするとここが throw に変わるため、**検証を「対象行が見つかった場合」の内側に置いて従来挙動を維持**しています(不一致なら書き込みもカスケードも走らないので、安全性は損なわれません)。

ただし **Prisma は対象の有無に関わらず検証エラーを投げます**(検証がクエリ送信前に走るため)。これは既存の差異であり本 PR で持ち込んだものではありませんが、**揃えるかどうかの判断は残ります**。`updateMany` は従来から一致の有無に関係なく検証するので、こちらは Prisma と同じです。

## 補足

下流(`resolveNestedUpdate` / `updateManyFunc`)の検証は残してあります。純粋関数なので二重実行は無害で、titles が渡るため読みも増えず、それらを直接呼ぶ経路の防御が維持されます。

なお **nested write の after フェーズによる部分書き込み**(子の typo で親が残る問題)は本 PR の対象外で、別途「ロックを取らない内部バッファ」方式の実現可能性を調査中です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)