### PR TITLE
fix: セルに書けない値を書き込み前にエラーにする

### DIFF
--- a/src/__test__/util/create/createDataValidation.test.ts
+++ b/src/__test__/util/create/createDataValidation.test.ts
@@ -166,14 +166,14 @@ describe("create: 列名キーへの素の dict 値はエラー", () => {
     expect(typed.count({})).toBe(3);
   });
 
-  test("配列値は従来どおり素通しされる", () => {
+  test("配列値もエラーになり追加されない", () => {
     const env = buildEnv();
     const typed = sheetOf(env.client, "Users");
     const loose: any = typed;
     expect(() =>
       loose.create({ data: { id: 8, name: "A", age: [1, 2] } }),
-    ).not.toThrow();
-    expect(typed.count({})).toBe(3);
+    ).toThrow(GassmaInvalidValueError);
+    expect(typed.count({})).toBe(2);
   });
 });
 

--- a/src/__test__/util/unwritableValues.test.ts
+++ b/src/__test__/util/unwritableValues.test.ts
@@ -1,0 +1,306 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import { raw } from "../../util/raw/raw";
+import { buildTestClient, sheetOf } from "./extends/extendsTestClient";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "./transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const looseUsers = (options?: {
+  relations?: boolean;
+}): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const typed = sheetOf(buildTestClient(options), "Users");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+const aliceUnchanged = (typed: ReturnType<typeof sheetOf>) => {
+  expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+    id: 1,
+    name: "Alice",
+    age: 20,
+  });
+};
+
+describe("セルに書けない数値はエラー", () => {
+  test("create: NaN はエラーになり行が追加されない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () =>
+      loose.create({ data: { id: 9, name: "Zed", age: Number("abc") } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received NaN.",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("create: Infinity はエラーになり行が追加されない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () => loose.create({ data: { id: 9, name: "Z", age: 1 / 0 } });
+    expect(fn).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received Infinity.",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("create: -Infinity はエラーになり行が追加されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.create({ data: { id: 9, name: "Z", age: -1 / 0 } }),
+    ).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received -Infinity.",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("createMany: 2行目の NaN もエラーになり1行も追加されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.createMany({
+        data: [
+          { id: 8, name: "Yui", age: 2 },
+          { id: 9, name: "Zed", age: NaN },
+        ],
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("update: NaN はエラーになり行が更新されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.update({ where: { id: 1 }, data: { age: NaN } }),
+    ).toThrow(GassmaInvalidValueError);
+    aliceUnchanged(typed);
+  });
+
+  test("updateMany: Infinity はエラーになり全行無変化", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.updateMany({ where: { age: { gte: 0 } }, data: { age: Infinity } }),
+    ).toThrow(GassmaInvalidValueError);
+    aliceUnchanged(typed);
+  });
+
+  test("update: increment に NaN はエラーになりセルが壊れない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () =>
+      loose.update({ where: { id: 1 }, data: { age: { increment: NaN } } });
+    expect(fn).toThrow(
+      "Invalid value for argument `increment`. Expected a finite number, but received NaN.",
+    );
+    aliceUnchanged(typed);
+  });
+
+  test("updateMany: divide に Infinity はエラー", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.updateMany({
+        where: { id: 1 },
+        data: { age: { divide: Infinity } },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    aliceUnchanged(typed);
+  });
+});
+
+describe("Invalid Date はエラー", () => {
+  test("create: Invalid Date はエラーになり行が追加されない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () =>
+      loose.create({ data: { id: 9, name: "Z", age: new Date("nope") } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `age`. Expected a valid Date, but the provided Date object is invalid.",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("update: Invalid Date はエラーになり行が更新されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.update({ where: { id: 1 }, data: { age: new Date("nope") } }),
+    ).toThrow(GassmaInvalidValueError);
+    aliceUnchanged(typed);
+  });
+});
+
+describe("セルに書けない型はエラー", () => {
+  test("create: 配列はエラーになり行が追加されない", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () => loose.create({ data: { id: 9, name: [1, 2], age: 1 } });
+    expect(fn).toThrow(
+      "Invalid value for argument `name`. Expected a scalar value, but received an array.",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("create: 関数はエラーになり行が追加されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.create({ data: { id: 9, name: () => "Z", age: 1 } }),
+    ).toThrow(
+      "Invalid value for argument `name`. Expected a scalar value, but received a function.",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("create: Symbol はエラーになり行が追加されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.create({ data: { id: 9, name: Symbol("Z"), age: 1 } }),
+    ).toThrow(
+      "Invalid value for argument `name`. Expected a scalar value, but received a symbol.",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("create: BigInt はエラーになり行が追加されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.create({ data: { id: 9, name: "Z", age: BigInt(5) } }),
+    ).toThrow(
+      "Invalid value for argument `age`. Expected a scalar value, but received a bigint.",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+});
+
+describe("upsert は未実行の分岐も検証される", () => {
+  test("upsert(作成分岐): update 側の NaN もエラーになり追加されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.upsert({
+        where: { id: 999 },
+        create: { id: 999, name: "A", age: 1 },
+        update: { age: NaN },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("upsert(更新分岐): create 側の NaN もエラーになり更新されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.upsert({
+        where: { id: 1 },
+        create: { id: 1, name: "Alice", age: NaN },
+        update: { name: "X" },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    aliceUnchanged(typed);
+  });
+});
+
+describe("nested write でもエラー", () => {
+  test("nested create の子データの NaN はエラーになり子が追加されない", () => {
+    const client = buildTestClient({ relations: true });
+    const users: any = sheetOf(client, "Users");
+    const posts = sheetOf(client, "Posts");
+    expect(() =>
+      users.create({
+        data: {
+          id: 9,
+          name: "Zed",
+          age: 1,
+          posts: { create: { id: 200, title: NaN } },
+        },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(posts.count({})).toBe(2);
+  });
+
+  test("nested update の子データの NaN はエラーになり子が更新されない", () => {
+    const client = buildTestClient({ relations: true });
+    const users: any = sheetOf(client, "Users");
+    const posts = sheetOf(client, "Posts");
+    expect(() =>
+      users.update({
+        where: { id: 1 },
+        data: {
+          posts: { update: { where: { id: 101 }, data: { title: NaN } } },
+        },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(posts.findFirst({ where: { id: 101 } })).toEqual({
+      id: 101,
+      authorId: 1,
+      title: "Post A",
+    });
+  });
+});
+
+describe("$transaction 経由", () => {
+  test("tx 内の NaN もエラーになりシートが変化しない", () => {
+    const env = buildTxTestEnv();
+    const tx = (env.client as any).$transaction.bind(env.client);
+    expect(() =>
+      tx((txClient: any) => {
+        txClient.Users.create({ data: { id: 9, name: "Zed", age: NaN } });
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+    ]);
+  });
+});
+
+describe("$extends 経由", () => {
+  test("query フックを素通しした data の NaN もエラー", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      query: {
+        Users: {
+          create({ args, query }) {
+            return query(args);
+          },
+        },
+      },
+    });
+    const loose: any = extended.Users;
+    expect(() =>
+      loose.create({ data: { id: 9, name: "Zed", age: NaN } }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(extended.Users.count({})).toBe(3);
+  });
+});
+
+describe("書ける値は従来どおり通る", () => {
+  test("数値・文字列・真偽値・null は通る", () => {
+    const { loose, typed } = looseUsers();
+    loose.create({ data: { id: 9, name: "Zed", age: 0 } });
+    loose.create({ data: { id: 10, name: "", age: null } });
+    loose.update({ where: { id: 9 }, data: { name: "Zed2" } });
+    expect(typed.count({})).toBe(5);
+  });
+
+  test("正常な Date は通る", () => {
+    const { loose, typed } = looseUsers();
+    loose.create({
+      data: { id: 9, name: "Z", age: new Date("2026-01-01T00:00:00Z") },
+    });
+    expect(typed.count({})).toBe(4);
+  });
+
+  test("Gassma.raw は素通し", () => {
+    const { loose, typed } = looseUsers();
+    loose.create({ data: { id: 9, name: raw("=SUM(A1:A2)"), age: 1 } });
+    expect(typed.count({})).toBe(4);
+  });
+
+  test("数値演算 increment は通る", () => {
+    const { loose, typed } = looseUsers();
+    loose.update({ where: { id: 1 }, data: { age: { increment: 5 } } });
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 25,
+    });
+  });
+});

--- a/src/util/validate/validateDataColumns.ts
+++ b/src/util/validate/validateDataColumns.ts
@@ -9,6 +9,7 @@ import { isDict } from "../other/isDict";
 import { isRawValue } from "../raw/raw";
 import { UPDATE_NESTED_WRITE_KEYS } from "../update/nestedWrite/extractRelationDataForUpdate";
 import { NUMBER_OPERATION_KEYS } from "../update/resolveNumberOperation";
+import { validateWritableValue } from "./validateWritableValue";
 
 type DataColumnMode = "create" | "createMany" | "update" | "updateMany";
 
@@ -27,14 +28,18 @@ const validateColumnOperations = (
   value: unknown,
   mode: DataColumnMode,
 ): void => {
-  if (!isPlainObjectValue(value)) return;
+  if (!isPlainObjectValue(value)) {
+    validateWritableValue(key, value);
+    return;
+  }
   if (mode === "create" || mode === "createMany") {
     throw new GassmaInvalidValueError(key, "a scalar value");
   }
-  Object.keys(value).forEach((operationKey) => {
+  Object.entries(value).forEach(([operationKey, operationValue]) => {
     if (!NUMBER_OPERATION_KEYS.includes(operationKey)) {
       throw new GassmaUnknownArgumentError(operationKey, NUMBER_OPERATION_KEYS);
     }
+    validateWritableValue(operationKey, operationValue);
   });
 };
 

--- a/src/util/validate/validateWritableValue.ts
+++ b/src/util/validate/validateWritableValue.ts
@@ -1,0 +1,35 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import { isDateValue } from "../other/isDateValue";
+
+const validateWritableValue = (key: string, value: unknown): void => {
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    throw new GassmaInvalidValueError(
+      key,
+      `a finite number, but received ${String(value)}`,
+    );
+  }
+  if (isDateValue(value) && Number.isNaN(value.getTime())) {
+    throw new GassmaInvalidValueError(
+      key,
+      "a valid Date, but the provided Date object is invalid",
+    );
+  }
+  if (Array.isArray(value)) {
+    throw new GassmaInvalidValueError(
+      key,
+      "a scalar value, but received an array",
+    );
+  }
+  if (
+    typeof value === "function" ||
+    typeof value === "symbol" ||
+    typeof value === "bigint"
+  ) {
+    throw new GassmaInvalidValueError(
+      key,
+      `a scalar value, but received a ${typeof value}`,
+    );
+  }
+};
+
+export { validateWritableValue };


### PR DESCRIPTION
gassma は利用者から受け取った値を検証せずセルに書いていました。

```js
create({ data: { 年齢: Number("abc") } })   // NaN がそのまま書かれる
```

**実機で確認したところ、`setValue(NaN)` は書けてしまい、セルは文字列 `"#NUM!"` になります。** 数値列に文字列が入り、以降その列は数値と文字列の混在になります。エラーは出ません。

入り口は現実的で、`Number("abc")` や `parseInt` の失敗からそのまま入ります。

## NaN だけではありませんでした

実測したところ、**以下がすべて黙って書かれていました**。

`NaN` / `±Infinity` / `Invalid Date` / **配列** / **関数** / **Symbol** / **BigInt** / `{ increment: NaN }` のような数値演算の値

すべて拒否対象にしました。

## なぜ「null に変換」ではなく「エラー」か

**NaN は「空」ではなく「数値として解釈できなかった」という意味だからです。**

```js
Number("")      // → 0     空欄は 0 になる
Number("abc")   // → NaN   数値として解釈できなかった
```

空欄は `0` になるので、**NaN が出るのは実際に不正な入力があったとき**です。null に変換すると「年齢が未入力」という**事実と違う記録**が残ります。

### Prisma は変換します。しかしそれは設計ではありません

**Prisma 7.4.1 + SQLite で実測しました。**

| 入力 | Prisma |
|---|---|
| `Int`(必須)+ NaN | `Argument \`reqInt\` is missing.` ← **値は渡しているのに「無い」と言われる** |
| **`Int?` + NaN** | **黙って NULL 保存** |
| `Float`(必須)+ NaN | DB 到達後に制約違反(P2011) |
| **`Invalid Date`** | **`Provided Date object is invalid.`** ← 唯一の意図的な検証 |

**これは一貫した設計ではなく、JSON プロトコルの副作用です。** Prisma v5 以降のクライアント⇔エンジン間プロトコルは JSON ベースで、**JSON は NaN / Infinity を表現できません**。その結果、Int の必須列では「値を渡しているのに Argument missing」という的外れなエラーになり、nullable 列では**黙って NULL** になります。

**Prisma 自身が未サポートを認めています。**

> Currently Prisma does not support NaN type at all, which leads to errors
> — [prisma/prisma#3492 "Support NaN"](https://github.com/prisma/prisma/issues/3492)(未解決)

つまり **「null に変換」は Prisma がやっていて、かつ問題視されている挙動**そのものです。このプロジェクトは「可能な限り Prisma に合わせる」方針ですが、**ここは合わせません**。

### 参考資料

- **[prisma/prisma#3492 "Support NaN"](https://github.com/prisma/prisma/issues/3492)** — Prisma が NaN を一切サポートしていないことを認めている issue(未解決)
- [prisma/prisma#28050](https://github.com/prisma/prisma/issues/28050) — 「Argument missing」という的外れなエラーがバグとして報告されているもの
- [jsonProtocol changes](https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-5/jsonprotocol-changes) — JSON プロトコル移行の説明(NaN を表現できない根拠)
- 公式ドキュメントに NaN / Infinity の挙動を説明するページは**存在しません**([Null and undefined](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/null-and-undefined) は null / undefined のみ)

## エラーメッセージ

既存の `GassmaInvalidValueError` を使っています(**新しいエラークラスは追加していません**)。文言は **Prisma の Invalid Date 検証(唯一の意図的な設計)**の書き方に倣いました。

```
Invalid value for argument `age`. Expected a finite number, but received NaN.
Invalid value for argument `age`. Expected a finite number, but received Infinity.
Invalid value for argument `name`. Expected a valid Date, but the provided Date object is invalid.
Invalid value for argument `name`. Expected a scalar value, but received an array.
Invalid value for argument `increment`. Expected a finite number, but received NaN.
```

**受け取った値を明示**しています。NaN と Infinity では原因の追跡先が変わるためです。

## 実装

`validateDataColumns`(#199 / #200 / #203 で作った**単一のチョークポイント**)に乗せました。全書き込み経路がここを通ります。

create / createMany / updateMany / update / updateManyAndReturn / **`upsert` の両分岐**(未実行の枝も事前検証)/ nested create / nested update。

**副作用の前**に、**既に取得済みの titles 上で**検証するので、**見出しの読みは増えません**(契約テストで確認済み)。判定は realm 安全です(`typeof` / `Array.isArray` / `isDateValue` + `Number.isNaN(getTime())`)。

## 検証結果

- `npm test`: **2,648件 全 green**(2,624 → +24)
- 往復契約テスト3スイート31件 green
- `tsc --noEmit` / lint(警告は main と同数)/ format / `verify:bundle`(公開シンボル57件)pass

拒否20件・素通し4件のテストに加え、正常な数値 / 文字列 / 真偽値 / `null` / 正常な Date / `Gassma.raw` / `increment`、nested write の正常系、`$transaction`、`$extends` の非回帰を確認しています。

### 変更した既存テスト(1件)

`createDataValidation.test.ts` の「**配列値は従来どおり素通しされる**」を「配列値もエラーになり追加されない」に更新しました。

これは #199 の時点で**当時の挙動を固定した**もので、今回「配列は現状の挙動を確認したうえで判断してほしい」と委ねた箇所そのものです。元のテストの `count=3` は「シード2行 + 配列の行が実際に書かれて3」であり、**素通ししていた証拠**でした。**これ以外の既存テストはすべて無変更**です。

## 判断が要る点

**`Gassma.raw(NaN)` のような不正値の raw 包みは素通しです。** `raw` はエスケープハッチであり、型シグネチャ上は string のみを受けるため実害は限定的と判断しました。

また、nested write の after 段階の子(親が FK を持たない側)は、**子の書き込み前には検証されるものの親行の書き込み後**になります。これは #199 / #200 の列名検証と同じ順序で、本 PR で新たな順序保証は足していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)