### PR TITLE
fix: distinct のキー衝突と orderBy のソート崩壊を直す

### DIFF
--- a/src/__test__/util/find/findUtil/applyDistinct.test.ts
+++ b/src/__test__/util/find/findUtil/applyDistinct.test.ts
@@ -1,0 +1,126 @@
+import { applyDistinct } from "../../../../util/find/findUtil/applyDistinct";
+
+describe("applyDistinct", () => {
+  test("should keep first occurrence for a single column", () => {
+    const result = applyDistinct(
+      [
+        { id: 1, v: "a" },
+        { id: 2, v: "b" },
+        { id: 3, v: "a" },
+      ],
+      ["v"],
+    );
+    expect(result).toEqual([
+      { id: 1, v: "a" },
+      { id: 2, v: "b" },
+    ]);
+  });
+
+  test("should accept a plain string as distinct key", () => {
+    const result = applyDistinct([{ v: 1 }, { v: 1 }, { v: 2 }], "v");
+    expect(result).toEqual([{ v: 1 }, { v: 2 }]);
+  });
+
+  test("should not collapse a Date with its ISO string", () => {
+    const rows = [
+      { id: 1, v: new Date("2024-01-01T00:00:00.000Z") },
+      { id: 2, v: "2024-01-01T00:00:00.000Z" },
+    ];
+    expect(applyDistinct(rows, ["v"])).toEqual(rows);
+  });
+
+  test("should keep NaN, null, Invalid Date and numbers as separate rows", () => {
+    const result = applyDistinct(
+      [
+        { id: 1, v: Number.NaN },
+        { id: 2, v: null },
+        { id: 3, v: new Date("invalid") },
+        { id: 4, v: Number.NaN },
+        { id: 5, v: 1 },
+      ],
+      ["v"],
+    );
+    expect(result.map((row) => row.id)).toEqual([1, 2, 3, 5]);
+  });
+
+  test("should collapse null rows together", () => {
+    const result = applyDistinct(
+      [
+        { id: 1, v: null },
+        { id: 2, v: null },
+        { id: 3, v: 1 },
+      ],
+      ["v"],
+    );
+    expect(result.map((row) => row.id)).toEqual([1, 3]);
+  });
+
+  test("should not collapse a number with its string form", () => {
+    const rows = [
+      { id: 1, v: 1 },
+      { id: 2, v: "1" },
+    ];
+    expect(applyDistinct(rows, ["v"])).toEqual(rows);
+  });
+
+  test("should collapse Invalid Date instances together", () => {
+    const result = applyDistinct(
+      [
+        { id: 1, v: new Date("invalid") },
+        { id: 2, v: new Date("nope") },
+      ],
+      ["v"],
+    );
+    expect(result.map((row) => row.id)).toEqual([1]);
+  });
+
+  test("should collapse Dates with the same time but different instances", () => {
+    const result = applyDistinct(
+      [
+        { id: 1, v: new Date("2024-01-01T00:00:00.000Z") },
+        { id: 2, v: new Date("2024-01-01T00:00:00.000Z") },
+      ],
+      ["v"],
+    );
+    expect(result.map((row) => row.id)).toEqual([1]);
+  });
+
+  describe("multiple columns", () => {
+    test("should deduplicate on the combination of columns", () => {
+      const result = applyDistinct(
+        [
+          { id: 1, a: "x", b: 1 },
+          { id: 2, a: "x", b: 2 },
+          { id: 3, a: "x", b: 1 },
+          { id: 4, a: "y", b: 1 },
+        ],
+        ["a", "b"],
+      );
+      expect(result.map((row) => row.id)).toEqual([1, 2, 4]);
+    });
+
+    test("should not collide when a separator-like text sits in a column", () => {
+      const rows = [
+        { id: 1, a: "x|y", b: "" },
+        { id: 2, a: "x", b: "y" },
+      ];
+      expect(applyDistinct(rows, ["a", "b"])).toEqual(rows);
+    });
+
+    test("should not collide when a column embeds another column's key text", () => {
+      const rows = [
+        { id: 1, a: "x|str:y", b: "" },
+        { id: 2, a: "x", b: "y|str:" },
+      ];
+      expect(applyDistinct(rows, ["a", "b"])).toEqual(rows);
+    });
+
+    test("should not collide Date and ISO string inside a composite key", () => {
+      const rows = [
+        { id: 1, a: new Date("2024-01-01T00:00:00.000Z"), b: 1 },
+        { id: 2, a: "2024-01-01T00:00:00.000Z", b: 1 },
+      ];
+      expect(applyDistinct(rows, ["a", "b"])).toEqual(rows);
+    });
+  });
+});

