### PR TITLE
feat: 複数シートに書く操作をバッファして部分書き込みを防ぐ

### DIFF
--- a/src/__test__/util/read/perCallReadCache.test.ts
+++ b/src/__test__/util/read/perCallReadCache.test.ts
@@ -307,10 +307,10 @@ describe("書き込み経路の鮮度(キャッシュを持ち込まない)", ()
     );
   });
 
-  test("Cascade update の読み往復数はキャッシュが効いた値まで下がらない", () => {
+  test("Cascade update の読みはシートごとのスナップショット読みに集約される", () => {
     const env = buildEnv(cascadeRelations);
     sheetOf(env.client, "Users").update({ where: { id: 1 }, data: { id: 10 } });
-    expect(env.totalTrips()).toBe(14);
+    expect(env.totalTrips()).toBe(4);
   });
 
   test("$transaction 内の findMany → update → findMany で2回目は新しい値を返す", () => {

--- a/src/__test__/util/relation/manyToManyWriteRoundTrips.test.ts
+++ b/src/__test__/util/relation/manyToManyWriteRoundTrips.test.ts
@@ -233,7 +233,7 @@ describe("manyToMany set のシート往復回数", () => {
       ...setWheres(20).map((w) => [1, w.id]),
     ]);
     expect([1, 3, 5, 20].map((k) => runSetScenario(k).trips)).toEqual([
-      19, 19, 19, 19,
+      10, 10, 10, 10,
     ]);
   });
 });
@@ -286,7 +286,7 @@ describe("manyToMany create のシート往復回数", () => {
       "25",
     );
     expect([1, 3, 5, 20].map((k) => runCreateScenario(k).trips)).toEqual([
-      9, 9, 9, 9,
+      12, 12, 12, 12,
     ]);
   });
 });

