### PR TITLE
fix: isNot の結果に「関連が無い行」を含める

### DIFF
--- a/src/__test__/util/relation/whereRelation/filters/isNotFilter.test.ts
+++ b/src/__test__/util/relation/whereRelation/filters/isNotFilter.test.ts
@@ -17,7 +17,7 @@ describe("applyIsNotFilter", () => {
       reference: "id",
     };
 
-    it("条件に合致するターゲットのキーでnotInフィルタを生成する", () => {
+    it("FK null の行を含めるためNOT+inフィルタを生成する", () => {
       const filterWhere: WhereUse = { name: "Alice" };
 
       mockFindMany.mockReturnValue([{ id: 1, name: "Alice" }]);
@@ -29,10 +29,10 @@ describe("applyIsNotFilter", () => {
         mockFindMany,
       );
 
-      expect(result).toEqual({ authorId: { notIn: [1] } });
+      expect(result).toEqual({ NOT: { authorId: { in: [1] } } });
     });
 
-    it("条件に合致するターゲットがない場合はnotIn: []を返す", () => {
+    it("条件に合致するターゲットがない場合はNOT+in: []を返す", () => {
       const filterWhere: WhereUse = { name: "Unknown" };
       mockFindMany.mockReturnValue([]);
 
@@ -43,7 +43,19 @@ describe("applyIsNotFilter", () => {
         mockFindMany,
       );
 
-      expect(result).toEqual({ authorId: { notIn: [] } });
+      expect(result).toEqual({ NOT: { authorId: { in: [] } } });
+    });
+
+    it("空の条件は全ターゲットキーのNOT+inを返す", () => {
+      mockFindMany.mockReturnValue([
+        { id: 1, name: "Alice" },
+        { id: 2, name: "Bob" },
+      ]);
+
+      const result = applyIsNotFilter(relation, "author", {}, mockFindMany);
+
+      expect(result).toEqual({ NOT: { authorId: { in: [1, 2] } } });
+      expect(mockFindMany).toHaveBeenCalledWith("Users", { where: {} });
     });
   });
 
@@ -55,7 +67,7 @@ describe("applyIsNotFilter", () => {
       reference: "userId",
     };
 
-    it("条件に合致するターゲットのreferenceキーでnotInフィルタを生成する", () => {
+    it("条件に合致するターゲットのreferenceキーでNOT+inフィルタを生成する", () => {
       const filterWhere: WhereUse = { bio: "developer" };
 
       mockFindMany.mockReturnValue([{ id: 1, userId: 10, bio: "developer" }]);
@@ -67,7 +79,7 @@ describe("applyIsNotFilter", () => {
         mockFindMany,
       );
 
-      expect(result).toEqual({ id: { notIn: [10] } });
+      expect(result).toEqual({ NOT: { id: { in: [10] } } });
     });
   });
 

--- a/src/__test__/util/relation/whereRelation/isNotNullFkRow.test.ts
+++ b/src/__test__/util/relation/whereRelation/isNotNullFkRow.test.ts
@@ -1,0 +1,188 @@
+import { GassmaClient } from "../../../../gassma";
+import type { GassmaController } from "../../../../gassmaController";
+import type { RelationsConfig } from "../../../../types/relationTypes";
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => { getValues: () => unknown[][] };
+  getDataRange: () => { getValues: () => unknown[][] };
+};
+
+const makeSheet = (name: string, data: unknown[][]): MockSheet => ({
+  getName: () => name,
+  getLastRow: () => data.length,
+  getLastColumn: () => data[0].length,
+  getRange: (row, col, numRows, numCols) => ({
+    getValues: () =>
+      data
+        .slice(row - 1, row - 1 + numRows)
+        .map((r) => r.slice(col - 1, col - 1 + numCols)),
+  }),
+  getDataRange: () => ({ getValues: () => data }),
+});
+
+const sheets = [
+  makeSheet("Users", [
+    ["id", "name"],
+    [1, "Alice"],
+    [2, "Bob"],
+  ]),
+  makeSheet("Posts", [
+    ["id", "authorId", "title"],
+    [101, 1, "Post A"],
+    [102, "", "Post B"],
+  ]),
+];
+
+const mockSpreadsheet = {
+  getId: () => "test-spreadsheet",
+  getSheets: () => sheets,
+  getSheetByName: (name: string) =>
+    sheets.find((sheet) => sheet.getName() === name) ?? null,
+};
+
+const relations: RelationsConfig = {
+  Users: {
+    post: {
+      type: "oneToOne",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+    },
+  },
+  Posts: {
+    author: {
+      type: "manyToOne",
+      to: "Users",
+      field: "authorId",
+      reference: "id",
+    },
+  },
+};
+
+const isGassmaController = (value: unknown): value is GassmaController =>
+  typeof value === "object" &&
+  value !== null &&
+  "findMany" in value &&
+  typeof value.findMany === "function";
+
+const sheetOf = (client: GassmaClient, name: string): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record[name];
+  if (!isGassmaController(controller)) {
+    throw new Error(`controller not found: ${name}`);
+  }
+  return controller;
+};
+
+const postA = { id: 101, authorId: 1, title: "Post A" };
+const postB = { id: 102, authorId: null, title: "Post B" };
+
+describe("isNot は関連が存在しない行(FK null)も返す（統合）", () => {
+  let client: GassmaClient;
+
+  beforeAll(() => {
+    Object.assign(globalThis, {
+      SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+    });
+    client = new GassmaClient({ relations });
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, { SpreadsheetApp: undefined });
+  });
+
+  describe("manyToOne（FK側）", () => {
+    it("isNot: 条件付きは FK null の行も返す", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { author: { isNot: { name: "Alice" } } },
+      });
+
+      expect(result).toEqual([postB]);
+    });
+
+    it("isNot: {} は FK null の行だけを返す", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { author: { isNot: {} } },
+      });
+
+      expect(result).toEqual([postB]);
+    });
+
+    it("全員に合致しない条件の isNot は全行を返す", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { author: { isNot: { name: "Unknown" } } },
+      });
+
+      expect(result).toEqual([postA, postB]);
+    });
+
+    it("is: 条件付きは変わらない（非回帰）", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { author: { is: { name: "Alice" } } },
+      });
+
+      expect(result).toEqual([postA]);
+    });
+
+    it("null ショートハンドは変わらない（非回帰）", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { author: null },
+      });
+
+      expect(result).toEqual([postB]);
+    });
+
+    it("notIn 単体は null 行を返さない（非回帰）", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { authorId: { notIn: [1] } },
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("通常条件と組み合わせられる", () => {
+      const result = sheetOf(client, "Posts").findMany({
+        where: { title: "Post B", author: { isNot: { name: "Alice" } } },
+      });
+
+      expect(result).toEqual([postB]);
+    });
+  });
+
+  describe("oneToOne（非FK側）", () => {
+    it("isNot: 条件付きは関連を持たない親も返す", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { post: { isNot: { title: "Post A" } } },
+      });
+
+      expect(result).toEqual([{ id: 2, name: "Bob" }]);
+    });
+
+    it("isNot: {} は関連を持たない親だけを返す", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { post: { isNot: {} } },
+      });
+
+      expect(result).toEqual([{ id: 2, name: "Bob" }]);
+    });
+
+    it("is: 条件付きは変わらない（非回帰）", () => {
+      const result = sheetOf(client, "Users").findMany({
+        where: { post: { is: { title: "Post A" } } },
+      });
+
+      expect(result).toEqual([{ id: 1, name: "Alice" }]);
+    });
+  });
+});