--- a/src/__test__/util/find/findUtil/orderByMissing.test.ts
+++ b/src/__test__/util/find/findUtil/orderByMissing.test.ts
@@ -1,0 +1,144 @@
+import { orderByFunc } from "../../../../util/find/findUtil/orderBy";
+import type { OrderBy } from "../../../../types/coreTypes";
+import { isDateValue } from "../../../../util/other/isDateValue";
+
+const canonical = (value: unknown): unknown => {
+  if (value === null || value === undefined) return "missing";
+  if (typeof value === "number" && Number.isNaN(value)) return "missing";
+  if (isDateValue(value)) {
+    return Number.isNaN(value.getTime()) ? "missing" : value.getTime();
+  }
+  return value;
+};
+
+const toRows = (values: unknown[]): Record<string, unknown>[] =>
+  values.map((v, i) => ({ id: i, v }));
+
+const sortedCanonical = (values: unknown[], orderBy: OrderBy[]): unknown[] =>
+  orderByFunc(toRows(values), orderBy).map((row) => canonical(row.v));
+
+const permutations = (values: unknown[]): unknown[][] => {
+  if (values.length <= 1) return [values];
+  return values.flatMap((v, i) =>
+    permutations([...values.slice(0, i), ...values.slice(i + 1)]).map(
+      (rest) => [v, ...rest],
+    ),
+  );
+};
+
+describe("orderBy with missing values (null / NaN / Invalid Date)", () => {
+  test("should sort numbers with NaN and null mixed (asc, defaults first)", () => {
+    expect(
+      sortedCanonical([3, Number.NaN, 1, null, 2], [{ v: "asc" }]),
+    ).toEqual(["missing", "missing", 1, 2, 3]);
+  });
+
+  test("should move a leading NaN with the missing group (asc)", () => {
+    expect(sortedCanonical([Number.NaN, 3, 1, 2], [{ v: "asc" }])).toEqual([
+      "missing",
+      1,
+      2,
+      3,
+    ]);
+  });
+
+  test("should move a trailing NaN with the missing group (asc)", () => {
+    expect(sortedCanonical([3, 1, 2, Number.NaN], [{ v: "asc" }])).toEqual([
+      "missing",
+      1,
+      2,
+      3,
+    ]);
+  });
+
+  test("should keep plain null sorting unchanged (asc)", () => {
+    expect(sortedCanonical([3, 1, null, 2], [{ v: "asc" }])).toEqual([
+      "missing",
+      1,
+      2,
+      3,
+    ]);
+  });
+
+  test("should place missing values last by default with desc", () => {
+    expect(sortedCanonical([3, Number.NaN, 1, null], [{ v: "desc" }])).toEqual([
+      3,
+      1,
+      "missing",
+      "missing",
+    ]);
+  });
+
+  test("should apply nulls: last to NaN as well (asc)", () => {
+    expect(
+      sortedCanonical(
+        [3, Number.NaN, null, 1],
+        [{ v: { sort: "asc", nulls: "last" } }],
+      ),
+    ).toEqual([1, 3, "missing", "missing"]);
+  });
+
+  test("should apply nulls: first to NaN as well (desc)", () => {
+    expect(
+      sortedCanonical(
+        [3, Number.NaN, 1, null],
+        [{ v: { sort: "desc", nulls: "first" } }],
+      ),
+    ).toEqual(["missing", "missing", 3, 1]);
+  });
+
+  test("should treat Invalid Date as missing among valid dates", () => {
+    expect(
+      sortedCanonical(
+        [new Date(5000), new Date("invalid"), new Date(1000)],
+        [{ v: "asc" }],
+      ),
+    ).toEqual(["missing", 1000, 5000]);
+  });
+
+  test("should tie-break rows whose first key is missing by the next key", () => {
+    const rows = [
+      { a: Number.NaN, b: 2 },
+      { a: Number.NaN, b: 1 },
+      { a: null, b: 0 },
+      { a: 1, b: 9 },
+    ];
+    const result = orderByFunc(rows, [{ a: "asc" }, { b: "asc" }]);
+    expect(result.map((row) => row.b)).toEqual([0, 1, 2, 9]);
+  });
+
+  describe("permutation invariance", () => {
+    const cases: [string, unknown[], OrderBy[]][] = [
+      [
+        "numbers with NaN and null (asc)",
+        [3, Number.NaN, 1, null, 2],
+        [{ v: "asc" }],
+      ],
+      [
+        "numbers with NaN and null (desc)",
+        [3, Number.NaN, 1, null, 2],
+        [{ v: "desc" }],
+      ],
+      [
+        "numbers with NaN and null (asc, nulls last)",
+        [3, Number.NaN, 1, null, 2],
+        [{ v: { sort: "asc", nulls: "last" } }],
+      ],
+      [
+        "dates with Invalid Date and NaN (asc)",
+        [null, Number.NaN, new Date("invalid"), new Date(0), 5],
+        [{ v: "asc" }],
+      ],
+    ];
+
+    test.each(cases)(
+      "should return the same order for every input permutation: %s",
+      (_label, values, orderBy) => {
+        const expected = sortedCanonical(values, orderBy);
+        permutations(values).forEach((permuted) => {
+          expect(sortedCanonical(permuted, orderBy)).toEqual(expected);
+        });
+      },
+    );
+  });
+});