--- a/src/__test__/util/write/internalWriteBuffer.test.ts
+++ b/src/__test__/util/write/internalWriteBuffer.test.ts
@@ -1,0 +1,348 @@
+import { GassmaClient } from "../../../gassma";
+import { GassmaController } from "../../../gassmaController";
+import type { RelationsConfig } from "../../../types/relationTypes";
+import {
+  clearGasGlobals,
+  makeLoggedSheet,
+} from "../transaction/transactionTestClient";
+
+type ObservedSheet = {
+  sheet: any;
+  snapshot: () => unknown[][];
+  trips: () => number;
+  multiRowReads: () => number;
+  reset: () => void;
+};
+
+const makeObservedSheet = (
+  name: string,
+  initial: unknown[][],
+): ObservedSheet => {
+  const logged = makeLoggedSheet(name, initial);
+  const base: any = logged.sheet;
+  let trips = 0;
+  let multiRowReads = 0;
+  const sheet: any = {
+    ...base,
+    getLastRow: () => {
+      trips += 1;
+      return base.getLastRow();
+    },
+    getRange: (row: number, col: number, numRows: number, numCols: number) => {
+      const range = base.getRange(row, col, numRows, numCols);
+      return {
+        ...range,
+        getValues: () => {
+          trips += 1;
+          if (numRows > 1) multiRowReads += 1;
+          return range.getValues();
+        },
+        setValues: (values: unknown[][]) => {
+          trips += 1;
+          range.setValues(values);
+        },
+      };
+    },
+    deleteRow: (rowIndex: number) => {
+      trips += 1;
+      base.deleteRow(rowIndex);
+    },
+    deleteRows: (rowPosition: number, howMany: number) => {
+      trips += 1;
+      base.deleteRows(rowPosition, howMany);
+    },
+  };
+  return {
+    sheet,
+    snapshot: logged.snapshot,
+    trips: () => trips,
+    multiRowReads: () => multiRowReads,
+    reset: () => {
+      trips = 0;
+      multiRowReads = 0;
+    },
+  };
+};
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!(controller instanceof GassmaController)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+const usersInitial: unknown[][] = [
+  ["id", "name", "age"],
+  [1, "Alice", 20],
+  [2, "Bob", 30],
+];
+
+const postsInitial: unknown[][] = [
+  ["id", "authorId", "title"],
+  [101, 1, "Post A"],
+  [102, 2, "Post B"],
+];
+
+const commentsInitial: unknown[][] = [
+  ["id", "postId", "body"],
+  [1001, 101, "C1"],
+];
+
+const defaultRelations: RelationsConfig = {
+  Users: {
+    posts: {
+      type: "oneToMany",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+    },
+  },
+  Posts: {
+    author: {
+      type: "manyToOne",
+      to: "Users",
+      field: "authorId",
+      reference: "id",
+    },
+    comments: {
+      type: "oneToMany",
+      to: "Comments",
+      field: "id",
+      reference: "postId",
+    },
+  },
+  Comments: {
+    post: {
+      type: "manyToOne",
+      to: "Posts",
+      field: "postId",
+      reference: "id",
+    },
+  },
+};
+
+type Env = {
+  client: GassmaClient;
+  users: ObservedSheet;
+  posts: ObservedSheet;
+  comments: ObservedSheet;
+};
+
+const buildEnv = (relations: RelationsConfig = defaultRelations): Env => {
+  const users = makeObservedSheet("Users", usersInitial);
+  const posts = makeObservedSheet("Posts", postsInitial);
+  const comments = makeObservedSheet("Comments", commentsInitial);
+  const sheets = [users.sheet, posts.sheet, comments.sheet];
+  const spreadsheet: any = {
+    getId: () => "internal-buffer-test",
+    getSheets: () => sheets,
+    getSheetByName: (n: string) =>
+      sheets.find((s: any) => s.getName() === n) ?? null,
+  };
+  const propsStore: Record<string, string> = {};
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => spreadsheet },
+    LockService: {
+      getScriptLock: () => ({ waitLock: () => {}, releaseLock: () => {} }),
+    },
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getProperty: (key: string) => propsStore[key] ?? null,
+        setProperty: (key: string, value: string) => {
+          propsStore[key] = value;
+        },
+        deleteProperty: (key: string) => {
+          delete propsStore[key];
+        },
+        getKeys: () => Object.keys(propsStore),
+      }),
+    },
+  });
+  const client = new GassmaClient({ relations });
+  users.reset();
+  posts.reset();
+  comments.reset();
+  return { client, users, posts, comments };
+};
+
+const anyData = (value: unknown): any => value;
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+describe("nested write のエラー時に1行も書かれない", () => {
+  it("子の typo で親 Users も書かれない", () => {
+    const env = buildEnv();
+    expect(() =>
+      sheetOf(env.client, "Users").create({
+        data: {
+          id: 3,
+          name: "Carol",
+          age: 40,
+          posts: anyData({ create: [{ id: 103, titel: "typo" }] }),
+        },
+      }),
+    ).toThrow();
+    expect(env.users.snapshot()).toEqual(usersInitial);
+    expect(env.posts.snapshot()).toEqual(postsInitial);
+  });
+
+  it("孫(3段ネスト)の typo で親も子も書かれない", () => {
+    const env = buildEnv();
+    expect(() =>
+      sheetOf(env.client, "Users").create({
+        data: {
+          id: 3,
+          name: "Carol",
+          age: 40,
+          posts: anyData({
+            create: [
+              {
+                id: 103,
+                title: "ok",
+                comments: { create: [{ id: 1002, bodi: "typo" }] },
+              },
+            ],
+          }),
+        },
+      }),
+    ).toThrow();
+    expect(env.users.snapshot()).toEqual(usersInitial);
+    expect(env.posts.snapshot()).toEqual(postsInitial);
+    expect(env.comments.snapshot()).toEqual(commentsInitial);
+  });
+
+  it("connect 先が不在なら親 Users も書かれない", () => {
+    const env = buildEnv();
+    expect(() =>
+      sheetOf(env.client, "Users").create({
+        data: {
+          id: 3,
+          name: "Carol",
+          age: 40,
+          posts: anyData({ connect: [{ id: 99999 }] }),
+        },
+      }),
+    ).toThrow();
+    expect(env.users.snapshot()).toEqual(usersInitial);
+    expect(env.posts.snapshot()).toEqual(postsInitial);
+  });
+
+  it("update のスカラー + nested 失敗で name も書き換わらない", () => {
+    const env = buildEnv();
+    expect(() =>
+      sheetOf(env.client, "Users").update({
+        where: { id: 1 },
+        data: {
+          name: "Changed",
+          age: 99,
+          posts: anyData({ connect: [{ id: 102 }, { id: 99999 }] }),
+        },
+      }),
+    ).toThrow();
+    expect(env.users.snapshot()).toEqual(usersInitial);
+    expect(env.posts.snapshot()).toEqual(postsInitial);
+  });
+
+  it("成功時は nested write の結果がシートに反映される", () => {
+    const env = buildEnv();
+    const result = sheetOf(env.client, "Users").create({
+      data: {
+        id: 3,
+        name: "Carol",
+        age: 40,
+        posts: anyData({ create: [{ id: 103, title: "ok" }] }),
+      },
+    });
+    expect(result).toEqual({ id: 3, name: "Carol", age: 40 });
+    expect(env.users.snapshot()).toEqual([...usersInitial, [3, "Carol", 40]]);
+    expect(env.posts.snapshot()).toEqual([...postsInitial, [103, 3, "ok"]]);
+  });
+});
+
+describe("リレーションが絡まない操作はバッファを通らない", () => {
+  it("単純 create は複数行読み(スナップショット)を発生させない", () => {
+    const env = buildEnv();
+    sheetOf(env.client, "Users").create({
+      data: { id: 3, name: "Carol", age: 40 },
+    });
+    expect(env.users.multiRowReads()).toBe(0);
+    expect(env.users.snapshot()).toEqual([...usersInitial, [3, "Carol", 40]]);
+  });
+
+  it("cascade しない単純 update の往復回数は従来どおり", () => {
+    const env = buildEnv();
+    sheetOf(env.client, "Users").update({
+      where: { id: 1 },
+      data: { name: "Renamed" },
+    });
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Renamed", 20],
+      [2, "Bob", 30],
+    ]);
+    expect(env.users.trips()).toBe(8);
+    expect(env.posts.trips()).toBe(0);
+  });
+
+  it("cascade を持たないシートの delete の往復回数は従来どおり", () => {
+    const env = buildEnv();
+    sheetOf(env.client, "Comments").delete({ where: { id: 1001 } });
+    expect(env.comments.snapshot()).toEqual([["id", "postId", "body"]]);
+    expect(env.comments.trips()).toBe(8);
+  });
+});
+
+describe("$transaction との相乗り", () => {
+  it("tx 内の nested write は tx バッファに乗り、rollback で消える", () => {
+    const env = buildEnv();
+    expect(() =>
+      env.client.$transaction((tx) => {
+        const users: any = Object.assign<Record<string, unknown>, object>(
+          {},
+          tx,
+        ).Users;
+        users.create({
+          data: {
+            id: 3,
+            name: "Carol",
+            age: 40,
+            posts: anyData({ create: [{ id: 103, title: "ok" }] }),
+          },
+        });
+        throw new Error("rollback");
+      }),
+    ).toThrow("rollback");
+    expect(env.users.snapshot()).toEqual(usersInitial);
+    expect(env.posts.snapshot()).toEqual(postsInitial);
+  });
+
+  it("tx 内の nested write は commit で1回だけ書かれる", () => {
+    const env = buildEnv();
+    env.client.$transaction(
+      (tx) => {
+        const users: any = Object.assign<Record<string, unknown>, object>(
+          {},
+          tx,
+        ).Users;
+        users.create({
+          data: {
+            id: 3,
+            name: "Carol",
+            age: 40,
+            posts: anyData({ create: [{ id: 103, title: "ok" }] }),
+          },
+        });
+      },
+      { rollback: false },
+    );
+    expect(env.users.snapshot()).toEqual([...usersInitial, [3, "Carol", 40]]);
+    expect(env.posts.snapshot()).toEqual([...postsInitial, [103, 3, "ok"]]);
+  });
+});

