### PR TITLE
fix: aggregate / groupBy の _count の未知キーをエラーにする

### DIFF
--- a/src/__test__/util/aggregate/aggregateCountKeys.test.ts
+++ b/src/__test__/util/aggregate/aggregateCountKeys.test.ts
@@ -1,0 +1,169 @@
+import { GassmaAggregateSelectionRequiredError } from "../../../errors/aggregate/aggregateError";
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../../errors/argument/argumentError";
+import { aggregateFunc } from "../../../util/aggregate/aggregate";
+import {
+  getExtendedMockControllerUtil,
+  getNullableMockControllerUtil,
+} from "../../consts/mockControllerUtil";
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "../extends/extendsTestClient";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "../transaction/transactionTestClient";
+
+afterEach(() => {
+  clearSpreadsheetApp();
+  clearGasGlobals();
+});
+
+const aggregateLoose: (util: any, data: any) => any = aggregateFunc;
+
+describe("aggregateFunc の _count キー検証", () => {
+  test("_al (typo) は偽のゼロを返さずエラーになりサジェストが出る", () => {
+    const fn = () =>
+      aggregateFunc(getExtendedMockControllerUtil(), {
+        _count: { _al: true },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `_al`. Did you mean `_all`?");
+  });
+
+  test("存在しない列はエラー", () => {
+    const fn = () =>
+      aggregateFunc(getExtendedMockControllerUtil(), {
+        _count: { 存在しない列: true },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("false のキーでも未知キーはエラー", () => {
+    const fn = () =>
+      aggregateLoose(getExtendedMockControllerUtil(), {
+        _count: { _al: false, _all: true },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("_count: {} は _sum と同居してもエラー", () => {
+    const fn = () =>
+      aggregateFunc(getExtendedMockControllerUtil(), {
+        _count: {},
+        _sum: { 年齢: true },
+      });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Expected a non-empty object");
+  });
+
+  test("falsy のみはエラー(truthy が1つ必要)", () => {
+    const fn = () =>
+      aggregateLoose(getExtendedMockControllerUtil(), {
+        _count: { 名前: false },
+      });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Expected at least one truthy value");
+  });
+
+  test("falsy のみは _sum と同居してもエラー", () => {
+    const fn = () =>
+      aggregateLoose(getExtendedMockControllerUtil(), {
+        _count: { 名前: false },
+        _sum: { 年齢: true },
+      });
+    expect(fn).toThrow(GassmaInvalidValueError);
+  });
+
+  test("truthy と falsy の混在は falsy キーを結果から除外する", () => {
+    const result = aggregateLoose(getExtendedMockControllerUtil(), {
+      _count: { 名前: false, 年齢: true },
+    });
+    expect(result).toEqual({ _count: { 年齢: 8 } });
+  });
+
+  test("ignore された列は _count できない", () => {
+    const util = {
+      ...getNullableMockControllerUtil(),
+      whereValidation: { ignoredFields: ["メモ"], relationNames: [] },
+    };
+    const fn = () => aggregateFunc(util, { _count: { メモ: true } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("_count: {} 単独は従来どおり集計指定なしエラー", () => {
+    const fn = () =>
+      aggregateFunc(getExtendedMockControllerUtil(), { _count: {} });
+    expect(fn).toThrow(GassmaAggregateSelectionRequiredError);
+  });
+
+  test("_count: true は従来どおり全行数を数値で返す", () => {
+    const result = aggregateFunc(getExtendedMockControllerUtil(), {
+      _count: true,
+    });
+    expect(result).toEqual({ _count: 8 });
+  });
+
+  test("_all と列名の指定は従来どおり集計する", () => {
+    const result = aggregateFunc(getNullableMockControllerUtil(), {
+      _count: { _all: true, メモ: true },
+    });
+    expect(result).toEqual({ _count: { _all: 3, メモ: 2 } });
+  });
+
+  test("where と併用しても従来どおり", () => {
+    const result = aggregateFunc(getExtendedMockControllerUtil(), {
+      where: { 住所: "Tokyo" },
+      _count: { _all: true },
+    });
+    expect(result).toEqual({ _count: { _all: 4 } });
+  });
+});
+
+describe("GassmaController 経由の aggregate _count キー検証", () => {
+  test("typo キーは偽のゼロでなくエラー", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    const loose: any = users;
+    const fn = () => loose.aggregate({ _count: { nmae: true } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `nmae`. Did you mean `name`?");
+  });
+
+  test("正しい列名は従来どおり集計する", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    expect(users.aggregate({ _count: { _all: true, name: true } })).toEqual({
+      _count: { _all: 3, name: 3 },
+    });
+  });
+
+  test("$transaction 経由でも検証が効く", () => {
+    const env = buildTxTestEnv();
+    const tx = (env.client as any).$transaction.bind(env.client);
+    const fn = () =>
+      tx((txClient: any) =>
+        txClient.Users.aggregate({ _count: { _al: true } }),
+      );
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("$extends の query フック経由でも検証が効く", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      query: {
+        Users: {
+          aggregate({ args, query }) {
+            return query(args);
+          },
+        },
+      },
+    });
+    const loose: any = extended.Users;
+    expect(() => loose.aggregate({ _count: { _al: true } })).toThrow(
+      GassmaUnknownArgumentError,
+    );
+  });
+});

--- a/src/__test__/util/groupby/groupbyCountKeys.test.ts
+++ b/src/__test__/util/groupby/groupbyCountKeys.test.ts
@@ -1,0 +1,133 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../../errors/argument/argumentError";
+import { groupByFunc } from "../../../util/groupby/groupby";
+import {
+  getExtendedMockControllerUtil,
+  getNullableMockControllerUtil,
+} from "../../consts/mockControllerUtil";
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "../extends/extendsTestClient";
+import { expectArrayToEqualIgnoringOrder } from "../../helpers/matchers";
+
+afterEach(() => {
+  clearSpreadsheetApp();
+});
+
+const groupByLoose: (util: any, data: any) => any = groupByFunc;
+
+describe("groupByFunc の _count キー検証", () => {
+  test("_al (typo) は偽のゼロを返さずエラーになりサジェストが出る", () => {
+    const fn = () =>
+      groupByFunc(getExtendedMockControllerUtil(), {
+        by: "住所",
+        _count: { _al: true },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `_al`. Did you mean `_all`?");
+  });
+
+  test("存在しない列はエラー", () => {
+    const fn = () =>
+      groupByFunc(getExtendedMockControllerUtil(), {
+        by: "住所",
+        _count: { 存在しない列: true },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("false のキーでも未知キーはエラー", () => {
+    const fn = () =>
+      groupByLoose(getExtendedMockControllerUtil(), {
+        by: "住所",
+        _count: { _al: false, _all: true },
+      });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("_count: {} はエラー", () => {
+    const fn = () =>
+      groupByFunc(getExtendedMockControllerUtil(), {
+        by: "住所",
+        _count: {},
+      });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Expected a non-empty object");
+  });
+
+  test("falsy のみはエラー(truthy が1つ必要)", () => {
+    const fn = () =>
+      groupByLoose(getExtendedMockControllerUtil(), {
+        by: "住所",
+        _count: { 名前: false },
+      });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Expected at least one truthy value");
+  });
+
+  test("truthy と falsy の混在は falsy キーを結果から除外する", () => {
+    const result = groupByLoose(getNullableMockControllerUtil(), {
+      by: "カテゴリ",
+      _count: { メモ: false, _all: true },
+    });
+    expectArrayToEqualIgnoringOrder(result, [
+      { カテゴリ: "a", _count: { _all: 2 } },
+      { カテゴリ: "b", _count: { _all: 1 } },
+    ]);
+  });
+
+  test("ignore された列は _count できない", () => {
+    const util = {
+      ...getNullableMockControllerUtil(),
+      whereValidation: { ignoredFields: ["メモ"], relationNames: [] },
+    };
+    const fn = () =>
+      groupByFunc(util, { by: "カテゴリ", _count: { メモ: true } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("_count: true はグループごとの行数を数値で返す", () => {
+    const result = groupByFunc(getNullableMockControllerUtil(), {
+      by: "カテゴリ",
+      _count: true,
+    });
+    expectArrayToEqualIgnoringOrder(result, [
+      { カテゴリ: "a", _count: 2 },
+      { カテゴリ: "b", _count: 1 },
+    ]);
+  });
+
+  test("_all と列名の指定は従来どおり集計する", () => {
+    const result = groupByFunc(getNullableMockControllerUtil(), {
+      by: "カテゴリ",
+      _count: { _all: true, メモ: true },
+    });
+    expectArrayToEqualIgnoringOrder(result, [
+      { カテゴリ: "a", _count: { _all: 2, メモ: 1 } },
+      { カテゴリ: "b", _count: { _all: 1, メモ: 1 } },
+    ]);
+  });
+});
+
+describe("GassmaController 経由の groupBy _count キー検証", () => {
+  test("typo キーは偽のゼロでなくエラー", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    const loose: any = users;
+    const fn = () => loose.groupBy({ by: ["name"], _count: { nmae: true } });
+    expect(fn).toThrow(GassmaUnknownArgumentError);
+    expect(fn).toThrow("Unknown argument `nmae`. Did you mean `name`?");
+  });
+
+  test("正しい列名は従来どおり集計する", () => {
+    const users = sheetOf(buildTestClient(), "Users");
+    const result = users.groupBy({ by: ["name"], _count: { _all: true } });
+    expect(Array.isArray(result)).toBe(true);
+    (result as any[]).forEach((row) => {
+      expect(row._count).toEqual({ _all: 1 });
+    });
+  });
+});

--- a/src/util/aggregate/aggregate.ts
+++ b/src/util/aggregate/aggregate.ts
@@ -6,6 +6,7 @@ import { getAvg } from "./aggregateUtil/avg";
 import { getCount } from "./aggregateUtil/count";
 import { getMax } from "./aggregateUtil/max";
 import { getMin } from "./aggregateUtil/min";
+import { buildValidatedCountSelect } from "../validate/buildValidatedCountSelect";
 import { getSum } from "./aggregateUtil/sum";
 import { ensureAggregateSelection } from "./ensureAggregateSelection";
 
@@ -21,7 +22,11 @@ const aggregateFunc = (
   const skip = "skip" in aggregateData ? aggregateData.skip : null;
   const cursor = "cursor" in aggregateData ? aggregateData.cursor : null;
   const avg = "_avg" in aggregateData ? aggregateData._avg : null;
-  const count = "_count" in aggregateData ? aggregateData._count : null;
+  const rawCount = "_count" in aggregateData ? aggregateData._count : null;
+  const count =
+    typeof rawCount === "object" && rawCount !== null
+      ? buildValidatedCountSelect(gassmaControllerUtil, rawCount)
+      : rawCount;
   const max = "_max" in aggregateData ? aggregateData._max : null;
   const min = "_min" in aggregateData ? aggregateData._min : null;
   const sum = "_sum" in aggregateData ? aggregateData._sum : null;

--- a/src/util/count/count.ts
+++ b/src/util/count/count.ts
@@ -2,9 +2,8 @@ import type { CountData } from "../../types/countType";
 import type { FindData } from "../../types/findTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import { getCount } from "../aggregate/aggregateUtil/count";
-import { getTitle } from "../core/getTitle";
 import { findManyFunc } from "../find/findMany";
-import { validateCountSelect } from "../validate/validateCountSelect";
+import { buildValidatedCountSelect } from "../validate/buildValidatedCountSelect";
 
 const countFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
@@ -17,15 +16,7 @@ const countFunc = (
 
   if (select === undefined || select === true) return rows.length;
 
-  const titles = getTitle(gassmaControllerUtil);
-  const ignoredFields =
-    gassmaControllerUtil.whereValidation?.ignoredFields ?? [];
-  const truthyKeys = validateCountSelect(select, titles, ignoredFields);
-
-  const truthySelect: Record<string, true> = {};
-  truthyKeys.forEach((key) => {
-    truthySelect[key] = true;
-  });
+  const truthySelect = buildValidatedCountSelect(gassmaControllerUtil, select);
 
   return getCount(rows, truthySelect);
 };

--- a/src/util/groupby/groupby.ts
+++ b/src/util/groupby/groupby.ts
@@ -8,6 +8,7 @@ import { getMax } from "../aggregate/aggregateUtil/max";
 import { getMin } from "../aggregate/aggregateUtil/min";
 import { getSum } from "../aggregate/aggregateUtil/sum";
 import { findManyFunc } from "../find/findMany";
+import { buildValidatedCountSelect } from "../validate/buildValidatedCountSelect";
 import { byClassification } from "./groubyUtil/by";
 import { havingFilter } from "./groubyUtil/having";
 
@@ -20,7 +21,11 @@ const groupByFunc = (
   const take = "take" in groupByData ? groupByData.take : null;
   const skip = groupByData.skip || null;
   const avg = groupByData._avg || null;
-  const count = groupByData._count || null;
+  const rawCount = groupByData._count ?? null;
+  const count =
+    typeof rawCount === "object" && rawCount !== null
+      ? buildValidatedCountSelect(gassmaControllerUtil, rawCount)
+      : rawCount;
   const max = groupByData._max || null;
   const min = groupByData._min || null;
   const sum = groupByData._sum || null;

--- a/src/util/validate/buildValidatedCountSelect.ts
+++ b/src/util/validate/buildValidatedCountSelect.ts
@@ -1,0 +1,23 @@
+import type { CountAggregateSelect } from "../../types/countType";
+import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
+import { getTitle } from "../core/getTitle";
+import { validateCountSelect } from "./validateCountSelect";
+
+const buildValidatedCountSelect = (
+  gassmaControllerUtil: GassmaControllerUtil,
+  select: CountAggregateSelect,
+): Record<string, true> => {
+  const titles = getTitle(gassmaControllerUtil);
+  const ignoredFields =
+    gassmaControllerUtil.whereValidation?.ignoredFields ?? [];
+  const truthyKeys = validateCountSelect(select, titles, ignoredFields);
+
+  const truthySelect: Record<string, true> = {};
+  truthyKeys.forEach((key) => {
+    truthySelect[key] = true;
+  });
+
+  return truthySelect;
+};
+
+export { buildValidatedCountSelect };


### PR DESCRIPTION
#201 で `count({ select })` にキー検証を入れた結果、**同じ形なのに `count` は落ちて `aggregate` は落ちない**という不整合が生じていました。その解消です。

## 問題

`_count` の中は**何を書いても通り、`0` が返ります**。

```js
aggregate({ _count: { _all: true } })   // → { _count: { _all: 2 } }   正しい綴り
aggregate({ _count: { _al: true } })    // → { _count: { _al: 0 } }    typo。素通り
aggregate({ _count: { nmae: true } })   // → { _count: { nmae: 0 } }   列名の typo も同じ
groupBy({ by: "住所", _count: { _al: true } })
// → [{"住所":"Tokyo","_count":{"_al":0}}, ...]   全グループが 0
```

**`0` が返るのが厄介**です。「条件に合う行が0件だった」という**正当な結果に見える**ため、フィルタと組み合わせていれば疑う理由がありません。同じ typo でも `_sum` は `null` を返すので、まだ「集計できていない」と気づけます。

#201 の後は、こうなっていました。

```
count({ select: { _al: true } })      → Unknown argument `_al`. Did you mean `_all`?
aggregate({ _count: { _al: true } })  → { _count: { _al: 0 } }
```

## 修正

**#201 が作った `validateCountSelect` を無改変でそのまま再利用**しています。

```
Unknown argument `_al`. Did you mean `_all`?
Unknown argument `nmae`. Did you mean `name`?
```

`aggregate` と `groupBy` は `getCount` をそれぞれ別経路で呼ぶため、2箇所に差し込んでいます(`groupBy` はグループのループの外で1回だけ)。`count` 側と重複していたロジックはヘルパーに抽出しました(`count.ts` は挙動不変で正味 -11行)。

## Prisma と実行時挙動が完全に一致していました

`count` の `select` と `aggregate` / `groupBy` の `_count` は、**エラーメッセージまで同一**であることを実測しました。

| 入力 | Prisma |
|---|---|
| `_count: {}`(単独 / `_sum` 同居とも) | エラー「must not be empty」 |
| `_count: { str: false }`(falsy のみ) | エラー「needs at least one truthy value」 |
| `_count: { nmae: true }` / `{ _al: true }` | エラー「Unknown field」 |
| **`_count: { nmae: false, _all: true }`** | **エラー**(falsy でも未知キーは検査される) |
| `_count: { str: false, num: true }` | OK。**falsy キーは結果から除外** |

#201 で「未実測なので実装時に確認推奨」と申し送りになっていた **`_sum` と同居した場合**も確認し、**同居に関係なく `_count` 単体で検証される**ことが分かりました。差が無かったので検証ロジックは無改変で流用しています。

## 検証結果

- `npm test`: **2,510件 全 green**(2,483 → +27、**既存テストの変更0件**)
- **往復回数の契約テスト**: 3スイート29件 green。`perCallReadCache` の「aggregate は3往復」「groupBy は3往復」が変更後も通っており、**見出し読みが増えていない**実証になっています(`getTitle` は読みキャッシュ内で `findManyFunc` の読みにヒットします)
- `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル57件)pass

before / after は同一スクリプトを main と本ブランチで実行して比較しています。正常系(`_count: true` / `_all` / 正しい列名 / `_count` 未指定 / `_count: false`)が**すべて main と一致**することも確認済みです。

## 判断が要る点

**`_count: {}` 単独は従来どおり `GassmaAggregateSelectionRequiredError`(#183)のまま**です。Prisma は select エラーを出しますが、どちらにせよエラーで結果は一致するため、#183 で固定した既存挙動を優先しました。

## `_sum` / `_avg` / `_max` / `_min` について(調査のみ・未実装)

同じ typo で `null` が返る問題が残っています。調査した結果、**流用は可能ですが仕様判断が2点**あります。

Prisma の実測では4系統とも未知キーはエラーですが、**許可キーが系統別**でした。`_all` は使えず、さらに **`_sum` / `_avg` は数値列のみ**(`_sum: { str: true }` は Unknown field)、`_max` / `_min` は全列可です。

- **障害1**: 「数値列のみ」は**本体が列の型情報を持たないため実行時に判定できません**。「全列許可(型チェックは cli の生成型に委ねる)」に緩める判断が要ります
- **障害2**: 既存テスト(`aggregateSelectionRequired.test.ts`)が「`_avg: {}` は有効な `_count` と同居なら素通りして `{_avg: {}}` を返す」を固定しています。**Prisma は同じケースでエラー**(実測済み)なので、実装するとこのテストの期待値変更が必要です

規模は本 PR と同程度です。着手するかご判断ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)