--- a/src/__test__/util/relation/whereRelation/resolveWhereRelation.test.ts
+++ b/src/__test__/util/relation/whereRelation/resolveWhereRelation.test.ts
@@ -124,7 +124,7 @@ describe("resolveWhereRelation", () => {
     const result = resolveWhereRelation(where, context);
 
     expect(result).toEqual({
-      AND: [{ authorId: { notIn: [1] } }],
+      AND: [{ NOT: { authorId: { in: [1] } } }],
     });
   });
 

--- a/src/util/relation/whereRelation/filters/isNotFilter.ts
+++ b/src/util/relation/whereRelation/filters/isNotFilter.ts
@@ -24,7 +24,7 @@ const applyIsNotFilter = (
 
   const targets = findManyOnSheet(relation.to, { where: filterWhere });
   const targetKeys = collectKeys(targets, relation.reference);
-  return { [relation.field]: { notIn: targetKeys } };
+  return { NOT: { [relation.field]: { in: targetKeys } } };
 };
 
 export { applyIsNotFilter };


### PR DESCRIPTION
`LLM/semantics-bugs.html` の **E** への対応です。

## 問題

```
Users:  1 Alice / 2 Bob
Posts:  101 (authorId=1) / 102 (authorId=null)
```

```js
Posts.findMany({ where: { author: { isNot: { name: "Alice" } } } })
// 修正前 → []      ← Post B(著者なし)が消える
// 修正後 → [102]
```