--- a/src/__test__/util/write/writeBufferGate.test.ts
+++ b/src/__test__/util/write/writeBufferGate.test.ts
@@ -1,0 +1,248 @@
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../../types/relationTypes";
+import { raw } from "../../../util/raw/raw";
+import {
+  shouldBufferCreate,
+  shouldBufferDelete,
+  shouldBufferUpdate,
+  shouldBufferUpdateMany,
+  shouldBufferUpsert,
+} from "../../../util/write/writeBufferGate";
+
+const contextOf = (
+  relations: Record<string, RelationDefinition>,
+): RelationContext => ({
+  relations,
+  findManyOnSheet: () => [],
+});
+
+const postsOneToMany = (
+  extra?: Partial<RelationDefinition>,
+): Record<string, RelationDefinition> => ({
+  posts: {
+    type: "oneToMany",
+    to: "Posts",
+    field: "id",
+    reference: "authorId",
+    ...extra,
+  },
+});
+
+describe("shouldBufferCreate", () => {
+  it("relationContext が無ければ false", () => {
+    expect(shouldBufferCreate(null, { posts: { create: [] } })).toBe(false);
+  });
+
+  it("nested write が無ければ false", () => {
+    const context = contextOf(postsOneToMany());
+    expect(shouldBufferCreate(context, { id: 1, name: "A" })).toBe(false);
+  });
+
+  it("relation 名のキーが nested write オブジェクトなら true", () => {
+    const context = contextOf(postsOneToMany());
+    expect(
+      shouldBufferCreate(context, { id: 1, posts: { create: [{ id: 2 }] } }),
+    ).toBe(true);
+  });
+
+  it("relation 名でも値がスカラーなら false", () => {
+    const context = contextOf(postsOneToMany());
+    expect(shouldBufferCreate(context, { id: 1, posts: 5 })).toBe(false);
+  });
+
+  it("relation 名でも値が Date / raw なら false", () => {
+    const context = contextOf(postsOneToMany());
+    expect(shouldBufferCreate(context, { posts: new Date() })).toBe(false);
+    expect(shouldBufferCreate(context, { posts: raw("x") })).toBe(false);
+  });
+
+  it("data が undefined なら false", () => {
+    const context = contextOf(postsOneToMany());
+    expect(shouldBufferCreate(context, undefined)).toBe(false);
+  });
+});
+
+describe("shouldBufferUpdate", () => {
+  it("nested write があれば true", () => {
+    const context = contextOf(postsOneToMany());
+    expect(
+      shouldBufferUpdate(context, { posts: { connect: [{ id: 1 }] } }),
+    ).toBe(true);
+  });
+
+  it("cascade も nested write も無ければ false", () => {
+    const context = contextOf(postsOneToMany());
+    expect(shouldBufferUpdate(context, { id: 9, name: "B" })).toBe(false);
+  });
+
+  it("onUpdate Cascade の field に触れる data なら true", () => {
+    const context = contextOf(postsOneToMany({ onUpdate: "Cascade" }));
+    expect(shouldBufferUpdate(context, { id: 9 })).toBe(true);
+  });
+
+  it("onUpdate Cascade でも field に触れない data なら false", () => {
+    const context = contextOf(postsOneToMany({ onUpdate: "Cascade" }));
+    expect(shouldBufferUpdate(context, { name: "B" })).toBe(false);
+  });
+
+  it("onUpdate SetNull の field に触れる data なら true", () => {
+    const context = contextOf(postsOneToMany({ onUpdate: "SetNull" }));
+    expect(shouldBufferUpdate(context, { id: 9 })).toBe(true);
+  });
+
+  it("onUpdate Restrict は書き込み前に throw するので false", () => {
+    const context = contextOf(postsOneToMany({ onUpdate: "Restrict" }));
+    expect(shouldBufferUpdate(context, { id: 9 })).toBe(false);
+  });
+
+  it("manyToMany の SetNull は resolver がスキップするので false", () => {
+    const context = contextOf({
+      tags: {
+        type: "manyToMany",
+        to: "Tags",
+        field: "id",
+        reference: "id",
+        through: { sheet: "PostTags", field: "postId", reference: "tagId" },
+        onUpdate: "SetNull",
+      },
+    });
+    expect(shouldBufferUpdate(context, { id: 9 })).toBe(false);
+  });
+
+  it("manyToMany の Cascade は through に書くので true", () => {
+    const context = contextOf({
+      tags: {
+        type: "manyToMany",
+        to: "Tags",
+        field: "id",
+        reference: "id",
+        through: { sheet: "PostTags", field: "postId", reference: "tagId" },
+        onUpdate: "Cascade",
+      },
+    });
+    expect(shouldBufferUpdate(context, { id: 9 })).toBe(true);
+  });
+
+  it("manyToOne 側の onUpdate は resolver がスキップするので false", () => {
+    const context = contextOf({
+      author: {
+        type: "manyToOne",
+        to: "Users",
+        field: "authorId",
+        reference: "id",
+        onUpdate: "Cascade",
+      },
+    });
+    expect(shouldBufferUpdate(context, { authorId: 9 })).toBe(false);
+  });
+
+  it("cascade field への数値オペレーションも true", () => {
+    const context = contextOf(postsOneToMany({ onUpdate: "Cascade" }));
+    expect(shouldBufferUpdate(context, { id: { increment: 1 } })).toBe(true);
+  });
+});
+
+describe("shouldBufferUpdateMany", () => {
+  it("cascade field に触れれば true", () => {
+    const context = contextOf(postsOneToMany({ onUpdate: "Cascade" }));
+    expect(shouldBufferUpdateMany(context, { id: 9 })).toBe(true);
+  });
+
+  it("nested write キーは updateMany では書き込み前に拒否されるので false", () => {
+    const context = contextOf(postsOneToMany());
+    expect(
+      shouldBufferUpdateMany(context, { posts: { connect: [{ id: 1 }] } }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldBufferDelete", () => {
+  it("relationContext が無ければ false", () => {
+    expect(shouldBufferDelete(null)).toBe(false);
+  });
+
+  it("onDelete 未指定 / NoAction / Restrict だけなら false", () => {
+    expect(shouldBufferDelete(contextOf(postsOneToMany()))).toBe(false);
+    expect(
+      shouldBufferDelete(contextOf(postsOneToMany({ onDelete: "NoAction" }))),
+    ).toBe(false);
+    expect(
+      shouldBufferDelete(contextOf(postsOneToMany({ onDelete: "Restrict" }))),
+    ).toBe(false);
+  });
+
+  it("oneToMany の Cascade / SetNull は true", () => {
+    expect(
+      shouldBufferDelete(contextOf(postsOneToMany({ onDelete: "Cascade" }))),
+    ).toBe(true);
+    expect(
+      shouldBufferDelete(contextOf(postsOneToMany({ onDelete: "SetNull" }))),
+    ).toBe(true);
+  });
+
+  it("manyToMany は Cascade のみ true(SetNull はスキップされる)", () => {
+    const m2m = (onDelete: "Cascade" | "SetNull") =>
+      contextOf({
+        tags: {
+          type: "manyToMany",
+          to: "Tags",
+          field: "id",
+          reference: "id",
+          through: { sheet: "PostTags", field: "postId", reference: "tagId" },
+          onDelete,
+        },
+      });
+    expect(shouldBufferDelete(m2m("Cascade"))).toBe(true);
+    expect(shouldBufferDelete(m2m("SetNull"))).toBe(false);
+  });
+
+  it("manyToOne 側の onDelete は resolver がスキップするので false", () => {
+    const context = contextOf({
+      author: {
+        type: "manyToOne",
+        to: "Users",
+        field: "authorId",
+        reference: "id",
+        onDelete: "Cascade",
+      },
+    });
+    expect(shouldBufferDelete(context)).toBe(false);
+  });
+});
+
+describe("shouldBufferUpsert", () => {
+  const context = () => contextOf(postsOneToMany({ onUpdate: "Cascade" }));
+
+  it("create ブランチに nested write があれば true", () => {
+    expect(
+      shouldBufferUpsert(context(), {
+        create: { id: 1, posts: { create: [{ id: 2 }] } },
+        update: { name: "B" },
+      }),
+    ).toBe(true);
+  });
+
+  it("update ブランチが cascade field に触れれば true", () => {
+    expect(
+      shouldBufferUpsert(context(), {
+        create: { id: 1 },
+        update: { id: 9 },
+      }),
+    ).toBe(true);
+  });
+
+  it("どちらのブランチも該当しなければ false", () => {
+    expect(
+      shouldBufferUpsert(context(), {
+        create: { id: 1 },
+        update: { name: "B" },
+      }),
+    ).toBe(false);
+  });
+
+  it("入力が undefined なら false", () => {
+    expect(shouldBufferUpsert(context(), undefined)).toBe(false);
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -92,6 +92,13 @@ import { updateManyFunc } from "./util/update/updateMany";
 import { upsertFunc } from "./util/upsert/upsert";
 import type { SheetWriter } from "./util/write/sheetWriter";
 import { immediateSheetWriter } from "./util/write/sheetWriter";
+import {
+  shouldBufferCreate,
+  shouldBufferDelete,
+  shouldBufferUpdate,
+  shouldBufferUpdateMany,
+  shouldBufferUpsert,
+} from "./util/write/writeBufferGate";
 
 class GassmaController {
   private readonly sheet: GoogleAppsScript.Spreadsheet.Sheet;
@@ -446,7 +453,10 @@ class GassmaController {
   }
 
   public create(createdData: CreateData) {
-    return runWithoutReadCache(() => this.createRaw(createdData));
+    return runWithoutReadCache(
+      () => this.createRaw(createdData),
+      shouldBufferCreate(this.relationContext, createdData?.data),
+    );
   }
 
   private createRaw(createdData: CreateData) {
@@ -876,7 +886,10 @@ class GassmaController {
   }
 
   public update(updateData: UpdateSingleData) {
-    return runWithoutReadCache(() => this.updateRaw(updateData));
+    return runWithoutReadCache(
+      () => this.updateRaw(updateData),
+      shouldBufferUpdate(this.relationContext, updateData?.data),
+    );
   }
 
   private updateRaw(updateData: UpdateSingleData) {
@@ -953,7 +966,10 @@ class GassmaController {
   }
 
   public updateMany(updateData: UpdateData) {
-    return runWithoutReadCache(() => this.updateManyRaw(updateData));
+    return runWithoutReadCache(
+      () => this.updateManyRaw(updateData),
+      shouldBufferUpdateMany(this.relationContext, updateData?.data),
+    );
   }
 
   private updateManyRaw(updateData: UpdateData) {
@@ -1003,7 +1019,10 @@ class GassmaController {
   }
 
   public updateManyAndReturn(updateData: UpdateManyAndReturnData) {
-    return runWithoutReadCache(() => this.updateManyAndReturnRaw(updateData));
+    return runWithoutReadCache(
+      () => this.updateManyAndReturnRaw(updateData),
+      shouldBufferUpdateMany(this.relationContext, updateData?.data),
+    );
   }
 
   private updateManyAndReturnRaw(updateData: UpdateManyAndReturnData) {
@@ -1081,7 +1100,10 @@ class GassmaController {
   }
 
   public upsert(upsertData: UpsertSingleData) {
-    return runWithoutReadCache(() => this.upsertRaw(upsertData));
+    return runWithoutReadCache(
+      () => this.upsertRaw(upsertData),
+      shouldBufferUpsert(this.relationContext, upsertData),
+    );
   }
 
   private upsertRaw(upsertData: UpsertSingleData) {
@@ -1131,7 +1153,10 @@ class GassmaController {
   }
 
   public delete(deleteData: DeleteSingleData) {
-    return runWithoutReadCache(() => this.deleteRaw(deleteData));
+    return runWithoutReadCache(
+      () => this.deleteRaw(deleteData),
+      shouldBufferDelete(this.relationContext),
+    );
   }
 
   private deleteRaw(deleteData: DeleteSingleData) {
@@ -1167,7 +1192,10 @@ class GassmaController {
   }
 
   public deleteMany(deleteData: DeleteData = {}) {
-    return runWithoutReadCache(() => this.deleteManyRaw(deleteData));
+    return runWithoutReadCache(
+      () => this.deleteManyRaw(deleteData),
+      shouldBufferDelete(this.relationContext),
+    );
   }
 
   private deleteManyRaw(deleteData: DeleteData) {

--- a/src/util/read/readCacheContext.ts
+++ b/src/util/read/readCacheContext.ts
@@ -1,4 +1,10 @@
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
+import {
+  applyInternalWriteBuffer,
+  closeInternalWriteBuffer,
+  flushInternalWriteBuffer,
+  openInternalWriteBuffer,
+} from "../write/internalWriteBuffer";
 import { resolveWriter } from "../write/sheetWriter";
 import type { SheetReadCache } from "./cachedSheetReader";
 import { createSheetReadCache } from "./cachedSheetReader";
@@ -17,22 +23,28 @@ const runWithReadCache = <T>(fn: () => T): T => {
   }
 };
 
-const runWithoutReadCache = <T>(fn: () => T): T => {
+const runWithoutReadCache = <T>(fn: () => T, buffered = false): T => {
   if (activeCache) activeCache.clear();
+  const isOutermost = writeDepth === 0;
+  if (isOutermost && buffered) openInternalWriteBuffer();
   writeDepth += 1;
   try {
-    return fn();
+    const result = fn();
+    if (isOutermost) flushInternalWriteBuffer();
+    return result;
   } finally {
     writeDepth -= 1;
+    if (isOutermost) closeInternalWriteBuffer();
   }
 };
 
 const applyReadCache = (util: GassmaControllerUtil): GassmaControllerUtil => {
-  if (!activeCache || writeDepth > 0) return util;
+  const base = applyInternalWriteBuffer(util);
+  if (!activeCache || writeDepth > 0) return base;
   return {
-    ...util,
-    reader: activeCache.wrapReader(resolveReader(util.reader)),
-    writer: activeCache.wrapWriter(resolveWriter(util.writer)),
+    ...base,
+    reader: activeCache.wrapReader(resolveReader(base.reader)),
+    writer: activeCache.wrapWriter(resolveWriter(base.writer)),
   };
 };
 

--- a/src/util/write/internalWriteBuffer.ts
+++ b/src/util/write/internalWriteBuffer.ts
@@ -1,0 +1,37 @@
+import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
+import type { TransactionBuffer } from "../transaction/transactionBuffer";
+import { createTransactionBuffer } from "../transaction/transactionBuffer";
+import { immediateSheetWriter, resolveWriter } from "./sheetWriter";
+
+let activeBuffer: TransactionBuffer | null = null;
+
+const openInternalWriteBuffer = (): void => {
+  activeBuffer = createTransactionBuffer();
+};
+
+const flushInternalWriteBuffer = (): void => {
+  activeBuffer?.flush();
+};
+
+const closeInternalWriteBuffer = (): void => {
+  activeBuffer = null;
+};
+
+const applyInternalWriteBuffer = (
+  util: GassmaControllerUtil,
+): GassmaControllerUtil => {
+  if (!activeBuffer) return util;
+  if (resolveWriter(util.writer) !== immediateSheetWriter) return util;
+  return {
+    ...util,
+    reader: activeBuffer.reader,
+    writer: activeBuffer.writer,
+  };
+};
+
+export {
+  applyInternalWriteBuffer,
+  closeInternalWriteBuffer,
+  flushInternalWriteBuffer,
+  openInternalWriteBuffer,
+};

--- a/src/util/write/writeBufferGate.ts
+++ b/src/util/write/writeBufferGate.ts
@@ -1,0 +1,82 @@
+import type {
+  RelationContext,
+  RelationDefinition,
+} from "../../types/relationTypes";
+import { isDateValue } from "../other/isDateValue";
+import { isDict } from "../other/isDict";
+import { isRawValue } from "../raw/raw";
+
+type UpsertBranches = { create?: unknown; update?: unknown };
+
+const isNestedWriteValue = (value: unknown): boolean =>
+  isDict(value) && !isDateValue(value) && !isRawValue(value);
+
+const hasNestedWrite = (
+  data: unknown,
+  relations: { [relationName: string]: RelationDefinition },
+): boolean => {
+  if (!isDict(data)) return false;
+  const relationNames = Object.keys(relations);
+  return Object.entries(data).some(
+    ([key, value]) => relationNames.includes(key) && isNestedWriteValue(value),
+  );
+};
+
+const writesToOtherSheet = (
+  relation: RelationDefinition,
+  action: "Cascade" | "SetNull" | "Restrict" | "NoAction" | undefined,
+): boolean => {
+  if (relation.type === "manyToOne") return false;
+  if (action === "Cascade") return true;
+  return action === "SetNull" && relation.type !== "manyToMany";
+};
+
+const touchesCascadeField = (
+  context: RelationContext,
+  data: unknown,
+): boolean => {
+  if (!isDict(data)) return false;
+  const dataKeys = Object.keys(data);
+  return Object.values(context.relations).some(
+    (relation) =>
+      writesToOtherSheet(relation, relation.onUpdate) &&
+      dataKeys.includes(relation.field),
+  );
+};
+
+const shouldBufferCreate = (
+  context: RelationContext | null,
+  data: unknown,
+): boolean => context !== null && hasNestedWrite(data, context.relations);
+
+const shouldBufferUpdateMany = (
+  context: RelationContext | null,
+  data: unknown,
+): boolean => context !== null && touchesCascadeField(context, data);
+
+const shouldBufferUpdate = (
+  context: RelationContext | null,
+  data: unknown,
+): boolean =>
+  shouldBufferCreate(context, data) || shouldBufferUpdateMany(context, data);
+
+const shouldBufferDelete = (context: RelationContext | null): boolean =>
+  context !== null &&
+  Object.values(context.relations).some((relation) =>
+    writesToOtherSheet(relation, relation.onDelete),
+  );
+
+const shouldBufferUpsert = (
+  context: RelationContext | null,
+  upsertData: UpsertBranches | undefined,
+): boolean =>
+  shouldBufferCreate(context, upsertData?.create) ||
+  shouldBufferUpdate(context, upsertData?.update);
+
+export {
+  shouldBufferCreate,
+  shouldBufferDelete,
+  shouldBufferUpdate,
+  shouldBufferUpdateMany,
+  shouldBufferUpsert,
+};


### PR DESCRIPTION
nested write が途中で失敗したときに**一部だけ書かれて残る**問題への対応です。

## 問題

エラーは正しく投げられるのに、**その前に書かれた分が残ります**。

```js
users.create({ data: { id: 1, name: "A", posts: { create: [{ titel: "x" }] } } })
// → 子で正しくエラーになるが、親 Users は既に書かれて残る

users.update({ where: { id: 1 }, data: { name: "Changed", posts: { connect: [{ id: 999 }] } } })
// → connect 先が無いのでエラー。しかし name は "Changed" に書き換わったまま
```

**Prisma は nested write 全体を暗黙のトランザクションで包みます。** 実測すると `UPDATE Author SET name='Changed'` を**実際に発行した後で ROLLBACK** し、読み直すと元のままです。

## 方針

既存のトランザクション基盤を内部で使いますが、**ロックもバックアップも取りません**。

**ロックを取らない理由**: GAS の **LockService はライブラリスコープ**です(実機検証済み)。内部で無自覚にロックを取ると、**gassma を使う全利用者のスクリプト横断で直列化**します。利用者が `$transaction` を書いていないのに他人の処理を待つことになります。

**バックアップを取らない理由**: 書き込みはバッファされフラッシュ時に流れるので、**フラッシュ前のエラーなら1行も書かれていません**。ロールバックが必要なのは「書いた後の失敗」だけです。`copyTo` は最も重い部分なので、これを外せる意味は大きいです。

## ゲート — リレーションが絡む操作だけ

**理由は正しさ基準です**(性能のためではありません)。単一シートへの書き込みは #199 / #200 / #203 の事前検証が書き込み前に完了するため、**ロジック起因の部分書き込みが既に起き得ません**。バッファしても買える正しさがゼロで、全グリッド読みと競合窓の拡大だけを支払うことになります。

「他シートへの書き込みが実際に発生し得るか」を**操作別に静的判定**します。

| 操作 | ゲート |
|---|---|
| `create` | data に nested write があるか |
| `update` | nested write **または** カスケードが発火する field に触れているか |
| `updateMany` / `updateManyAndReturn` | カスケード発火のみ(nested write は書き込み前に拒否されるため) |
| `upsert` | 両ブランチの和(どちらに入るかは読みの後にしか分からないため) |
| `delete` / `deleteMany` | `onDelete` の Cascade / SetNull が実際に書く条件と一致 |
| `createMany` / `createManyAndReturn` | **常に非バッファ**(relation キーは書き込み前にエラーになる) |

`Restrict` は書き込み前に throw するので両ゲートから除外しています。**relationContext の有無で判定する最も粗い案より2段細かい**判定です。

## 買えた正しさ(実装前に RED を確認して固定)

```
[子のtypo]           GassmaUnknownArgumentError
[Users 不変]          true                        ← 以前は親が残っていた
[scalar+connect失敗]  NestedWriteConnectNotFoundError
[Alice 行]            [1,"Alice",20]              ← 以前は [1,"Changed",20]
[正常 nested create]  Users=4行 Posts=4行          ← 正常系は両シートに書かれる
```

- 子の typo → 親を含め1行も書かれない
- **孫(3段ネスト)の typo** → Users / Posts / Comments すべて不変
- `connect` 先が不在 → 親が書かれない
- update のスカラー + nested 失敗 → スカラーが書き換わらない

## 往復回数(契約テストの期待値を3件変更)

| シナリオ | 変更前 | 変更後 | |
|---|---|---|---|
| 多対多 `set`(k=1,3,5,20) | 19 | **10** | 読みがシートごと1回に集約された改善 |
| cascade update の読み | 14 | **4** | 同上 |
| 多対多 `create`(k=1,3,5,20) | 9 | **12** | **これが正しさの対価**(スナップショット読み) |

`titleRowReadTrips` は**期待値変更なしで通過**しています。リレーションを持たないクライアントの書き込みが完全に従来経路であることの証拠です。

`perCallReadCache` のテスト名が実態と合わなくなったため改名しました(「キャッシュが効いた値まで下がらない」→「シートごとのスナップショット読みに集約される」)。**鮮度の意図は隣の「Cascade update でも子シートが追従し一時値が残らない」が担保**しており、そちらは無変更で通過しています。

## 実装

- `src/util/write/writeBufferGate.ts`(新規82行): ゲート述語(純関数)
- `src/util/write/internalWriteBuffer.ts`(新規37行): バッファ保持
- `src/util/read/readCacheContext.ts`(+12行): writeDepth 0→1 の最外殻のみ open、成功時 flush
- `src/gassmaController.ts`: 公開メソッド7箇所に引数を追加(各1行)。**ロジックは書いていません**

`$transaction` 内では writer が別インスタンスなので**自動的にスキップして外側のバッファに相乗り**します。nested の再帰は既存の `writeDepth` が最外殻を判定するので追加の仕組みは不要でした。

## 検証結果

- `npm test`: **2,520件 全 green**(2,483 → +37。既存テストは**上記3件の期待値変更以外すべて無変更**)
- 往復契約テスト3スイート29件 green
- `$transaction` / `$extends` 129件、`Gassma.raw` 45件、autoincrement 25件すべて通過
- `tsc --noEmit` / lint(警告は既存と同数)/ format / `verify:bundle`(**公開シンボル57件で増減なし**)pass

## 守れない範囲(明示)

- **フラッシュ中の GAS API 失敗**では部分書き込みが残ります。ただし残留の形は現状の直接書き込みと同じ op 列の接頭辞で、**現状より悪くはなりません**
- **autoincrement のカウンタ**は ScriptProperties にあり巻き戻せません(Prisma のシーケンスも同じ)
- **同時実行の競合**

## 判断が要る点 — 競合の窓が広がります

**これは性能ではなく、別の正しさとのトレードオフです。**

`updateRow` / `deleteRow` の行番号はスナップショット時点で確定し、フラッシュまで持ち越されます。従来 cascade update は「読み→書き→読み→書き」と進むため途中で他者の書き込みを拾い得ましたが、バッファ後は**操作開始時点の像に対して全計画を立て、最後にまとめて書く**ため、操作中に他者が同じシートを書くと丸ごと上書きし得ます。

`$transaction` の flush と同じ性質で、ロックを取らない以上は構造的に避けられません。**限定適用によって、この窓を「本当に正しさを買える操作」だけに絞っています。**

なお `appendRows` はフラッシュ時に `getLastRow()` を取り直すため、追記同士の競合には**現状より安全**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)