### PR TITLE
fix: is: null / none / every で「自キーが null の親」を落とさないようにする

### DIFF
--- a/src/__test__/util/relation/whereRelation/filters/everyFilter.test.ts
+++ b/src/__test__/util/relation/whereRelation/filters/everyFilter.test.ts
@@ -18,7 +18,7 @@ describe("applyEveryFilter", () => {
       reference: "authorId",
     };
 
-    it("全子レコードが条件に合致する親は通過する（notInに含まれない）", () => {
+    it("全子レコードが条件に合致する親は通過する（NOTのinに含まれない）", () => {
       const filterWhere: WhereUse = { published: true };
 
       mockFindMany.mockImplementation(
@@ -48,10 +48,10 @@ describe("applyEveryFilter", () => {
 
       // authorId=2 は全数1, 合致数0 → 失敗
       // authorId=1 は全数2, 合致数2 → 成功（notInに含まれない）
-      expect(result).toEqual({ id: { notIn: [2] } });
+      expect(result).toEqual({ NOT: { id: { in: [2] } } });
     });
 
-    it("一部の子レコードが条件に合致しない親はnotInに含まれる", () => {
+    it("一部の子レコードが条件に合致しない親はNOTのinに含まれる", () => {
       const filterWhere: WhereUse = { published: true };
 
       mockFindMany.mockImplementation(
@@ -80,10 +80,10 @@ describe("applyEveryFilter", () => {
 
       // authorId=1: 全数2, 合致1 → 失敗
       // authorId=2: 全数2, 合致1 → 失敗
-      expect(result).toEqual({ id: { notIn: [1, 2] } });
+      expect(result).toEqual({ NOT: { id: { in: [1, 2] } } });
     });
 
-    it("子レコードが0件の親はvacuous truthで通過する（notInに含まれない）", () => {
+    it("子レコードが0件の親はvacuous truthで通過する（NOTのinに含まれない）", () => {
       const filterWhere: WhereUse = { published: true };
 
       // 全子レコードが空
@@ -97,10 +97,10 @@ describe("applyEveryFilter", () => {
       );
 
       // 誰も失敗しない
-      expect(result).toEqual({ id: { notIn: [] } });
+      expect(result).toEqual({ NOT: { id: { in: [] } } });
     });
 
-    it("全子レコードが条件に合致しない場合は全親がnotInに含まれる", () => {
+    it("全子レコードが条件に合致しない場合は全親がNOTのinに含まれる", () => {
       const filterWhere: WhereUse = { published: true };
 
       mockFindMany.mockImplementation(
@@ -122,7 +122,7 @@ describe("applyEveryFilter", () => {
         mockFindMany,
       );
 
-      expect(result).toEqual({ id: { notIn: [1, 2] } });
+      expect(result).toEqual({ NOT: { id: { in: [1, 2] } } });
     });
   });
 
@@ -139,7 +139,7 @@ describe("applyEveryFilter", () => {
       },
     };
 
-    it("全関連ターゲットが条件合致しない親はnotInに含まれる", () => {
+    it("全関連ターゲットが条件合致しない親はNOTのinに含まれる", () => {
       const filterWhere: WhereUse = { active: true };
 
       mockFindMany.mockImplementation(
@@ -175,7 +175,7 @@ describe("applyEveryFilter", () => {
 
       // post1: tag10(合致) + tag20(不合致) → 全数2, 合致数1 → 失敗
       // post2: tag10(合致) → 全数1, 合致数1 → 成功
-      expect(result).toEqual({ id: { notIn: [1] } });
+      expect(result).toEqual({ NOT: { id: { in: [1] } } });
     });
   });
 });
@@ -194,7 +194,7 @@ describe("applyEveryFilter with Date keys", () => {
     reference: "authorKey",
   };
 
-  it("全子が合致する親はDateキーでもnotInに含まれない", () => {
+  it("全子が合致する親はDateキーでもNOTのinに含まれない", () => {
     mockFindMany.mockImplementation(
       (_sheet: string, findData: { where?: WhereUse }) => {
         if (!findData.where || Object.keys(findData.where).length === 0) {
@@ -218,10 +218,10 @@ describe("applyEveryFilter with Date keys", () => {
       mockFindMany,
     );
 
-    expect(result).toEqual({ key: { notIn: [] } });
+    expect(result).toEqual({ NOT: { key: { in: [] } } });
   });
 
-  it("合致しない子を持つ親のDateキーは元の値でnotInに含まれる", () => {
+  it("合致しない子を持つ親のDateキーは元の値でNOTのinに含まれる", () => {
     mockFindMany.mockImplementation(
       (_sheet: string, findData: { where?: WhereUse }) => {
         if (!findData.where || Object.keys(findData.where).length === 0) {
@@ -250,7 +250,7 @@ describe("applyEveryFilter with Date keys", () => {
     );
 
     expect(result).toEqual({
-      key: { notIn: [new Date("2026-07-18T10:30:00.000Z")] },
+      NOT: { key: { in: [new Date("2026-07-18T10:30:00.000Z")] } },
     });
   });
 
@@ -293,7 +293,7 @@ describe("applyEveryFilter with Date keys", () => {
     );
 
     expect(result).toEqual({
-      at: { notIn: [new Date("2026-07-02T00:00:00.000Z")] },
+      NOT: { at: { in: [new Date("2026-07-02T00:00:00.000Z")] } },
     });
   });
 
@@ -321,6 +321,6 @@ describe("applyEveryFilter with Date keys", () => {
       mockFindMany,
     );
 
-    expect(result).toEqual({ key: { notIn: [] } });
+    expect(result).toEqual({ NOT: { key: { in: [] } } });
   });
 });

--- a/src/__test__/util/relation/whereRelation/filters/isFilter.test.ts
+++ b/src/__test__/util/relation/whereRelation/filters/isFilter.test.ts
@@ -98,7 +98,7 @@ describe("applyIsFilter", () => {
       reference: "userId",
     };
 
-    it("相手シートのreference値に含まれないフィールドのnotIn条件を返す", () => {
+    it("相手シートのreference値に含まれないことを示すNOT + in条件を返す", () => {
       mockFindMany.mockReturnValue([
         { id: 301, userId: 1 },
         { id: 302, userId: 2 },
@@ -106,7 +106,7 @@ describe("applyIsFilter", () => {
 
       const result = applyIsFilter(relation, "profile", null, mockFindMany);
 
-      expect(result).toEqual({ id: { notIn: [1, 2] } });
+      expect(result).toEqual({ NOT: { id: { in: [1, 2] } } });
       expect(mockFindMany).toHaveBeenCalledWith("Profiles", { where: {} });
     });
 
@@ -118,15 +118,15 @@ describe("applyIsFilter", () => {
 
       const result = applyIsFilter(relation, "profile", null, mockFindMany);
 
-      expect(result).toEqual({ id: { notIn: [1] } });
+      expect(result).toEqual({ NOT: { id: { in: [1] } } });
     });
 
-    it("相手シートが空の場合はnotIn: []を返す", () => {
+    it("相手シートが空の場合はNOT + in: []を返す", () => {
       mockFindMany.mockReturnValue([]);
 
       const result = applyIsFilter(relation, "profile", null, mockFindMany);
 
-      expect(result).toEqual({ id: { notIn: [] } });
+      expect(result).toEqual({ NOT: { id: { in: [] } } });
     });
   });
 });

--- a/src/__test__/util/relation/whereRelation/filters/noneFilter.test.ts
+++ b/src/__test__/util/relation/whereRelation/filters/noneFilter.test.ts
@@ -17,7 +17,7 @@ describe("applyNoneFilter", () => {
       reference: "authorId",
     };
 
-    it("条件に合致する子レコードを持つ親のキーでnotInフィルタを生成する", () => {
+    it("条件に合致する子レコードを持つ親のキーでNOT + inフィルタを生成する", () => {
       const filterWhere: WhereUse = { published: true };
 
       mockFindMany.mockReturnValue([
@@ -32,10 +32,10 @@ describe("applyNoneFilter", () => {
         mockFindMany,
       );
 
-      expect(result).toEqual({ id: { notIn: [1, 3] } });
+      expect(result).toEqual({ NOT: { id: { in: [1, 3] } } });
     });
 
-    it("条件に合致する子レコードがない場合はnotIn: []を返す", () => {
+    it("条件に合致する子レコードがない場合はNOT + in: []を返す", () => {
       const filterWhere: WhereUse = { published: true };
       mockFindMany.mockReturnValue([]);
 
@@ -46,7 +46,7 @@ describe("applyNoneFilter", () => {
         mockFindMany,
       );
 
-      expect(result).toEqual({ id: { notIn: [] } });
+      expect(result).toEqual({ NOT: { id: { in: [] } } });
     });
   });
 
@@ -63,7 +63,7 @@ describe("applyNoneFilter", () => {
       },
     };
 
-    it("中間テーブル経由で条件合致のparentKeyでnotInフィルタを生成する", () => {
+    it("中間テーブル経由で条件合致のparentKeyでNOT + inフィルタを生成する", () => {
       const filterWhere: WhereUse = { name: "TypeScript" };
 
       mockFindMany.mockImplementation((sheet: string) => {
@@ -84,7 +84,7 @@ describe("applyNoneFilter", () => {
         mockFindMany,
       );
 
-      expect(result).toEqual({ id: { notIn: [1, 3] } });
+      expect(result).toEqual({ NOT: { id: { in: [1, 3] } } });
     });
   });
 });

--- a/src/__test__/util/relation/whereRelation/nullKeyParentRow.test.ts
+++ b/src/__test__/util/relation/whereRelation/nullKeyParentRow.test.ts
@@ -1,0 +1,241 @@
+import { GassmaClient } from "../../../../gassma";
+import type { GassmaController } from "../../../../gassmaController";
+import type { RelationsConfig } from "../../../../types/relationTypes";
+
+type MockSheet = {
+  getName: () => string;
+  getLastRow: () => number;
+  getLastColumn: () => number;
+  getRange: (
+    row: number,
+    col: number,
+    numRows: number,
+    numCols: number,
+  ) => { getValues: () => unknown[][] };
+  getDataRange: () => { getValues: () => unknown[][] };
+};
+
+const makeSheet = (name: string, data: unknown[][]): MockSheet => ({
+  getName: () => name,
+  getLastRow: () => data.length,
+  getLastColumn: () => data[0].length,
+  getRange: (row, col, numRows, numCols) => ({
+    getValues: () =>
+      data
+        .slice(row - 1, row - 1 + numRows)
+        .map((r) => r.slice(col - 1, col - 1 + numCols)),
+  }),
+  getDataRange: () => ({ getValues: () => data }),
+});
+
+const sheets = [
+  makeSheet("Users", [
+    ["id", "name"],
+    [1, "Alice"],
+    ["", "NoKey"],
+    [2, "Bob"],
+  ]),
+  makeSheet("Posts", [
+    ["id", "authorId", "title"],
+    [101, 1, "Post A"],
+  ]),
+  makeSheet("Articles", [
+    ["id", "authorId", "published"],
+    [201, 1, true],
+    [202, 2, false],
+  ]),
+  makeSheet("Drafts", [["id", "authorId", "published"]]),
+  makeSheet("Tags", [
+    ["id", "name"],
+    [10, "Tech"],
+  ]),
+  makeSheet("UserTags", [
+    ["userId", "tagId"],
+    [1, 10],
+  ]),
+];
+
+const mockSpreadsheet = {
+  getId: () => "test-spreadsheet",
+  getSheets: () => sheets,
+  getSheetByName: (name: string) =>
+    sheets.find((sheet) => sheet.getName() === name) ?? null,
+};
+
+const relations: RelationsConfig = {
+  Users: {
+    post: {
+      type: "oneToOne",
+      to: "Posts",
+      field: "id",
+      reference: "authorId",
+    },
+    articles: {
+      type: "oneToMany",
+      to: "Articles",
+      field: "id",
+      reference: "authorId",
+    },
+    drafts: {
+      type: "oneToMany",
+      to: "Drafts",
+      field: "id",
+      reference: "authorId",
+    },
+    tags: {
+      type: "manyToMany",
+      to: "Tags",
+      field: "id",
+      reference: "id",
+      through: {
+        sheet: "UserTags",
+        field: "userId",
+        reference: "tagId",
+      },
+    },
+  },
+};
+
+const isGassmaController = (value: unknown): value is GassmaController =>
+  typeof value === "object" &&
+  value !== null &&
+  "findMany" in value &&
+  typeof value.findMany === "function";
+
+const usersOf = (client: GassmaClient): GassmaController => {
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record.Users;
+  if (!isGassmaController(controller)) {
+    throw new Error("controller not found: Users");
+  }
+  return controller;
+};
+
+const alice = { id: 1, name: "Alice" };
+const noKey = { id: null, name: "NoKey" };
+const bob = { id: 2, name: "Bob" };
+
+describe("自キー列が null の親もリレーションの否定形フィルタに含まれる（統合）", () => {
+  let client: GassmaClient;
+
+  beforeAll(() => {
+    Object.assign(globalThis, {
+      SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+    });
+    client = new GassmaClient({ relations });
+  });
+
+  afterAll(() => {
+    Object.assign(globalThis, { SpreadsheetApp: undefined });
+  });
+
+  describe("oneToOne（非FK側）", () => {
+    it("is: null は自キーが null の親も返す（シート順）", () => {
+      const result = usersOf(client).findMany({
+        where: { post: { is: null } },
+      });
+
+      expect(result).toEqual([noKey, bob]);
+    });
+
+    it("null ショートハンドも同様に返す（シート順）", () => {
+      const result = usersOf(client).findMany({
+        where: { post: null },
+      });
+
+      expect(result).toEqual([noKey, bob]);
+    });
+
+    it("isNot: null は自キーが null の親を返さない（非回帰）", () => {
+      const result = usersOf(client).findMany({
+        where: { post: { isNot: null } },
+      });
+
+      expect(result).toEqual([alice]);
+    });
+
+    it("is: 条件付きは自キーが null の親を返さない（非回帰）", () => {
+      const result = usersOf(client).findMany({
+        where: { post: { is: { title: "Post A" } } },
+      });
+
+      expect(result).toEqual([alice]);
+    });
+  });
+
+  describe("oneToMany", () => {
+    it("none は自キーが null の親も返す（シート順）", () => {
+      const result = usersOf(client).findMany({
+        where: { articles: { none: { published: true } } },
+      });
+
+      expect(result).toEqual([noKey, bob]);
+    });
+
+    it("every は自キーが null の親も返す（vacuous truth・シート順）", () => {
+      const result = usersOf(client).findMany({
+        where: { articles: { every: { published: true } } },
+      });
+
+      expect(result).toEqual([alice, noKey]);
+    });
+
+    it("子シートが空でも every は全親を返す（シート順）", () => {
+      const result = usersOf(client).findMany({
+        where: { drafts: { every: { published: true } } },
+      });
+
+      expect(result).toEqual([alice, noKey, bob]);
+    });
+
+    it("some は自キーが null の親を返さない（非回帰）", () => {
+      const result = usersOf(client).findMany({
+        where: { articles: { some: { published: true } } },
+      });
+
+      expect(result).toEqual([alice]);
+    });
+  });
+
+  describe("manyToMany", () => {
+    it("none は自キーが null の親も返す（シート順）", () => {
+      const result = usersOf(client).findMany({
+        where: { tags: { none: { name: "Tech" } } },
+      });
+
+      expect(result).toEqual([noKey, bob]);
+    });
+
+    it("every は自キーが null の親も返す（vacuous truth・シート順）", () => {
+      const result = usersOf(client).findMany({
+        where: { tags: { every: { name: "Tech" } } },
+      });
+
+      expect(result).toEqual([alice, noKey, bob]);
+    });
+
+    it("some は自キーが null の親を返さない（非回帰）", () => {
+      const result = usersOf(client).findMany({
+        where: { tags: { some: { name: "Tech" } } },
+      });
+
+      expect(result).toEqual([alice]);
+    });
+  });
+
+  describe("通常条件との組み合わせ", () => {
+    it("none と通常条件の AND でも順序が保たれる", () => {
+      const result = usersOf(client).findMany({
+        where: {
+          name: { in: ["Alice", "NoKey", "Bob"] },
+          articles: { none: { published: true } },
+        },
+      });
+
+      expect(result).toEqual([noKey, bob]);
+    });
+  });
+});

--- a/src/__test__/util/relation/whereRelation/relationNullShorthand.test.ts
+++ b/src/__test__/util/relation/whereRelation/relationNullShorthand.test.ts
@@ -58,7 +58,7 @@ describe("where 直値 null ショートハンド（resolveWhereRelation 単体�
     expect(mockFindMany).not.toHaveBeenCalled();
   });
 
-  it("oneToOne(非FK側)の直値 null は is: null と同義（reference 値の notIn）", () => {
+  it("oneToOne(非FK側)の直値 null は is: null と同義（reference 値の NOT + in）", () => {
     const where: WhereUse = { profile: null };
 
     mockFindMany.mockReturnValue([
@@ -68,7 +68,7 @@ describe("where 直値 null ショートハンド（resolveWhereRelation 単体�
 
     const result = resolveWhereRelation(where, context);
 
-    expect(result).toEqual({ AND: [{ id: { notIn: [1, 2] } }] });
+    expect(result).toEqual({ AND: [{ NOT: { id: { in: [1, 2] } } }] });
     expect(mockFindMany).toHaveBeenCalledWith("Profiles", { where: {} });
   });
 

--- a/src/__test__/util/relation/whereRelation/resolveWhereRelation.test.ts
+++ b/src/__test__/util/relation/whereRelation/resolveWhereRelation.test.ts
@@ -84,7 +84,7 @@ describe("resolveWhereRelation", () => {
     const result = resolveWhereRelation(where, context);
 
     expect(result).toEqual({
-      AND: [{ id: { notIn: [2] } }],
+      AND: [{ NOT: { id: { in: [2] } } }],
     });
   });
 
@@ -140,7 +140,7 @@ describe("resolveWhereRelation", () => {
     });
   });
 
-  it("oneToOne(非FK側)のis: nullは相手reference値のnotIn条件に変換する", () => {
+  it("oneToOne(非FK側)のis: nullは相手reference値のNOT + in条件に変換する", () => {
     const where: WhereUse = {
       profile: { is: null },
     };
@@ -153,7 +153,7 @@ describe("resolveWhereRelation", () => {
     const result = resolveWhereRelation(where, context);
 
     expect(result).toEqual({
-      AND: [{ id: { notIn: [1, 2] } }],
+      AND: [{ NOT: { id: { in: [1, 2] } } }],
     });
     expect(mockFindMany).toHaveBeenCalledWith("Profiles", { where: {} });
   });
@@ -196,7 +196,7 @@ describe("resolveWhereRelation", () => {
     const result = resolveWhereRelation(where, context);
 
     expect(result).toEqual({
-      AND: [{ id: { notIn: [2] } }],
+      AND: [{ NOT: { id: { in: [2] } } }],
     });
   });
 

--- a/src/util/relation/whereRelation/filters/everyFilter.ts
+++ b/src/util/relation/whereRelation/filters/everyFilter.ts
@@ -51,7 +51,7 @@ const applyEveryFilterOneToMany = (
 ): WhereUse => {
   const allChildren = findManyOnSheet(relation.to, { where: {} });
   if (allChildren.length === 0) {
-    return { [relation.field]: { notIn: [] } };
+    return { NOT: { [relation.field]: { in: [] } } };
   }
 
   const matchChildren = findManyOnSheet(relation.to, { where: filterWhere });
@@ -60,7 +60,7 @@ const applyEveryFilterOneToMany = (
   const matchCounts = countByKey(matchChildren, relation.reference);
   const failing = findFailingKeys(allCounts, matchCounts);
 
-  return { [relation.field]: { notIn: failing } };
+  return { NOT: { [relation.field]: { in: failing } } };
 };
 
 const applyEveryFilterManyToMany = (
@@ -72,7 +72,7 @@ const applyEveryFilterManyToMany = (
 
   const allJunctions = findManyOnSheet(through.sheet, { where: {} });
   if (allJunctions.length === 0) {
-    return { [relation.field]: { notIn: [] } };
+    return { NOT: { [relation.field]: { in: [] } } };
   }
 
   const allCounts = countByKey(allJunctions, through.field);
@@ -89,7 +89,7 @@ const applyEveryFilterManyToMany = (
   const matchCounts = countByKey(matchJunctions, through.field);
 
   const failing = findFailingKeys(allCounts, matchCounts);
-  return { [relation.field]: { notIn: failing } };
+  return { NOT: { [relation.field]: { in: failing } } };
 };
 
 const applyEveryFilter = (

--- a/src/util/relation/whereRelation/filters/isFilter.ts
+++ b/src/util/relation/whereRelation/filters/isFilter.ts
@@ -17,7 +17,7 @@ const applyIsFilter = (
     if (relation.type === "oneToOne") {
       const targets = findManyOnSheet(relation.to, { where: {} });
       const targetKeys = collectKeys(targets, relation.reference);
-      return { [relation.field]: { notIn: targetKeys } };
+      return { NOT: { [relation.field]: { in: targetKeys } } };
     }
     return { [relation.field]: null };
   }

--- a/src/util/relation/whereRelation/filters/noneFilter.ts
+++ b/src/util/relation/whereRelation/filters/noneFilter.ts
@@ -20,12 +20,12 @@ const applyNoneFilter = (
       filterWhere,
       findManyOnSheet,
     );
-    return { [relation.field]: { notIn: parentKeys } };
+    return { NOT: { [relation.field]: { in: parentKeys } } };
   }
 
   const children = findManyOnSheet(relation.to, { where: filterWhere });
   const parentKeys = collectKeys(children, relation.reference);
-  return { [relation.field]: { notIn: parentKeys } };
+  return { NOT: { [relation.field]: { in: parentKeys } } };
 };
 
 export { applyNoneFilter };


### PR DESCRIPTION
#209(`isNot` の修正)のレビューで指摘した `oneToOne` の `is: null` の穴への対応です。**調べたら `is: null` だけではありませんでした。**

## 問題

`notIn` はセル値 null に対して false を返します(**これ自体は Prisma と一致していて正しい**)。そのため **`notIn` で「〜でない」を表現している箇所はすべて null 行を落とします**。

`isNot` は #209 で直しましたが、**同じ形が `is: null` / `none` / `every` にも残っていました**。

**自キー列が null の親には、そもそも子が付きようがありません**(子は null を参照できない)。したがって「子を持たない親」として、これらすべてに含まれるべきです。

## 修正した箇所(7箇所)

すべて `{ field: { notIn: keys } }` → `{ NOT: { field: { in: keys } } }` への置換です。

| ファイル | 対象 |
|---|---|
| `isFilter.ts` | `is: null`(oneToOne 非FK側) |
| `noneFilter.ts` | `none`(manyToMany / oneToMany の両分岐) |
| `everyFilter.ts` | `every`(両分岐の本経路 + **子ゼロ件の早期 return 2箇所**) |

`{ rel: null }` の null ショートハンドは `applyIsFilter` に委譲しているので自動的に直ります。

**これで、リレーションフィルタの翻訳結果から `notIn` が完全に消えました**(grep で0件を確認)。

## `notIn` を使っている箇所の全数確認

| 箇所 | 判定 | 理由 |
|---|---|---|
| `isFilter` / `noneFilter` / `everyFilter` | **修正** | 自キー null の親が落ちていた |
| `someFilter` / `isNotFilter` / `manyToManyHelper` | 無変更 | `notIn` 不使用。`in` は null を除外するが、それは「子なし親は `some` に合致しない」という**正しい方向** |
| `filterConditions.ts`(`notIn` の実装本体) | 無変更 | null に false は **Prisma と一致**。不可侵 |
| `notPatternFilter.ts`(groupBy の having) | 無変更 | **利用者が書いた `notIn` をそのまま転記する経路**であって、こちら側の「〜でない」の翻訳ではない |

## 実証

フィクスチャ: Users = Alice(id:1)/ **NoKey(id:null)**/ Bob(id:2)。Alice のみ子を持ちます。

| クエリ | 修正前 | 修正後 |
|---|---|---|
| oneToOne `post: { is: null }` | [Bob] | **[NoKey, Bob]** |
| `post: null`(ショートハンド) | [Bob] | **[NoKey, Bob]** |
| oneToMany `articles: { none: {...} }` | [Bob] | **[NoKey, Bob]** |
| oneToMany `articles: { every: {...} }` | [Alice] | **[Alice, NoKey]** |
| 空シートへの `every` | [Alice, Bob] | **[Alice, NoKey, Bob]** |
| manyToMany `tags: { none: {...} }` | [Bob] | **[NoKey, Bob]** |
| manyToMany `tags: { every: {...} }` | [Alice, Bob] | **[Alice, NoKey, Bob]** |
| `isNot: null` / `is: {条件}` / `some` | null 親を返さない | **変わらず返さない** |

`every` が自キー null の親を含むのは **vacuous truth**(子が0件なら「すべての子が条件を満たす」は真)です。

## 順序が崩れていないことの確認

#209 で「`OR` を使うと返却行の順序がシート順から崩れる」と分かった点への対応です。

**NoKey をシートの中間行(2行目)に置き**、期待値を `toEqual` で**厳密な配列順**として固定しました。`[Alice, NoKey]` / `[Alice, NoKey, Bob]` / `[NoKey, Bob]` がすべてシート順どおりであることをテストが保証します。`OR` 連結だと null 補完分が末尾に付くため、順序が崩れればこれらは fail します。通常条件との `AND` 併用でも順序維持を検証しています。

## 検証結果

- `npm test`: **2,636件 全 green**(2,624 → +12)
- 往復契約テスト3スイート31件 green
- `tsc --noEmit` / lint(警告は main と同数)/ format / `verify:bundle`(公開シンボル57件)pass
- `$transaction` 70件、`$extends` 63件、relation 全体456件を明示的に実行して非回帰を確認
- **#209 の `isNot` は無変更**で、その統合テストも全通過

### 変更した既存テスト

**翻訳結果の形を固定していたもの17件**です(`isFilter` 3件・`noneFilter` 3件・`everyFilter` 7件・`resolveWhereRelation` 3件・`relationNullShorthand` 1件)。

`NOT + in` は**非 null セルに対して `notIn` と真理値が同一**(2値論理の補集合)で、**null セルに対してのみ true に変わります**。その変わる方向こそが今回の修正意図です。結果レベルの正しさは新規統合テスト12件と、既存の結果検証テストが全通過していることで担保しています。**`notIn` 演算子自体の挙動テストは無変更で通過**しています。

## スコープ外

**manyToOne の dangling FK**(FK が非 null だが参照先が存在しない行)は、Prisma の LEFT JOIN なら `is: null` 側に入る可能性があります。`notIn` とは無関係な別論点なので触れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)