--- a/src/util/aggregate/aggregateUtil/isMissingAggregateValue.ts
+++ b/src/util/aggregate/aggregateUtil/isMissingAggregateValue.ts
@@ -1,10 +1,6 @@
-import { isDateValue } from "../../other/isDateValue";
+import { isMissingValue } from "../../other/isMissingValue";
 
-// SQL の集計が NULL を無視するのに合わせ、NaN / Invalid Date も欠損として扱う
-const isMissingAggregateValue = (value: unknown): boolean => {
-  if (value === null || value === undefined) return true;
-  if (typeof value === "number" && Number.isNaN(value)) return true;
-  return isDateValue(value) && Number.isNaN(value.getTime());
-};
+// SQL の集計が NULL を無視するのに合わせた欠損判定
+const isMissingAggregateValue = isMissingValue;
 
 export { isMissingAggregateValue };

--- a/src/util/find/findUtil/applyDistinct.ts
+++ b/src/util/find/findUtil/applyDistinct.ts
@@ -1,3 +1,14 @@
+import { toLookupKey } from "../../other/toLookupKey";
+
+const toDistinctKeyPart = (value: unknown): string => {
+  const key = toLookupKey(value);
+  if (typeof key === "string") return key;
+  if (typeof key === "object" && key !== null) {
+    return `json:${JSON.stringify(key)}`;
+  }
+  return `raw:${String(key)}`;
+};
+
 const applyDistinct = (
   records: Record<string, unknown>[],
   distinct: string | string[],
@@ -6,7 +17,9 @@ const applyDistinct = (
   const seen = new Set<string>();
 
   return records.filter((row) => {
-    const key = distinctKeys.map((k) => JSON.stringify(row[k])).join("|");
+    const key = JSON.stringify(
+      distinctKeys.map((k) => toDistinctKeyPart(row[k])),
+    );
 
     if (seen.has(key)) return false;
 

--- a/src/util/find/findUtil/orderBy.ts
+++ b/src/util/find/findUtil/orderBy.ts
@@ -8,6 +8,7 @@ import type {
   RelationOrderBy,
 } from "../../../types/coreTypes";
 import { isDict } from "../../other/isDict";
+import { isMissingValue } from "../../other/isMissingValue";
 
 type ParsedOrderByEntry = [
   string,
@@ -71,8 +72,8 @@ const search = (
   const aVal = a[key];
   const bVal = b[key];
 
-  const aIsNull = aVal === null || aVal === undefined;
-  const bIsNull = bVal === null || bVal === undefined;
+  const aIsNull = isMissingValue(aVal);
+  const bIsNull = isMissingValue(bVal);
 
   if (aIsNull && bIsNull) {
     if (cnt === keys.length - 1) return 0;

--- a/src/util/other/isMissingValue.ts
+++ b/src/util/other/isMissingValue.ts
@@ -1,0 +1,10 @@
+import { isDateValue } from "./isDateValue";
+
+// null / undefined に加え、NaN / Invalid Date も欠損として扱う
+const isMissingValue = (value: unknown): boolean => {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "number" && Number.isNaN(value)) return true;
+  return isDateValue(value) && Number.isNaN(value.getTime());
+};
+
+export { isMissingValue };


### PR DESCRIPTION
`LLM/comparison-inconsistencies.html` の **3** と **4** への対応です。

## 1. `distinct` が `JSON.stringify` をキーにしていて行が消える

**`JSON.stringify(Date)` は引用符付きの ISO 文字列を返します。** そのため列に Date と同値の文字列が両方あると**同じキーになり、片方が黙って消えます**。

```js
distinct(["v"]) を [Date("2024-01-01T00:00:00.000Z"), "2024-01-01T00:00:00.000Z"] に
// 修正前 → 1行に潰れる
// 修正後 → 2行
```

NaN / null / Invalid Date もすべて `"null"` になり、まとめて潰れていました。

**これは NaN と無関係に、ごく普通のデータで踏めます。** #211(書けない値を書き込み前に拒否)が入っても残っていた唯一の実害です。

### 修正

`toLookupKey` に統一しました。型ごとに接頭辞が付く(`date:<epoch>` / `str:...`)ので衝突しません。**#212 の groupBy と同じキー生成**になり、一貫性も出ます。

**複合キーは連結ではなく文字列配列の `JSON.stringify`** にしました。区切り文字を値の中に埋め込んで衝突を作れないようにするためです。素朴な `|` 連結なら同一キーになる組(`a="x|str:y", b=""` と `a="x", b="y|str:"`)をテストで固定しています。

**`null` 同士が1行に畳まれる挙動は維持**しています。**Prisma も同じ**です(実測済み。しかも Prisma は `SELECT DISTINCT` を使わずクライアント側のインメモリ処理で重複除去しています)。

## 2. `orderBy` で NaN があるとソート自体が崩れる

NaN との比較は `<` も `>` も `false` になるため、**比較器の推移律が破れて**いました。`Array.sort` の結果が**初期配置に依存**します。

```
修正前(すべて昇順):
[3, NaN, 1, null, 2]  →  [null, 3, NaN, 1, 2]   壊れている
[NaN, 3, 1, 2]        →  [NaN, 1, 2, 3]         NaN はその場のまま
[3, 1, 2, NaN]        →  [1, 2, 3, NaN]         NaN はその場のまま
```

### 修正

**NaN と Invalid Date を `null` と同じ「欠損」として扱います。** #212 で集計に入れたのと同じ扱いで、判定を共通化しました(`isMissingAggregateValue` と内容が完全一致していたため実装を `util/other/` に移し、aggregate 側は委譲に)。

**`nulls: "first" / "last"` は3つとも同じ指定に従います。** デフォルトの位置(昇順で先頭)は変えていません。

### 推移律を回復したことの検証

**5要素の全120順列をソートし、結果が完全に一致すること**を機械的に検証しました。推移律が破れていると初期配置依存で順列ごとに結果が変わるため、これが直接の証明になります。`asc` / `desc` / `nulls:"last"` / Date 混在の4ケースで実施しています。

理屈の上でも、欠損を1つの同値類に畳んだ後は「欠損と非欠損は常に厳密順序、非欠損同士は通常比較」となり、**NaN が比較経路に入らなくなります**。

## 検証結果

- `npm test`: **2,702件 全 green**(2,677 → +25)
- 往復契約テスト3スイート31件 green
- `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル57件・増減なし)pass
- distinct / orderBy(リレーション指定含む)156件、`$transaction` 70件、`$extends` 63件を明示的に実行して非回帰を確認

**既存テストの変更はゼロ**です。2,677件すべて無変更で通っています。

### 計算量は変わっていません

- `distinct`: 行数1パス + 行あたり列数分のキー構築 + Set 照合。**O(n) 維持**
- `orderBy`: 比較器に O(1) の判定が加わっただけ。**O(n log n) 維持**

## 判断が要る点

**オブジェクト値のキー生成に `json:` 接頭辞 + `JSON.stringify` の分岐を残しました。** シートのセル値には実質現れませんが、旧実装が deep な `JSON.stringify` で区別していたため、退化を避けています(`raw:` に落とすと全オブジェクトが `[object Object]` に潰れるため)。

**`null` と `undefined` は distinct では別キーのまま**です(旧実装と同じ)。`orderBy` では従来どおり両方とも欠損扱いで、挙動は変わりません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)