### PR TITLE
fix: 比較できない値をクエリの入口で弾く

### DIFF
--- a/src/__test__/util/invalidQueryValues.test.ts
+++ b/src/__test__/util/invalidQueryValues.test.ts
@@ -1,0 +1,410 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import { raw } from "../../util/raw/raw";
+import { buildTestClient, sheetOf } from "./extends/extendsTestClient";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+} from "./transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const looseUsers = (options?: {
+  relations?: boolean;
+}): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const typed = sheetOf(buildTestClient(options), "Users");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+describe("where の直値の不正値はエラー", () => {
+  test("NaN はエラー", () => {
+    const { loose } = looseUsers();
+    const fn = () => loose.findMany({ where: { age: NaN } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("Infinity はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { age: Infinity } })).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received Infinity.",
+    );
+  });
+
+  test("-Infinity はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findFirst({ where: { age: -Infinity } })).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received -Infinity.",
+    );
+  });
+
+  test("Invalid Date はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { age: new Date("nope") } })).toThrow(
+      "Invalid value for argument `age`. Expected a valid Date, but the provided Date object is invalid.",
+    );
+  });
+
+  test("配列を直値に渡すとエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { age: [1, 2] } })).toThrow(
+      "Invalid value for argument `age`. Expected a scalar value, but received an array.",
+    );
+  });
+
+  test("関数はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { name: () => "A" } })).toThrow(
+      "Invalid value for argument `name`. Expected a scalar value, but received a function.",
+    );
+  });
+
+  test("Symbol はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { name: Symbol("A") } })).toThrow(
+      "Invalid value for argument `name`. Expected a scalar value, but received a symbol.",
+    );
+  });
+
+  test("BigInt はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { age: BigInt(5) } })).toThrow(
+      "Invalid value for argument `age`. Expected a scalar value, but received a bigint.",
+    );
+  });
+
+  test("Gassma.raw はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.findMany({ where: { name: raw("=SUM(A1:A2)") } }),
+    ).toThrow(
+      "Invalid value for argument `name`. Expected a scalar value, but received a Gassma.raw value.",
+    );
+  });
+});
+
+describe("フィルタ演算子の不正値はエラー", () => {
+  test("gte の NaN はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { age: { gte: NaN } } })).toThrow(
+      "Invalid value for argument `gte`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("lt の Infinity はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { age: { lt: Infinity } } })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+
+  test("in の配列の中の NaN はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { age: { in: [1, NaN] } } })).toThrow(
+      "Invalid value for argument `in`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("notIn の配列の中の Invalid Date はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.findMany({ where: { age: { notIn: [new Date("nope")] } } }),
+    ).toThrow(
+      "Invalid value for argument `notIn`. Expected a valid Date, but the provided Date object is invalid.",
+    );
+  });
+
+  test("in の配列の中の配列はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { age: { in: [[1]] } } })).toThrow(
+      "Invalid value for argument `in`. Expected a scalar value, but received an array.",
+    );
+  });
+
+  test("gte の配列はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ where: { age: { gte: [1] } } })).toThrow(
+      "Invalid value for argument `gte`. Expected a scalar value, but received an array.",
+    );
+  });
+
+  test("not の入れ子の NaN はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.findMany({ where: { age: { not: { equals: NaN } } } }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+});
+
+describe("AND / OR / NOT の中もエラー", () => {
+  test("OR の中の NaN はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.findMany({ where: { OR: [{ age: NaN }, { name: "Alice" }] } }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("AND の入れ子の in の Invalid Date はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.findMany({
+        where: { AND: [{ NOT: { age: { in: [new Date("nope")] } } }] },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+});
+
+describe("where を持つ他の操作もエラー", () => {
+  test("count の where の NaN はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.count({ where: { age: NaN } })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+
+  test("updateMany の where の NaN はエラーで全行無変化", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.updateMany({ where: { age: NaN }, data: { name: "X" } }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+    });
+  });
+
+  test("deleteMany の where の Invalid Date はエラーで全行残る", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.deleteMany({ where: { age: new Date("nope") } }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("aggregate の where の NaN はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.aggregate({ _max: { age: true }, where: { age: NaN } }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+});
+
+describe("cursor の不正値はエラー", () => {
+  test("findMany の cursor の NaN はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.findMany({ cursor: { id: NaN }, orderBy: { id: "asc" } }),
+    ).toThrow(
+      "Invalid value for argument `id`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("findFirst の cursor の Invalid Date はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findFirst({ cursor: { id: new Date("nope") } })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+
+  test("cursor の配列はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() => loose.findMany({ cursor: { id: [1] } })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+});
+
+describe("having の不正値はエラー", () => {
+  test("集計条件の NaN はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.groupBy({
+        by: ["age"],
+        _min: { age: true },
+        having: { age: { _min: { gte: NaN } } },
+      }),
+    ).toThrow(
+      "Invalid value for argument `gte`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("having の OR の中の Infinity はエラー", () => {
+    const { loose } = looseUsers();
+    expect(() =>
+      loose.groupBy({
+        by: ["age"],
+        _min: { age: true },
+        having: { OR: [{ age: { _min: { lt: Infinity } } }] },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+});
+
+describe("リレーションフィルタの内側もエラー", () => {
+  test("some の中の NaN はエラー", () => {
+    const { loose } = looseUsers({ relations: true });
+    expect(() =>
+      loose.findMany({ where: { posts: { some: { title: NaN } } } }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("every の中の Invalid Date はエラー", () => {
+    const { loose } = looseUsers({ relations: true });
+    expect(() =>
+      loose.findMany({
+        where: { posts: { every: { title: new Date("nope") } } },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("is の中の NaN はエラー", () => {
+    const client = buildTestClient({ relations: true });
+    const posts: any = sheetOf(client, "Posts");
+    expect(() =>
+      posts.findMany({ where: { author: { is: { age: NaN } } } }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("include の where の NaN はエラー", () => {
+    const { loose } = looseUsers({ relations: true });
+    expect(() =>
+      loose.findMany({ include: { posts: { where: { title: NaN } } } }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+});
+
+describe("nested write の where もエラー", () => {
+  test("connect の NaN はエラーで FK が変化しない", () => {
+    const client = buildTestClient({ relations: true });
+    const users: any = sheetOf(client, "Users");
+    const posts = sheetOf(client, "Posts");
+    expect(() =>
+      users.update({
+        where: { id: 1 },
+        data: { posts: { connect: { id: NaN } } },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(posts.findMany({})).toEqual([
+      { id: 101, authorId: 1, title: "Post A" },
+      { id: 102, authorId: 2, title: "Post B" },
+    ]);
+  });
+
+  test("nested update の where の NaN はエラー", () => {
+    const client = buildTestClient({ relations: true });
+    const users: any = sheetOf(client, "Users");
+    expect(() =>
+      users.update({
+        where: { id: 1 },
+        data: {
+          posts: { update: { where: { id: NaN }, data: { title: "X" } } },
+        },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+});
+
+describe("$transaction / $extends 経由もエラー", () => {
+  test("tx 内の where の NaN もエラーでシートが変化しない", () => {
+    const env = buildTxTestEnv();
+    const tx = (env.client as any).$transaction.bind(env.client);
+    expect(() =>
+      tx((txClient: any) => {
+        txClient.Users.updateMany({
+          where: { age: NaN },
+          data: { name: "X" },
+        });
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(env.users.snapshot()).toEqual([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [2, "Bob", 30],
+    ]);
+  });
+
+  test("query フックを素通しした where の NaN もエラー", () => {
+    const client = buildTestClient();
+    const extended = client.$extends({
+      query: {
+        Users: {
+          findMany({ args, query }) {
+            return query(args);
+          },
+        },
+      },
+    });
+    const loose: any = extended.Users;
+    expect(() => loose.findMany({ where: { age: NaN } })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+});
+
+describe("正常な値は従来どおり通る", () => {
+  test("数値・文字列・真偽値・null の where は通る", () => {
+    const { typed } = looseUsers();
+    expect(typed.findMany({ where: { age: 20 } })).toEqual([
+      { id: 1, name: "Alice", age: 20 },
+    ]);
+    expect(typed.findMany({ where: { name: "Bob" } })).toHaveLength(1);
+    expect(typed.findMany({ where: { age: null } })).toEqual([]);
+  });
+
+  test("in / notIn / 比較演算子の正常値は通る", () => {
+    const { typed } = looseUsers();
+    expect(typed.findMany({ where: { age: { in: [20, 30] } } })).toHaveLength(
+      2,
+    );
+    expect(typed.findMany({ where: { age: { notIn: [20] } } })).toHaveLength(2);
+    expect(
+      typed.findMany({ where: { age: { gte: 21, lt: 40 } } }),
+    ).toHaveLength(1);
+    expect(typed.findMany({ where: { in: undefined, age: 20 } })).toHaveLength(
+      1,
+    );
+  });
+
+  test("正常な Date の where は通る", () => {
+    const { typed } = looseUsers();
+    expect(
+      typed.findMany({
+        where: { age: { lt: new Date("2026-01-01T00:00:00Z") } },
+      }),
+    ).toHaveLength(3);
+    expect(
+      typed.findMany({ where: { age: new Date("2026-01-01T00:00:00Z") } }),
+    ).toEqual([]);
+  });
+
+  test("undefined はエラーにならず従来の挙動のまま", () => {
+    const { typed } = looseUsers();
+    expect(typed.findMany({ where: { age: undefined } })).toHaveLength(0);
+    expect(typed.findMany({ where: { age: { gte: undefined } } })).toHaveLength(
+      0,
+    );
+  });
+
+  test("正常な cursor / having / リレーションフィルタは通る", () => {
+    const { typed } = looseUsers();
+    expect(
+      typed.findMany({ cursor: { id: 2 }, orderBy: { id: "asc" } }),
+    ).toHaveLength(2);
+    expect(
+      typed.groupBy({
+        by: ["age"],
+        _min: { age: true },
+        having: { age: { _min: { gte: 25 } } },
+      }),
+    ).toHaveLength(2);
+    const { typed: withRel } = looseUsers({ relations: true });
+    expect(
+      withRel.findMany({ where: { posts: { some: { title: "Post A" } } } }),
+    ).toHaveLength(1);
+  });
+});

--- a/src/util/core/filterRowsByWhere.ts
+++ b/src/util/core/filterRowsByWhere.ts
@@ -2,6 +2,7 @@ import type { GassmaAny, WhereUse } from "../../types/coreTypes";
 import type { HitRowData } from "../../types/hitRowDataType";
 import { isLogicMatch } from "../andOrNot/entry";
 import { resetMembershipCache } from "../other/isValueEqual";
+import { validateQueryValues } from "../validate/validateQueryValues";
 import { getWantFindIndexFromTitles } from "./getWantFindIndex";
 import { rowMatchesWhereFields } from "./rowMatchesWhereFields";
 
@@ -10,6 +11,7 @@ const filterRowsByWhere = (
   titles: GassmaAny[],
   where: WhereUse,
 ): HitRowData[] => {
+  validateQueryValues(where);
   resetMembershipCache();
   if (Object.keys(where).length === 0) {
     return allDataList.map((row, index): HitRowData => {

--- a/src/util/groupby/groubyUtil/having.ts
+++ b/src/util/groupby/groubyUtil/having.ts
@@ -3,6 +3,7 @@ import type {
   HitByClassificationedRowData,
   RowRecord,
 } from "../../../types/coreTypes";
+import { validateQueryValues } from "../../validate/validateQueryValues";
 import { isLogicMatchHaving } from "./andOrNot/entry";
 import { normalHaving } from "./having/normalHavingFilter";
 
@@ -19,6 +20,7 @@ const havingFilter = (
   havingData: HavingUse,
   by: string[],
 ) => {
+  validateQueryValues(havingData);
   const byClassificationedRowIncludeIndex: HitByClassificationedRowData[] =
     byClassificationedRow.map((byClassificationedOneRow, index) => {
       return { rowNumber: index, row: byClassificationedOneRow };

--- a/src/util/validate/validateFieldKeys.ts
+++ b/src/util/validate/validateFieldKeys.ts
@@ -1,4 +1,5 @@
 import { GassmaUnknownArgumentError } from "../../errors/argument/argumentError";
+import { validateQueryScalar } from "./validateQueryValues";
 
 const validateFieldKeys = (keys: string[], titles: string[]): void => {
   keys.forEach((key) => {
@@ -20,6 +21,10 @@ const validateCursorKeys = (
   titles: string[],
 ): void => {
   validateFieldKeys(Object.keys(cursor), titles);
+  Object.entries(cursor).forEach(([key, value]) => {
+    if (value === undefined) return;
+    validateQueryScalar(key, value);
+  });
 };
 
 export { validateCursorKeys, validateDistinctKeys };

--- a/src/util/validate/validateQueryValues.ts
+++ b/src/util/validate/validateQueryValues.ts
@@ -1,0 +1,54 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import { isDict } from "../other/isDict";
+import { isRawValue } from "../raw/raw";
+import { validateWritableValue } from "./validateWritableValue";
+
+const LOGICAL_KEYS = new Set(["AND", "OR", "NOT"]);
+const LIST_OPERATOR_KEYS = new Set(["in", "notIn"]);
+
+const validateQueryScalar = (key: string, value: unknown): void => {
+  if (isRawValue(value)) {
+    throw new GassmaInvalidValueError(
+      key,
+      "a scalar value, but received a Gassma.raw value",
+    );
+  }
+  validateWritableValue(key, value);
+};
+
+const walkOperators = (conditions: Record<string, unknown>): void => {
+  Object.entries(conditions).forEach(([key, value]) => {
+    if (value === undefined) return;
+    if (LIST_OPERATOR_KEYS.has(key) && Array.isArray(value)) {
+      value.forEach((item) => {
+        validateQueryScalar(key, item);
+      });
+      return;
+    }
+    if (isDict(value)) {
+      walkOperators(value);
+      return;
+    }
+    validateQueryScalar(key, value);
+  });
+};
+
+const validateQueryValues = (where: Record<string, unknown>): void => {
+  Object.entries(where).forEach(([key, value]) => {
+    if (value === undefined) return;
+    if (LOGICAL_KEYS.has(key)) {
+      const branches = Array.isArray(value) ? value : [value];
+      branches.forEach((branch) => {
+        if (isDict(branch)) validateQueryValues(branch);
+      });
+      return;
+    }
+    if (isDict(value)) {
+      walkOperators(value);
+      return;
+    }
+    validateQueryScalar(key, value);
+  });
+};
+
+export { validateQueryScalar, validateQueryValues };


### PR DESCRIPTION
`LLM/comparison-inconsistencies.html` の **1** と **2** への対応です。#211(書き込み側)の**読み取り側の対**になります。

## 問題

**同じ「等しい」が場所によって違っていました。**

```js
isValueEqual(NaN, NaN)      // → false   等価比較の系統(===)
containsValue([NaN], NaN)   // → true    in / notIn の系統(SameValueZero)
```

`where: { age: NaN }` は何にもマッチしないのに、`where: { age: { in: [NaN] } }` は NaN の行にマッチします。

Invalid Date はさらに悪く、**どのインスタンスを渡したかで結果が変わります**。

```js
const d = new Date("nope");
containsValue([d], d)                             // → true
containsValue([new Date("x")], new Date("nope"))  // → false
```

## 方針: 比較ロジックではなく入口を直す

**Prisma がこの問題を持たないのは、比較が優れているからではありません。** 実測で分かったのは、**不正な値を比較器まで到達させない**という戦略でした。

```
where: { createdAt: new Date("nope") }
→ Invalid value for argument `createdAt`: Provided Date object is invalid. Expected Date.
（SQL は一切発行されない)
```

**#211 で書き込み側は塞いだので、今回はその対を読み取り側に作ります。** 比較ロジックには一切触れていません。

## 実装

判定は **#211 の `validateWritableValue` をそのまま再利用**したので、対象の値もエラー文言も**書き込み側と完全に一致**します(NaN / ±Infinity / Invalid Date / 配列 / 関数 / Symbol / BigInt)。

差し込みは3箇所です。

| 位置 | カバー範囲 |
|---|---|
| `filterRowsByWhere` | **where の全経路の唯一の合流点**。呼び出し元は `whereFilter` と `connectBatch` の `matchRecords` の2つだけ(grep で確認)。リレーションフィルタや `include` の内側は対象シートへの再入で同じ点を通る |
| `validateCursorKeys` | `cursor`(`findMany` / `findFirst` の両方をこの1関数がカバー) |
| `havingFilter` | `having`(`whereFilter` を経由しない別経路) |

検証は**行ループの外**で1クエリにつき1回だけ走ります。**シートの読みは増えません**(契約テストで確認済み)。

### `in` の配列の扱い

**`in` / `notIn` は配列を正当に受け取ります。** 演算子オブジェクトの中の `in` / `notIn` キー直下の配列**だけ**要素を個別に検証し、それ以外の位置の配列は #211 と同じ文言で拒否します。

トップレベルのキーは列名なので、**`in` という名前の列があっても**直値の配列は拒否されます(walker がトップレベルと演算子レベルを分けて歩くため)。

## 実証

```
[where {age: NaN}]          Invalid value for argument `age`. Expected a finite number, but received NaN.
[where {age: {in:[NaN]}}]   Invalid value for argument `in`. Expected a finite number, but received NaN.
[where {name: InvalidDate}] Invalid value for argument `name`. Expected a valid Date, but ...
[cursor {id: NaN}]          Invalid value for argument `id`. Expected a finite number, but received NaN.
[正常 where {name:'Alice'}]  通った: [1]
[正常 in]                    通った: [1,2]
```

修正前は**35件の不正値テストがすべて素通り**していました(NaN の where は0件、cursor の NaN は黙って空、`connect` の NaN は不一致扱い)。

## 検証結果

- `npm test`: **2,717件 全 green**(2,677 → +40)
- 往復契約テスト3スイート31件 green
- `tsc --noEmit` / lint / format / `verify:bundle`(公開シンボル57件)pass

**既存テストの失敗・期待値変更はゼロ**です(`where` に不正値を使う既存テストは存在しませんでした)。

## 判断が要る点

**1. `Gassma.raw` を `where` に渡すと、これまでサイレントに0件だったのがエラーになります。**

型上は `WhereUse` に渡せませんが JS からは渡せて、参照比較で決して一致しない状態でした。「入口で守る」方針に合わせて明示拒否にしています。**却下なら分岐とテスト1件を消すだけで戻せます。**

**2. 検証位置がリレーション解決の「後」です。**

`filterRowsByWhere` に届く where は、リレーション解決で**シート由来の値が `in: [...]` として合成済み**です。したがって理屈の上では「利用者が書いていない値」で throw し得ます。

ただし**実機の `getValues()` はセル値として NaN や Invalid Date を返さない**うえ、**#211 で書き込み経路も塞がっている**ので、実際には到達しません(モックでのみ再現可能)。既存の NaN セル値テストはリレーションを使わないため影響ゼロでした。

利用者入力の段(controller の入口)に移すと、`include` やリレーションフィルタの再入呼び出しを区別する仕組みが必要になり複雑化するため、**#196 と同じ合流点方針**を採っています。

## 別途見つかった差異(**本 PR では未対応**)

**`where` のフィールドに `undefined` を渡すと 0件になります。Prisma は「未指定」として無視するので全件のはずです。**

```js
findMany({ where: { age: undefined } })                  // → []      Prisma なら全件
findMany({ where: { name: "Alice", age: undefined } })   // → []      Prisma なら Alice
findMany({ where: {} })                                  // → 全件(対照)
```

「未指定」として扱われるのは **`where` 全体が `undefined` の場合だけ**でした。本 PR で持ち込んだ差異ではなく既存のものです(検証は `undefined` をスキップし、現状挙動をテストで固定しています)。**別途対応するか判断をお願いします。**

なお **`skip` / `take` に NaN を渡すと現状は黙って素通り**します。比較値ではなくオプションの数値なので #211 の集合の対象外とし、今回は触れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)