### PR TITLE
fix: NaN / Invalid Date を1グループにまとめ、集計では欠損として扱う

### DIFF
--- a/src/__test__/util/aggregate/aggregateUtil/avg.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/avg.test.ts
@@ -32,6 +32,20 @@ describe("getAvg", () => {
     });
   });
 
+  test("should ignore NaN like null (denominator excludes NaN)", () => {
+    const rows = [{ age: 20 }, { age: 30 }, { age: NaN }];
+    const result = getAvg(rows, { age: true });
+
+    expect(result).toEqual({ age: 25 });
+  });
+
+  test("should return null when all values are NaN", () => {
+    const rows = [{ age: NaN }, { age: NaN }];
+    const result = getAvg(rows, { age: true });
+
+    expect(result).toEqual({ age: null });
+  });
+
   test("should handle mixed null and numeric values", () => {
     const rows = [
       { age: 10, score: null },

--- a/src/__test__/util/aggregate/aggregateUtil/count.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/count.test.ts
@@ -51,6 +51,27 @@ describe("getCount", () => {
     });
   });
 
+  test("should exclude NaN and Invalid Date from field counts like null", () => {
+    const rows = [
+      { age: 10, at: new Date(1700000000000) },
+      { age: NaN, at: new Date("invalid") },
+      { age: 30, at: new Date("invalid") },
+    ];
+    const result = getCount(rows, { age: true, at: true });
+
+    expect(result).toEqual({
+      age: 2,
+      at: 1,
+    });
+  });
+
+  test("should count NaN rows in _all", () => {
+    const rows = [{ age: 10 }, { age: NaN }];
+    const result = getCount(rows, { _all: true, age: true });
+
+    expect(result).toEqual({ _all: 2, age: 1 });
+  });
+
   test("should count zero and false as valid values", () => {
     const rows = [
       { num: 0, flag: false },

--- a/src/__test__/util/aggregate/aggregateUtil/maxMinSemantics.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/maxMinSemantics.test.ts
@@ -95,13 +95,18 @@ describe("string max/min semantics", () => {
 });
 
 describe("number max/min semantics", () => {
-  test("NaN propagates", () => {
+  test("NaN is ignored like null", () => {
     expect(getMax([{ v: 1 }, { v: NaN }, { v: 2 }], { v: true })).toEqual({
-      v: NaN,
+      v: 2,
     });
     expect(getMin([{ v: 1 }, { v: NaN }, { v: 2 }], { v: true })).toEqual({
-      v: NaN,
+      v: 1,
     });
+  });
+
+  test("all NaN yields null", () => {
+    expect(getMax([{ v: NaN }, { v: NaN }], { v: true })).toEqual({ v: null });
+    expect(getMin([{ v: NaN }, { v: NaN }], { v: true })).toEqual({ v: null });
   });
 
   test("Infinity and -Infinity are handled", () => {
@@ -140,6 +145,21 @@ describe("date max/min semantics", () => {
     const b = new Date(1700000000000);
     expect(getDateMax([a, b]).getTime()).toBe(1700000000000);
     expect(getDateMin([a, b]).getTime()).toBe(1700000000000);
+  });
+
+  test("getMax/getMin ignore Invalid Date like null", () => {
+    const invalid = new Date("invalid");
+    const early = new Date(1600000000000);
+    const late = new Date(1700000000000);
+    const rows = [{ v: early }, { v: invalid }, { v: late }];
+    expect(getMax(rows, { v: true })).toEqual({ v: late });
+    expect(getMin(rows, { v: true })).toEqual({ v: early });
+  });
+
+  test("getMax/getMin with only Invalid Date yield null", () => {
+    const rows = [{ v: new Date("invalid") }, { v: new Date("invalid") }];
+    expect(getMax(rows, { v: true })).toEqual({ v: null });
+    expect(getMin(rows, { v: true })).toEqual({ v: null });
   });
 
   test("Invalid Date propagates as Invalid Date", () => {

--- a/src/__test__/util/aggregate/aggregateUtil/sum.test.ts
+++ b/src/__test__/util/aggregate/aggregateUtil/sum.test.ts
@@ -46,6 +46,20 @@ describe("getSum", () => {
     });
   });
 
+  test("should ignore NaN like null", () => {
+    const rows = [{ age: 20 }, { age: 30 }, { age: NaN }];
+    const result = getSum(rows, { age: true });
+
+    expect(result).toEqual({ age: 50 });
+  });
+
+  test("should return null when all values are NaN", () => {
+    const rows = [{ age: NaN }, { age: NaN }];
+    const result = getSum(rows, { age: true });
+
+    expect(result).toEqual({ age: null });
+  });
+
   test("should throw GassmaAggregateSumError for mixed data types", () => {
     const rows = [{ field: 10 }, { field: "string" }, { field: 30 }];
 

--- a/src/__test__/util/groupby/groupbyNanInvalidDate.test.ts
+++ b/src/__test__/util/groupby/groupbyNanInvalidDate.test.ts
@@ -1,0 +1,109 @@
+import type { GassmaControllerUtil } from "../../../types/gassmaControllerUtilType";
+import { aggregateFunc } from "../../../util/aggregate/aggregate";
+import { groupByFunc } from "../../../util/groupby/groupby";
+import { expectArrayToEqualIgnoringOrder } from "../../helpers/matchers";
+
+const getNanMockControllerUtil = (): GassmaControllerUtil => {
+  const data = [
+    ["id", "名前", "年齢"],
+    [1, "Alice", 20],
+    [2, "Bob", 30],
+    [9, "FromForm", NaN],
+    [10, "FromForm2", NaN],
+  ];
+
+  return {
+    sheet: {
+      getDataRange: () => ({
+        getValues: () => data.map((row) => [...row]),
+      }),
+      getLastRow: () => data.length,
+      getLastColumn: () => 3,
+      getRange: (row: number, _col: number, numRows: number) => ({
+        getValues: () =>
+          row === 1 && numRows === 1
+            ? [[...data[0]]]
+            : data.slice(1).map((dataRow) => [...dataRow]),
+      }),
+    } as any,
+    startRowNumber: 1,
+    startColumnNumber: 1,
+    endColumnNumber: 3,
+  };
+};
+
+describe("groupBy with NaN values", () => {
+  test("NaN rows form a single group instead of crashing", () => {
+    const result = groupByFunc(getNanMockControllerUtil(), { by: "年齢" });
+
+    expectArrayToEqualIgnoringOrder(result, [
+      { 年齢: 20 },
+      { 年齢: 30 },
+      { 年齢: NaN },
+    ]);
+  });
+
+  test("NaN rows are not dropped when NaN column is not the last by column", () => {
+    const result = groupByFunc(getNanMockControllerUtil(), {
+      by: ["年齢", "名前"],
+    });
+
+    expectArrayToEqualIgnoringOrder(result, [
+      { 年齢: 20, 名前: "Alice" },
+      { 年齢: 30, 名前: "Bob" },
+      { 年齢: NaN, 名前: "FromForm" },
+      { 年齢: NaN, 名前: "FromForm2" },
+    ]);
+  });
+
+  test("aggregates inside groupBy ignore NaN", () => {
+    const result = groupByFunc(getNanMockControllerUtil(), {
+      by: "名前",
+      _count: { _all: true, 年齢: true },
+    });
+
+    expectArrayToEqualIgnoringOrder(result, [
+      { 名前: "Alice", _count: { _all: 1, 年齢: 1 } },
+      { 名前: "Bob", _count: { _all: 1, 年齢: 1 } },
+      { 名前: "FromForm", _count: { _all: 1, 年齢: 0 } },
+      { 名前: "FromForm2", _count: { _all: 1, 年齢: 0 } },
+    ]);
+  });
+
+  test("having still filters groups when NaN rows exist", () => {
+    const result = groupByFunc(getNanMockControllerUtil(), {
+      by: "年齢",
+      having: { 年齢: { _min: { gte: 25 } } },
+    });
+
+    expect(result).toEqual([{ 年齢: 30 }]);
+  });
+});
+
+describe("aggregate with NaN values", () => {
+  test("_max/_min/_sum/_avg ignore NaN rows", () => {
+    const result = aggregateFunc(getNanMockControllerUtil(), {
+      _max: { 年齢: true },
+      _min: { 年齢: true },
+      _sum: { 年齢: true },
+      _avg: { 年齢: true },
+    });
+
+    expect(result).toEqual({
+      _max: { 年齢: 30 },
+      _min: { 年齢: 20 },
+      _sum: { 年齢: 50 },
+      _avg: { 年齢: 25 },
+    });
+  });
+
+  test("_count counts NaN as missing for the field but keeps the row in _all", () => {
+    const result = aggregateFunc(getNanMockControllerUtil(), {
+      _count: { _all: true, 年齢: true },
+    });
+
+    expect(result).toEqual({
+      _count: { _all: 4, 年齢: 2 },
+    });
+  });
+});

--- a/src/__test__/util/groupby/groupbyUtil/byClassification.test.ts
+++ b/src/__test__/util/groupby/groupbyUtil/byClassification.test.ts
@@ -115,8 +115,8 @@ describe("byClassification の型区別", () => {
   });
 });
 
-describe("byClassification の NaN / Invalid Date(現行挙動の保存)", () => {
-  test("NaN キーは初出位置に空グループを残し行は含まれない", () => {
+describe("byClassification の NaN / Invalid Date", () => {
+  test("NaN の行は初出位置の1グループにまとまる", () => {
     const rows = [
       { k: 1, v: "a" },
       { k: NaN, v: "b" },
@@ -126,43 +126,85 @@ describe("byClassification の NaN / Invalid Date(現行挙動の保存)", () =>
 
     const result = byClassification(rows, ["k"]);
 
-    expect(result).toEqual([[{ k: 1, v: "a" }], [], [{ k: 2, v: "c" }]]);
+    expect(result).toEqual([
+      [{ k: 1, v: "a" }],
+      [
+        { k: NaN, v: "b" },
+        { k: NaN, v: "d" },
+      ],
+      [{ k: 2, v: "c" }],
+    ]);
   });
 
-  test("Invalid Date は同一インスタンスで1つ・別インスタンスで別の空グループ", () => {
+  test("Invalid Date は別インスタンスでも1グループにまとまる", () => {
     const shared = new Date("invalid");
+    const another = new Date("invalid");
     const rows = [
       { k: shared, v: "a" },
       { k: shared, v: "b" },
-      { k: new Date("invalid"), v: "c" },
+      { k: another, v: "c" },
       { k: 1, v: "d" },
     ];
 
     const result = byClassification(rows, ["k"]);
 
-    expect(result).toEqual([[], [], [{ k: 1, v: "d" }]]);
+    expect(result).toEqual([
+      [
+        { k: shared, v: "a" },
+        { k: shared, v: "b" },
+        { k: another, v: "c" },
+      ],
+      [{ k: 1, v: "d" }],
+    ]);
   });
 
-  test("深さ2: 非最終カラムの NaN 行は空グループを残さず消える", () => {
+  test("深さ2: 非最終カラムの NaN 行も消えない", () => {
     const rows = [
       { a: NaN, b: 1, v: "x" },
       { a: 1, b: 1, v: "y" },
+      { a: NaN, b: 2, v: "z" },
     ];
 
     const result = byClassification(rows, ["a", "b"]);
 
-    expect(result).toEqual([[{ a: 1, b: 1, v: "y" }]]);
+    expect(result).toEqual([
+      [{ a: NaN, b: 1, v: "x" }],
+      [{ a: NaN, b: 2, v: "z" }],
+      [{ a: 1, b: 1, v: "y" }],
+    ]);
   });
 
-  test("深さ2: 最終カラムの NaN は空グループを残す", () => {
+  test("深さ2: 最終カラムの NaN も1グループになる", () => {
     const rows = [
       { a: 1, b: NaN, v: "x" },
       { a: 1, b: 2, v: "y" },
+      { a: 1, b: NaN, v: "z" },
     ];
 
     const result = byClassification(rows, ["a", "b"]);
 
-    expect(result).toEqual([[], [{ a: 1, b: 2, v: "y" }]]);
+    expect(result).toEqual([
+      [
+        { a: 1, b: NaN, v: "x" },
+        { a: 1, b: NaN, v: "z" },
+      ],
+      [{ a: 1, b: 2, v: "y" }],
+    ]);
+  });
+
+  test("NaN と null は別グループ", () => {
+    const rows = [{ k: NaN }, { k: null }, { k: NaN }];
+
+    const result = byClassification(rows, ["k"]);
+
+    expect(result).toEqual([[{ k: NaN }, { k: NaN }], [{ k: null }]]);
+  });
+
+  test("Invalid Date と NaN は別グループ", () => {
+    const invalid = new Date("invalid");
+    const rows = [{ k: invalid }, { k: NaN }];
+
+    expect(byClassification(rows, ["k"])).toHaveLength(2);
   });
 });
 

--- a/src/util/aggregate/aggregateUtil/avg.ts
+++ b/src/util/aggregate/aggregateUtil/avg.ts
@@ -1,3 +1,4 @@
+import { isMissingAggregateValue } from "./isMissingAggregateValue";
 import {
   GassmaAggregateAvgError,
   GassmaAggregateAvgTypeError,
@@ -12,13 +13,9 @@ const getAvg = (rows: Record<string, any>[], avgData: Select) => {
   const avgResult = {};
 
   avgKeys.forEach((key) => {
-    const hitsDataIncludeNull = rows.map((row) => {
-      if (row[key] === null || row[key] === undefined) return null;
-
-      return row[key];
-    });
-
-    const hitsData = hitsDataIncludeNull.filter((row) => row !== null);
+    const hitsData = rows
+      .map((row) => row[key])
+      .filter((value) => !isMissingAggregateValue(value));
 
     if (hitsData.length === 0) {
       avgResult[key] = null;

--- a/src/util/aggregate/aggregateUtil/count.ts
+++ b/src/util/aggregate/aggregateUtil/count.ts
@@ -1,4 +1,5 @@
 import type { Select } from "../../../types/coreTypes";
+import { isMissingAggregateValue } from "./isMissingAggregateValue";
 
 const getCount = (rows: Record<string, any>[], countData: Select | true) => {
   if (countData === true) return rows.length;
@@ -13,9 +14,9 @@ const getCount = (rows: Record<string, any>[], countData: Select | true) => {
       return;
     }
 
-    const hitCount = rows.filter((row) => {
-      return row[key] !== null && row[key] !== undefined;
-    }).length;
+    const hitCount = rows.filter(
+      (row) => !isMissingAggregateValue(row[key]),
+    ).length;
 
     countResult[key] = hitCount;
   });

--- a/src/util/aggregate/aggregateUtil/isMissingAggregateValue.ts
+++ b/src/util/aggregate/aggregateUtil/isMissingAggregateValue.ts
@@ -1,0 +1,10 @@
+import { isDateValue } from "../../other/isDateValue";
+
+// SQL の集計が NULL を無視するのに合わせ、NaN / Invalid Date も欠損として扱う
+const isMissingAggregateValue = (value: unknown): boolean => {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "number" && Number.isNaN(value)) return true;
+  return isDateValue(value) && Number.isNaN(value.getTime());
+};
+
+export { isMissingAggregateValue };

--- a/src/util/aggregate/aggregateUtil/max.ts
+++ b/src/util/aggregate/aggregateUtil/max.ts
@@ -1,3 +1,4 @@
+import { isMissingAggregateValue } from "./isMissingAggregateValue";
 import {
   GassmaAggregateMaxError,
   GassmaAggregateTypeError,
@@ -14,13 +15,9 @@ const getMax = (rows: Record<string, any>[], avgData: Select) => {
   const maxResult = {};
 
   maxKeys.forEach((key) => {
-    const hitsDataIncludeNull = rows.map((row) => {
-      if (row[key] === null || row[key] === undefined) return null;
-
-      return row[key];
-    });
-
-    const hitsData = hitsDataIncludeNull.filter((row) => row !== null);
+    const hitsData = rows
+      .map((row) => row[key])
+      .filter((value) => !isMissingAggregateValue(value));
 
     if (hitsData.length === 0) {
       maxResult[key] = null;

--- a/src/util/aggregate/aggregateUtil/min.ts
+++ b/src/util/aggregate/aggregateUtil/min.ts
@@ -1,3 +1,4 @@
+import { isMissingAggregateValue } from "./isMissingAggregateValue";
 import {
   GassmaAggregateMinError,
   GassmaAggregateTypeError,
@@ -14,13 +15,9 @@ const getMin = (rows: Record<string, any>[], avgData: Select) => {
   const minResult = {};
 
   minKeys.forEach((key) => {
-    const hitsDataIncludeNull = rows.map((row) => {
-      if (row[key] === null || row[key] === undefined) return null;
-
-      return row[key];
-    });
-
-    const hitsData = hitsDataIncludeNull.filter((row) => row !== null);
+    const hitsData = rows
+      .map((row) => row[key])
+      .filter((value) => !isMissingAggregateValue(value));
 
     if (hitsData.length === 0) {
       minResult[key] = null;

--- a/src/util/aggregate/aggregateUtil/sum.ts
+++ b/src/util/aggregate/aggregateUtil/sum.ts
@@ -1,3 +1,4 @@
+import { isMissingAggregateValue } from "./isMissingAggregateValue";
 import {
   GassmaAggregateSumError,
   GassmaAggregateSumTypeError,
@@ -12,13 +13,9 @@ const getSum = (rows: Record<string, any>[], avgData: Select) => {
   const sumResult = {};
 
   sumKeys.forEach((key) => {
-    const hitsDataIncludeNull = rows.map((row) => {
-      if (row[key] === null || row[key] === undefined) return null;
-
-      return row[key];
-    });
-
-    const hitsData = hitsDataIncludeNull.filter((row) => row !== null);
+    const hitsData = rows
+      .map((row) => row[key])
+      .filter((value) => !isMissingAggregateValue(value));
 
     if (hitsData.length === 0) {
       sumResult[key] = null;

--- a/src/util/groupby/groubyUtil/by.ts
+++ b/src/util/groupby/groubyUtil/by.ts
@@ -1,10 +1,4 @@
-import { isDateValue } from "../../other/isDateValue";
 import { toLookupKey } from "../../other/toLookupKey";
-
-const isSelfUnequal = (value: unknown): boolean =>
-  isDateValue(value)
-    ? Number.isNaN(value.getTime())
-    : typeof value === "number" && Number.isNaN(value);
 
 const groupByColumn = (
   rows: Record<string, any>[],
@@ -13,17 +7,15 @@ const groupByColumn = (
   const groups = new Map<unknown, Record<string, any>[]>();
 
   rows.forEach((row) => {
-    const data = row[column];
-    const selfUnequal = isSelfUnequal(data);
-    const key = selfUnequal && isDateValue(data) ? data : toLookupKey(data);
+    const key = toLookupKey(row[column]);
     const group = groups.get(key);
 
     if (group === undefined) {
-      groups.set(key, selfUnequal ? [] : [row]);
+      groups.set(key, [row]);
       return;
     }
 
-    if (!selfUnequal) group.push(row);
+    group.push(row);
   });
 
   return Array.from(groups.values());


### PR DESCRIPTION
`LLM/semantics-bugs.html` の **F**、および `LLM/remaining-bugs-e-f.html` で説明した F-1 への対応です。

## 問題

`age` 列に NaN が1つ混ざっただけで、こうなります。

| 操作 | 修正前 | 修正後 |
|---|---|---|
| `groupBy({ by: "年齢" })` | **TypeError: Cannot read properties of undefined** | 3グループ |
| `groupBy({ by: ["年齢","名前"] })` | **NaN の2行が黙って消える** | 4グループ、行消失なし |
| `_max` | `null` | **30** |
| `_min` | `null` | **20** |
| `_sum` | `null` | **50** |
| `_avg` | `null` | **25**(分母も NaN 除外で2) |
| `_count: { 年齢 }` | 4(NaN を数える) | **2**(`_all` は 4 のまま) |

## 原因

グループの**収集**と**振り分け**で判定が非対称でした。

| | 使う判定 | NaN 同士は |
|---|---|---|
| 収集(ユニーク値を集める) | `includes`(SameValueZero) | **等しい** |
| 振り分け(行をグループへ) | `isValueEqual`(`===`) | **等しくない** |

キーとしては登録されるのに、そこに入る行が1つも無い。**誰も入っていない空グループ**ができます。最終カラムなら先頭要素を参照して `TypeError`、非最終カラムなら `flat` で消滅して**行ごと消えます**。

Invalid Date も同じで、`getTime()` が `NaN` なので **同一インスタンスでも `isValueEqual` が false** になります。

**この非対称は `isSelfUnequal` として明示的に書かれていました。** #191(groupBy の Map 化)が**性能改善の PR で仕様を変えない**ために意図的に保存したものです。今回それを外します。

## 修正

**1. groupBy** — `isSelfUnequal` の分岐を削除し、全値を `toLookupKey` でキー化。Map は SameValueZero なので NaN 同士は同一キーになり、Invalid Date は `toLookupKey` が `date:NaN` に正規化するので別インスタンスでも同一キーになります。**SQL の `GROUP BY` が NULL を1つの等価クラスにまとめるのと同じ**発想です。

**2. 集計** — 欠損値の判定を1箇所に集約し、**NaN / Invalid Date を null と同じ「欠損」として無視**します。

### 集計の方針を「無視」にした理由

1. **SQL の集計が NULL を無視するのと同型**です。特に **SQLite(実在の Prisma バックエンド)は NaN を NULL として格納する**ので、Prisma + SQLite の実挙動と一致します
2. 「NaN を伝播」させると**1つの NaN が列全体の結果を毒します**。しかも GAS 境界の JSON 化で NaN は null になるため、**「データが無かった」と区別できません**(修正前に `null` が返っていたのはこれが正体です)
3. **`_count` も無視に含めました。** `_max` は無視するのに `_count` は数えると「count が3なのに sum は2件分」という不整合が出ます。SQL でも `COUNT(col)` は NULL を数えません

**「NaN が含まれていた」という情報は `_count: { _all: true }` と `_count: { 列 }` の差で検出できます。** SQL で NULL を検出するのとまったく同じ方法です。

## #191 の性能は落ちていません

同一プロセスで旧実装と比較しました(`by` 3カラム)。

| n | 修正前 | 修正後 |
|---|---|---|
| 1,600 | 0.31ms | **0.25ms** |
| 16,000 | 1.94ms | **1.66ms** |
| 160,000 | 18.94ms | **15.51ms** |

10倍スケールで時間も約10倍、線形を維持しています。**分岐が減ったぶん僅かに速く**なりました。

## 検証結果

- `npm test`: **2,641件 全 green**(2,624 → +17)
- 往復契約テスト3スイート31件 green
- `tsc --noEmit` / lint(警告は main と同数)/ format / `verify:bundle`(公開シンボル57件)pass

修正前の挙動は、src だけ stash して新テストを旧実装に当てて **TypeError と行消失を実記録**しています。

### 変更した既存テスト

**1. `byClassification.test.ts` の「NaN / Invalid Date(現行挙動の保存)」4件** — #191 が意図的に固定した空グループと行消失の挙動です。**今回はまさにその仕様変更が目的**なので、新仕様の6件に置換しました。

**2. `maxMinSemantics.test.ts` の `NaN propagates`** — `NaN is ignored like null` に変更。集計方針の変更そのものです。

## 判断が要る点

**`_count` のフィールドカウントから NaN を除外しました。** PostgreSQL は NaN を実在値として数えるので「数える」も擁護可能でしたが、`_max` らと同一の欠損定義にすること・SQLite の実挙動・`_all` との差分で存在を検出できることから除外を選びました。**ここが唯一の実質的な仕様判断**です。

## 別途見つかった不整合(**本 PR では未修正**)

`distinct` / `orderBy` / `where` を確認したところ、**4件の不整合**が見つかりました。判断をお願いします。

**1. `where` の等価判定が2系統ある** — `where: { age: NaN }` は何にもマッチしないのに、**`where: { age: { in: [NaN] } }` は NaN 行にマッチ**します(前者は `===`、後者は Set の SameValueZero)。

**2. `in` の Invalid Date がインスタンス依存** — 同一インスタンスなら true、別インスタンスなら false。

**3. `distinct` が NaN / null / Invalid Date を全部同一視** — `JSON.stringify` をキーにしているため3つとも `"null"` に潰れ、**行が黙って消えます**。実測で `[NaN, null, invalidDate, NaN, 1]` → `[NaN, 1]`。今回の groupBy(3つとも別グループ)とも食い違います。**おまけに Date と、それと同値の ISO 文字列も衝突します**(これは NaN と無関係に踏める実害です)。

**4. `orderBy` で NaN があるとソート自体が崩れる** — 比較が両方向 false になり推移律が破れます。実測で `[3, NaN, 1, null, 2]` の昇順が **`[null, 3, NaN, 1, 2]`**。null には `nulls first/last` の明示処理があるのに NaN は素通りしています。

**3 と 4 が実害候補**です。特に 3 の「Date と ISO 文字列の衝突」は、NaN を書き込み前に弾く #211 が入っても残ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)