**「Alice が書いたものではない Post」を求めているのに、著者が設定されていない Post B が返りませんでした。**

Prisma は含めます。発行 SQL に `OR` が入っているのが証拠です。

```sql
LEFT JOIN Author j0 ON j0.id = Post.authorId
WHERE ((NOT j0.name = ?) OR (j0.id IS NULL))
```

意味論としては、Prisma の `isNot` が「**条件にマッチする関連が存在しない**」なのに対し、gassma は「**関連が存在して、かつ条件を満たさない**」になっていました。

## `notIn` はバグではない

原因は `isNot` が `{ authorId: { notIn: [1] } }` に翻訳されることでしたが、**`notIn` 自体の挙動は正しい**です。

Prisma も `notIn` は null 行を返しません。公式リファレンスに "**null values are not returned**" と明記があり、SQL の3値論理どおりです。`notIn` の実装には**一切触れていません**。

問題は**その形で問いを立てたこと**でした。

## 修正(実装は1行)

```diff
- { [relation.field]: { notIn: targetKeys } }
+ { NOT: { [relation.field]: { in: targetKeys } } }
```

`isNot` は「マッチする関連が存在しない」なので、**`in` の補集合**を取るのが素直な翻訳です。2値論理の補集合なので FK が null の行も dangling FK の行も含み、Prisma の `LEFT JOIN ... WHERE NOT cond OR IS NULL` と同値になります。

> [!NOTE]
> 当初は `{ OR: [{ FK: null }, { FK: { notIn: keys } }] }` で実装しましたが、**返却行の順序がシート順から崩れました**(`OR` がブランチ順に行を連結するため、FK null の行が先頭に来る)。補集合を取る形なら `isNotMatch` が元の順序を保つので、**意味論と順序の両方が正しくなります**。

## 実証

| クエリ | 修正前 | 修正後 | Prisma |
|---|---|---|---|
| `is: { name: "Alice" }` | [101] | [101](無変更) | [101] |
| `isNot: { name: "Alice" }` | **[]** | **[102]** | [102] |
| `isNot: {}` | **[]** | **[102]** | [102] |
| `isNot: { name: "Unknown" }` | [101] のみ | **[101, 102]**(シート順) | 全行 |
| `author: null` | [102] | [102](無変更) | [102] |
| `authorId: { notIn: [1] }` | [] | **[](無変更)** | [] |

`oneToOne` 側も確認しました。調査の結果**元から概ね正しく**(自分のキー列は通常 non-null なので `notIn` が素通しし、「関連を持たない親」は既に返っていた)、今回追加で正しくなるのは「自キー列が null の親」という端ケースのみです。これも Prisma の LEFT JOIN 意味論と一致します。

## 検証結果

- `npm test`: **2,624件 全 green**(2,613 → +11)
- 往復契約テスト3スイート31件 green
- `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル57件)pass
- `some` / `none` / `every` 16件、`$transaction` 70件、`$extends` 63件を明示的に実行して非回帰を確認

### 変更した既存テスト

翻訳結果の期待値**4件のみ**です(`isNotFilter.test.ts` の3件と `resolveWhereRelation.test.ts` の1件)。旧期待値は「FK null 行を落とす」というバグ挙動そのものを固定していたものです。

**`isNot: null` 系・`is` 系の期待値は無変更**で、`oneToOneNullFilter.test.ts` の「isNot: 条件付き非回帰」も無変更のまま通過しています(oneToOne 側の従来挙動が保たれた証拠)。

## 判断が要る点(スコープ外)

**`oneToOne` の `is: null` に同型の穴が残っています。** `{ field: { notIn: allChildFks } }` という翻訳なので、**自キー列が null の親を落とします**。Prisma の LEFT JOIN では「子なし」として `is: null` に含まれるはずです。

「`is` の挙動は変えない」という制約に従って無変更にしました。別途対応するか判断をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)