### PR TITLE
fix: 対象行の有無に関わらず入力を検証する

### DIFF
--- a/src/__test__/util/dataColumnValidation.test.ts
+++ b/src/__test__/util/dataColumnValidation.test.ts
@@ -198,6 +198,76 @@ describe("リレーション名に不正な値", () => {
   });
 });
 
+describe("対象行が無くても入力は検証される", () => {
+  test("update: where 不一致でも typo はエラー", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () => loose.update({ where: { id: 999 }, data: { nmae: "X" } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `nmae`. Did you mean `name`?");
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("update: relations ありでも where 不一致の typo はエラー", () => {
+    const { loose, typed } = looseUsers({ relations: true });
+    expect(() =>
+      loose.update({ where: { id: 999 }, data: { nmae: "X" } }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("update: where 不一致で typo 無しは従来どおり null", () => {
+    const { loose, typed } = looseUsers();
+    expect(
+      loose.update({ where: { id: 999 }, data: { name: "X" } }),
+    ).toBeNull();
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("updateMany: where 不一致でも typo はエラー", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.updateMany({ where: { id: 999 }, data: { nmae: "X" } }),
+    ).toThrow(GassmaUnknownArgumentError);
+    aliceUnchanged(typed);
+  });
+
+  test("upsert(作成分岐): 未実行の update 側の typo もエラーになり追加されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.upsert({
+        where: { id: 999 },
+        create: { id: 999, name: "A", age: 1 },
+        update: { nmae: "X" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("upsert(更新分岐): 未実行の create 側の typo もエラーになり更新されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.upsert({
+        where: { id: 1 },
+        create: { id: 1, nmae: "Alice", age: 20 },
+        update: { name: "X" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    aliceUnchanged(typed);
+  });
+
+  test("upsert: relations ありでも未実行の update 側の typo はエラー", () => {
+    const { loose, typed } = looseUsers({ relations: true });
+    expect(() =>
+      loose.upsert({
+        where: { id: 999 },
+        create: { id: 999, name: "A", age: 1 },
+        update: { nmae: "X" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+    expect(typed.count({})).toBe(3);
+  });
+});
+
 describe("従来どおり動くこと", () => {
   test("正しい列名の create は通る", () => {
     const { typed } = looseUsers();

--- a/src/__test__/util/relation/onUpdate/validateBeforeCascade.test.ts
+++ b/src/__test__/util/relation/onUpdate/validateBeforeCascade.test.ts
@@ -153,13 +153,21 @@ describe("前倒し検証が正当な操作を壊さない", () => {
     ]);
   });
 
-  it("update: where が一致しない場合は typo があっても従来どおり null を返す", () => {
+  it("update: where が一致しなくても typo はエラーになり両シートが無変化", () => {
     const { env, users } = buildCascadeEnv();
 
-    const result = users.update({
-      where: { id: 999 },
-      data: { id: 100, nmae: "X" },
-    });
+    expect(() =>
+      users.update({ where: { id: 999 }, data: { id: 100, nmae: "X" } }),
+    ).toThrow(GassmaUnknownArgumentError);
+
+    expect(env.users.snapshot()).toEqual(initialUsers);
+    expect(env.posts.snapshot()).toEqual(initialPosts);
+  });
+
+  it("update: where が一致せず typo も無い場合は従来どおり null を返す", () => {
+    const { env, users } = buildCascadeEnv();
+
+    const result = users.update({ where: { id: 999 }, data: { id: 100 } });
 
     expect(result).toBeNull();
     expect(env.users.snapshot()).toEqual(initialUsers);

--- a/src/__test__/util/write/titleRowReadTrips.test.ts
+++ b/src/__test__/util/write/titleRowReadTrips.test.ts
@@ -144,6 +144,36 @@ describe("書き込み系の見出し行読み取り回数", () => {
     expect(env.users.titleReads()).toBe(1);
   });
 
+  test("update: where 不一致でも見出し行は1回だけ読む", () => {
+    const env = buildEnv();
+    const result = sheetOf(env.client, "Users").update({
+      where: { id: 999 },
+      data: { age: 21 },
+    });
+    expect(result).toBeNull();
+    expect(env.users.titleReads()).toBe(1);
+  });
+
+  test("upsert(更新分岐)の見出し行読みは3回のまま増えない", () => {
+    const env = buildEnv();
+    sheetOf(env.client, "Users").upsert({
+      where: { id: 1 },
+      create: { id: 1, name: "Alice", age: 20 },
+      update: { age: 21 },
+    });
+    expect(env.users.titleReads()).toBe(3);
+  });
+
+  test("upsert(作成分岐)の見出し行読みは3回のまま増えない", () => {
+    const env = buildEnv();
+    sheetOf(env.client, "Users").upsert({
+      where: { id: 99 },
+      create: { id: 99, name: "Zed", age: 1 },
+      update: { age: 21 },
+    });
+    expect(env.users.titleReads()).toBe(3);
+  });
+
   test("updateMany は見出し行を1回だけ読む", () => {
     const env = buildEnv();
     const result = sheetOf(env.client, "Users").updateMany({

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -907,13 +907,13 @@ class GassmaController {
         where: resolvedWhere,
         take: 1,
       });
+      precomputedTitles = validateUpdateColumnsEarly(
+        this.getGassmaControllerUtil(),
+        updateData.data,
+        this.relationContext,
+        "update",
+      );
       if (beforeRecords.length > 0) {
-        precomputedTitles = validateUpdateColumnsEarly(
-          this.getGassmaControllerUtil(),
-          updateData.data,
-          this.relationContext,
-          "update",
-        );
         const predictedAfter = resolveNumberOperations(
           beforeRecords[0],
           updateData.data,

--- a/src/util/update/nestedWrite/resolveNestedUpdate.ts
+++ b/src/util/update/nestedWrite/resolveNestedUpdate.ts
@@ -1,7 +1,6 @@
 import type { WhereUse } from "../../../types/coreTypes";
 import type { GassmaControllerUtil } from "../../../types/gassmaControllerUtilType";
 import type { RelationContext } from "../../../types/relationTypes";
-import { NestedWriteWithoutRelationsError } from "../../../errors/relation/nestedWriteError";
 import { getTitle } from "../../core/getTitle";
 import { getWantUpdateIndexFromTitles } from "../../core/getWantUpdateIndex";
 import { whereFilter } from "../../core/whereFilter";
@@ -23,7 +22,7 @@ import {
 } from "../resolveNumberOperation";
 import { escapeFormulaInjectionRow } from "../../core/escapeFormulaInjection";
 import { unwrapRawCell } from "../../raw/raw";
-import { validateDataColumns } from "../../validate/validateDataColumns";
+import { validateUpdateColumnsEarly } from "../../validate/validateUpdateColumnsEarly";
 import { resolveWriter } from "../../write/sheetWriter";
 
 type UpdateInput = {
@@ -52,6 +51,14 @@ const resolveNestedUpdate = (
   const titles = precomputedTitles ?? getTitle(util);
   const matchedRows = whereFilter(updateInput.where, util, titles);
 
+  validateUpdateColumnsEarly(
+    util,
+    updateInput.data,
+    relationContext ?? null,
+    "update",
+    titles,
+  );
+
   if (matchedRows.length === 0) return null;
 
   const firstRow = matchedRows[0];
@@ -66,25 +73,6 @@ const resolveNestedUpdate = (
   );
 
   if (!hasUpdateNestedWriteFields(updateInput.data, relationContext)) {
-    if (
-      !relationContext &&
-      Object.entries(updateInput.data).some(
-        ([key, value]) =>
-          !titles.includes(key) && isUpdateNestedWriteOperation(value),
-      )
-    ) {
-      throw new NestedWriteWithoutRelationsError();
-    }
-
-    if (util.whereValidation) {
-      validateDataColumns(
-        updateInput.data,
-        titles,
-        util.whereValidation,
-        "update",
-      );
-    }
-
     const wantUpdateIndex = getWantUpdateIndexFromTitles(
       titles,
       updateInput.data,
@@ -117,10 +105,6 @@ const resolveNestedUpdate = (
     updateInput.data,
     relationContext!.relations,
   );
-
-  if (util.whereValidation) {
-    validateDataColumns(scalarData, titles, util.whereValidation, "update");
-  }
 
   const enrichedData = processBeforeCreate(
     scalarData,

--- a/src/util/upsert/upsert.ts
+++ b/src/util/upsert/upsert.ts
@@ -13,6 +13,7 @@ import { resolveInclude } from "../relation/resolveInclude";
 import { resolveOnUpdate } from "../relation/onUpdate/resolveOnUpdate";
 import { resolveNestedUpdate } from "../update/nestedWrite/resolveNestedUpdate";
 import { resolveNumberOperations } from "../update/resolveNumberOperation";
+import { validateCreateColumnsEarly } from "../validate/validateCreateColumnsEarly";
 import { validateUpdateColumnsEarly } from "../validate/validateUpdateColumnsEarly";
 
 const applyOptions = (
@@ -41,19 +42,36 @@ const upsertFunc = (
   relationContext?: RelationContext | null,
   prepareCreate?: (data: Record<string, unknown>) => Record<string, unknown>,
 ): Record<string, unknown> => {
+  const titles = getTitle(gassmaControllerUtil);
+  validateCreateColumnsEarly(
+    gassmaControllerUtil,
+    upsertData.create,
+    relationContext ?? null,
+    titles,
+  );
+  validateUpdateColumnsEarly(
+    gassmaControllerUtil,
+    upsertData.update,
+    relationContext ?? null,
+    "update",
+    titles,
+  );
+
   const record = findFirstFunc(gassmaControllerUtil, {
     where: upsertData.where,
   });
 
   if (!record) {
-    const wrappedCreate = (data: Record<string, unknown>, titles?: string[]) =>
-      createFunc(gassmaControllerUtil, { data: data as AnyUse }, titles);
+    const wrappedCreate = (
+      data: Record<string, unknown>,
+      rowTitles?: string[],
+    ) => createFunc(gassmaControllerUtil, { data: data as AnyUse }, rowTitles);
     const created = resolveNestedCreate(
       upsertData.create,
       wrappedCreate,
       relationContext ?? undefined,
       {
-        getTitles: () => getTitle(gassmaControllerUtil),
+        getTitles: () => titles,
         validation: gassmaControllerUtil.whereValidation,
         ...(prepareCreate ? { prepare: prepareCreate } : {}),
       },
@@ -61,14 +79,7 @@ const upsertFunc = (
     return applyOptions(created, upsertData, relationContext);
   }
 
-  let precomputedTitles: string[] | undefined;
   if (relationContext) {
-    precomputedTitles = validateUpdateColumnsEarly(
-      gassmaControllerUtil,
-      upsertData.update,
-      relationContext,
-      "update",
-    );
     const beforeRecords = findManyFunc(gassmaControllerUtil, {
       where: upsertData.where,
       take: 1,
@@ -86,7 +97,7 @@ const upsertFunc = (
     gassmaControllerUtil,
     { where: upsertData.where, data: upsertData.update },
     relationContext ?? undefined,
-    precomputedTitles,
+    titles,
   );
   if (!updated) return record;
 

--- a/src/util/validate/validateCreateColumnsEarly.ts
+++ b/src/util/validate/validateCreateColumnsEarly.ts
@@ -1,0 +1,29 @@
+import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
+import type { RelationContext } from "../../types/relationTypes";
+import { NestedWriteWithoutRelationsError } from "../../errors/relation/nestedWriteError";
+import { getTitle } from "../core/getTitle";
+import {
+  extractRelationData,
+  isNestedWriteOperation,
+} from "../create/nestedWrite/extractRelationData";
+import { validateDataColumns } from "./validateDataColumns";
+
+const validateCreateColumnsEarly = (
+  util: GassmaControllerUtil,
+  data: Record<string, unknown>,
+  relationContext: RelationContext | null,
+  precomputedTitles?: string[],
+): string[] => {
+  const titles = precomputedTitles ?? getTitle(util);
+  if (!relationContext && Object.values(data).some(isNestedWriteOperation)) {
+    throw new NestedWriteWithoutRelationsError();
+  }
+  if (!util.whereValidation) return titles;
+  const scalarData = relationContext
+    ? extractRelationData(data, relationContext.relations).scalarData
+    : data;
+  validateDataColumns(scalarData, titles, util.whereValidation, "create");
+  return titles;
+};
+
+export { validateCreateColumnsEarly };

--- a/src/util/validate/validateUpdateColumnsEarly.ts
+++ b/src/util/validate/validateUpdateColumnsEarly.ts
@@ -1,19 +1,31 @@
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import type { RelationContext } from "../../types/relationTypes";
+import { NestedWriteWithoutRelationsError } from "../../errors/relation/nestedWriteError";
 import { getTitle } from "../core/getTitle";
-import { extractRelationDataForUpdate } from "../update/nestedWrite/extractRelationDataForUpdate";
+import {
+  extractRelationDataForUpdate,
+  isUpdateNestedWriteOperation,
+} from "../update/nestedWrite/extractRelationDataForUpdate";
 import { validateDataColumns } from "./validateDataColumns";
 
 const validateUpdateColumnsEarly = (
   util: GassmaControllerUtil,
   data: Record<string, unknown>,
-  relationContext: RelationContext,
+  relationContext: RelationContext | null,
   mode: "update" | "updateMany",
+  precomputedTitles?: string[],
 ): string[] => {
-  const titles = getTitle(util);
+  const titles = precomputedTitles ?? getTitle(util);
+  if (mode === "update" && !relationContext) {
+    const hasNestedShapeValue = Object.entries(data).some(
+      ([key, value]) =>
+        !titles.includes(key) && isUpdateNestedWriteOperation(value),
+    );
+    if (hasNestedShapeValue) throw new NestedWriteWithoutRelationsError();
+  }
   if (!util.whereValidation) return titles;
   const scalarData =
-    mode === "update"
+    mode === "update" && relationContext
       ? extractRelationDataForUpdate(data, relationContext.relations).scalarData
       : data;
   validateDataColumns(scalarData, titles, util.whereValidation, mode);


### PR DESCRIPTION
#202 のレビューで挙げた「`where` が一致しないときは typo があってもエラーにならない」件への対応です。ご指示のとおり Prisma に揃えました。

## 問題

検証が「対象行が見つかった場合」の内側にあったため、**一致しなければ typo が黙って無視**されていました。

```js
Users.update({ where: { id: 999 }, data: { nmae: "X" } })
//                     ↑ 存在しない        ↑ typo
// → null を返すだけ。typo は報告されない
```

**`upsert` は逆向きに同じ形**を持っていました。`where` が一致しないと create 枝に行くので、**実行されなかった `update` 枝は一度も検証されません**(逆も同様)。

```js
Users.upsert({
  where: { id: 999 },              // 一致しない → create 枝へ
  create: { id: 999, name: "A" },
  update: { nmae: "X" },           // ← typo だが検証されない
})
```

**Prisma は結果の行がどうであれ、クエリ全体をクエリ送信前に検証します。**

## 修正

検証を一致判定より前に、`upsert` では**枝の判定より前**に移動しました。

- `update`: `findManyFunc` の直後、カスケード判定の前
- `resolveNestedUpdate`: no-match の `return null` より前(**リレーション未定義のクライアントの update も no-match で検証される**ようになります)
- `upsert`: 冒頭で見出しを1回読み、**create 側と update 側を両方検証**してから枝を判定

`upsert` の対称性のために `validateCreateColumnsEarly` を新設しました(29行)。両ヘルパーは既存の検証優先順位(`NestedWriteWithoutRelationsError` → 列名検証、リレーションありは scalarData 抽出後)をそのまま再現しているので、**既存のエラー種別とメッセージは変わりません**。新しいエラークラスも追加していません。

## 往復回数は増えていません(実測)

検証を前倒しすると対象が無い場合にも見出しを読むことになるため、**実装前後で見出し行の読み回数を同一テストで比較**しました。

| | 修正前 | 修正後 |
|---|---|---|
| relations 無し: update no-match | 1 | 1 |
| relations 無し: upsert 更新枝 / 作成枝 | 3 / 3 | 3 / 3 |
| relations 有り: update match / no-match | 3 / 3 | 3 / 3 |
| relations 有り: upsert 更新枝 / 作成枝 | 5 / 3 | 5 / 3 |

`upsert` は冒頭の1回が、従来の「更新枝の検証内の読み / 作成枝の読み」1回と**ちょうど置き換わる**形です。`whereFilter` と検証で二重に読むこともありません(titles を引き回して吸収)。

**往復契約テストも既存の期待値のまま通過**しています(`titleRowReadTrips` 8/8・`perCallReadCache` 15/15・`manyToManyWriteRoundTrips` 6/6)。さらに今回の挙動を固定する契約テストを3件追加しました。

## 他に同じ性質の箇所は無い

確認済みです。

- **`updateMany` / `updateManyAndReturn`**: `updateManyFunc` が no-match の return より前に検証しており、実装前から「no-match + typo → エラー」でした(red フェーズで実測確認)
- **`delete` / `deleteMany`**: `data` 入力が無く、`where` は `whereFilter` 内の検証が一致の有無に関係なく走ります
- **#201 で入った `count` の `select` / `updateManyAndReturn`** も確認済みで該当なし

## 検証結果

- `npm test`: **2,483件 全 green**
- `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル57件)pass

### 変更した既存テスト

**#202 で追加した1件のみ**です。「`where` 不一致なら typo でも `null`」を throw 期待に反転し、「typo が無ければ `null`」というガードテストを併設しました。**他の既存テストの期待値変更はゼロ**です。

## 判断が要る点

**`upsert` で `where` と `data` の両方に typo がある場合、エラーの優先順位が data 側優先に変わります**(従来は `findFirst` の `where` 検証が先)。既存テストへの影響は無く、Prisma もクエリ全体を事前検証するため許容と判断しました。`upsert` の検証順は引数の宣言順に合わせて create → update です。

また、リレーション未定義のクライアントに nested write 形の値を渡した場合、`NestedWriteWithoutRelationsError` が **no-match でも投げられる**ようになります。前倒しの自然な帰結で、Prisma 同様の事前検証として妥当と判断しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)