### PR TITLE
fix: nested update / delete の不在ターゲットをエラーにする

### DIFF
--- a/src/__test__/util/update/nestedWrite/processAfterUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/processAfterUpdate.test.ts
@@ -1,4 +1,7 @@
-import { NestedWriteInvalidOperationError } from "../../../../errors/relation/nestedWriteError";
+import {
+  NestedWriteInvalidOperationError,
+  NestedWriteTargetNotFoundError,
+} from "../../../../errors/relation/nestedWriteError";
 import { processAfterUpdate } from "../../../../util/update/nestedWrite/processAfterUpdate";
 import type {
   RelationDefinition,
@@ -245,6 +248,99 @@ describe("processAfterUpdate", () => {
         makeContext({ posts: oneToManyRelation }),
       ),
     ).toThrow("disconnect");
+  });
+
+  it("oneToMany + update で対象0件なら NestedWriteTargetNotFoundError", () => {
+    mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("posts", {
+      update: { where: { id: 999 }, data: { title: "新タイトル" } },
+    });
+
+    expect(() =>
+      processAfterUpdate(
+        { id: 1, name: "田中" },
+        relationOps,
+        makeContext({ posts: oneToManyRelation }),
+      ),
+    ).toThrow(NestedWriteTargetNotFoundError);
+  });
+
+  it("oneToMany + update（配列）で一部が対象0件ならエラー", () => {
+    mockUpdateManyOnSheet
+      .mockReturnValueOnce({ count: 1 })
+      .mockReturnValueOnce({ count: 0 });
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("posts", {
+      update: [
+        { where: { id: 5 }, data: { title: "A" } },
+        { where: { id: 999 }, data: { title: "B" } },
+      ],
+    });
+
+    expect(() =>
+      processAfterUpdate(
+        { id: 1, name: "田中" },
+        relationOps,
+        makeContext({ posts: oneToManyRelation }),
+      ),
+    ).toThrow(NestedWriteTargetNotFoundError);
+  });
+
+  it("oneToMany + delete で対象0件なら NestedWriteTargetNotFoundError", () => {
+    mockDeleteManyOnSheet.mockReturnValue({ count: 0 });
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("posts", { delete: { id: 999 } });
+
+    expect(() =>
+      processAfterUpdate(
+        { id: 1, name: "田中" },
+        relationOps,
+        makeContext({ posts: oneToManyRelation }),
+      ),
+    ).toThrow(NestedWriteTargetNotFoundError);
+  });
+
+  it("oneToMany + deleteMany は対象0件でもエラーにならない", () => {
+    mockDeleteManyOnSheet.mockReturnValue({ count: 0 });
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("posts", { deleteMany: { published: false } });
+
+    expect(() =>
+      processAfterUpdate(
+        { id: 1, name: "田中" },
+        relationOps,
+        makeContext({ posts: oneToManyRelation }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("oneToMany + disconnect は対象0件でもエラーにならない", () => {
+    mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("posts", { disconnect: { id: 999 } });
+
+    expect(() =>
+      processAfterUpdate(
+        { id: 1, name: "田中" },
+        relationOps,
+        makeContext({ posts: oneToManyRelation }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("oneToMany + set は対象0件でもエラーにならない", () => {
+    mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
+    const relationOps = new Map<string, NestedWriteOperation>();
+    relationOps.set("posts", { set: [{ id: 999 }] });
+
+    expect(() =>
+      processAfterUpdate(
+        { id: 1, name: "田中" },
+        relationOps,
+        makeContext({ posts: oneToManyRelation }),
+      ),
+    ).not.toThrow();
   });
 
   it("manyToOne は無視される", () => {

--- a/src/__test__/util/update/nestedWrite/resolveNestedUpdate.test.ts
+++ b/src/__test__/util/update/nestedWrite/resolveNestedUpdate.test.ts
@@ -243,6 +243,58 @@ describe("resolveNestedUpdate", () => {
     expect(mockDeleteManyOnSheet).toHaveBeenCalledTimes(2);
   });
 
+  it("oneToMany + update で相手不在ならエラー", () => {
+    const util = setupSheet(["id", "name"], [[1, "田中"]]);
+    mockUpdateManyOnSheet.mockReturnValue({ count: 0 });
+
+    expect(() =>
+      resolveNestedUpdate(
+        util,
+        {
+          where: { id: 1 },
+          data: {
+            posts: {
+              update: { where: { id: 999 }, data: { title: "新タイトル" } },
+            },
+          },
+        },
+        makeContext({ posts: oneToManyRelation }),
+      ),
+    ).toThrow(NestedWriteTargetNotFoundError);
+  });
+
+  it("oneToMany + delete で相手不在ならエラー", () => {
+    const util = setupSheet(["id", "name"], [[1, "田中"]]);
+    mockDeleteManyOnSheet.mockReturnValue({ count: 0 });
+
+    expect(() =>
+      resolveNestedUpdate(
+        util,
+        {
+          where: { id: 1 },
+          data: { posts: { delete: { id: 999 } } },
+        },
+        makeContext({ posts: oneToManyRelation }),
+      ),
+    ).toThrow(NestedWriteTargetNotFoundError);
+  });
+
+  it("oneToMany + deleteMany は対象0件でもエラーにならない", () => {
+    const util = setupSheet(["id", "name"], [[1, "田中"]]);
+    mockDeleteManyOnSheet.mockReturnValue({ count: 0 });
+
+    const result = resolveNestedUpdate(
+      util,
+      {
+        where: { id: 1 },
+        data: { posts: { deleteMany: { published: false } } },
+      },
+      makeContext({ posts: oneToManyRelation }),
+    );
+
+    expect(result).toEqual({ id: 1, name: "田中" });
+  });
+
   it("manyToOne + disconnect の統合テスト", () => {
     const util = setupSheet(["id", "title", "authorId"], [[1, "記事A", 1]]);
 

--- a/src/util/update/nestedWrite/processAfterUpdate.ts
+++ b/src/util/update/nestedWrite/processAfterUpdate.ts
@@ -3,7 +3,10 @@ import type {
   NestedWriteOperation,
   NestedUpdateInput,
 } from "../../../types/nestedWriteTypes";
-import { NestedWriteInvalidOperationError } from "../../../errors/relation/nestedWriteError";
+import {
+  NestedWriteInvalidOperationError,
+  NestedWriteTargetNotFoundError,
+} from "../../../errors/relation/nestedWriteError";
 import { isGassmaAny } from "../../relation/collectKeys";
 
 const isNestedUpdateInput = (value: unknown): value is NestedUpdateInput =>
@@ -34,19 +37,25 @@ const processAfterUpdate = (
           : [];
       items.forEach((item) => {
         if (!isNestedUpdateInput(item)) return;
-        context.updateManyOnSheet!(relation.to, {
+        const result = context.updateManyOnSheet!(relation.to, {
           where: { ...item.where, [relation.reference]: parentValue },
           data: item.data as Record<string, never>,
         });
+        if (result.count === 0) {
+          throw new NestedWriteTargetNotFoundError(relation.to, "update");
+        }
       });
     }
 
     if (ops.delete && ops.delete !== true) {
       const items = Array.isArray(ops.delete) ? ops.delete : [ops.delete];
       items.forEach((where) => {
-        context.deleteManyOnSheet!(relation.to, {
+        const result = context.deleteManyOnSheet!(relation.to, {
           where: { ...where, [relation.reference]: parentValue },
         });
+        if (result.count === 0) {
+          throw new NestedWriteTargetNotFoundError(relation.to, "delete");
+        }
       });
     }
 


### PR DESCRIPTION
Prisma 7.4.1 の実挙動を実測して gassma と突き合わせたところ、**2件の乖離**が見つかりました。

## Prisma の使い分けの論理

存在しない ID を nested write に渡したときの挙動です(発行 SQL つきで実測)。

| 操作 | Prisma | gassma(修正前) | |
|---|---|---|---|
| `set: [{id:999}]` | **黙殺** | 黙殺 | 一致 |
| `disconnect: {id:999}` | **黙殺** | 黙殺 | 一致 |
| `connect: {id:999}` | エラー P2018 | `NestedWriteConnectNotFoundError` | 一致 |
| nested `delete: {id:999}` | エラー **P2017** | **黙殺** | **乖離** |
| nested `update: {where:{id:999}}` | エラー **P2025** | **黙殺** | **乖離** |

**すべての黙殺が悪いわけではありません。** Prisma には一貫した線引きがあります。

- **`set` と `disconnect` は「最終状態がこうであれ」という宣言**なので、存在しないターゲットが混ざっても最終状態は達成できます(999 が繋がっていない、は既に真)。だから黙殺してよい
- **`connect` / `delete` / `update` は特定のレコードを名指しする命令**なので、対象が無ければ要求は満たせません

## 修正

**`NestedWriteTargetNotFoundError` は既に存在し、`oneToOne` の `update` / `delete` では既に使われていました。** つまり **1対多だけが黙殺という内部の非対称**だったので、同じクラス・同じパターンで揃えただけです。**新しいエラークラスは追加していません**(cli の追随も不要です)。

`updateManyOnSheet` / `deleteManyOnSheet` の戻り値の `count === 0` で throw します。

## 変えていないもの

- **`set` と `disconnect` の黙殺は維持**(Prisma と一致しているため)
- **`deleteMany` 形式は0件を許容**。「条件に合うものすべて」を選ぶ操作であって行を名指ししないので、Prisma も0件を許容します。**黙殺の維持をテストで固定**しました

## 調査で分かったこと(スコープ外)

- **`manyToMany` には nested `update` / `delete` の実装自体がありません**。`processManyToManyUpdate` が扱うのは `disconnect` と `set` の2つだけで、`update` / `delete` を渡しても全経路で無視されます。**実装の追加は新機能なので、確認なしには行っていません**。「未実装の操作が黙殺される」という別の問題として残ります
- `updateMany` 形式は `NestedWriteOperation` 型に存在しません
- oneToMany の `delete: true`(`where` なし)は現行コードのガードで黙殺されますが、Prisma では oneToMany に `delete: true` という形自体が無効なのでスコープ外としました

## 実証

修正を stash した状態(= main 相当)と適用状態で同じテストを実行しています。

| ケース | 修正前 | 修正後 |
|---|---|---|
| nested `update` where id 999 | 黙殺 | `NestedWriteTargetNotFoundError` |
| nested `delete` {id:999} | 黙殺 | `NestedWriteTargetNotFoundError` |
| `set` [{id:999}] | 黙殺・全子切断 | **同一(維持)** |
| `disconnect` {id:999} | 黙殺・無変化 | **同一(維持)** |
| 正常な nested update / delete | 動作 | **同一(シート状態も一致)** |

## 検証結果

- `npm test`: **2,492件 全 green**(2,483 → +9、**既存テストの変更0件**)
- 往復契約テスト3スイート29件 green
- `tsc --noEmit` / lint(警告は main と同数)/ format / `verify:bundle`(公開シンボル57件)pass

黙殺を固定していた既存テストは存在しませんでした(既存の update / delete テストはすべて `{count: 1}` を返すモックなので、count チェックと両立します)。

## 判断が要る点

**nested `update` を配列で渡して一部成功した後に throw すると、先行分は書き込み済みになります。** `oneToOne` の既存 throw も同じ性質で、`$transaction` の外では rollback されません。

これは**別途進めている内部バッファ(リレーションが絡む操作をバッファしてフラッシュ時にまとめて流す)で解消される見込み**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)