### PR TITLE
fix: undefined と空オブジェクトの扱いを Prisma に合わせる

### DIFF
--- a/src/__test__/util/andOrNot/emptyLogicalOperators.test.ts
+++ b/src/__test__/util/andOrNot/emptyLogicalOperators.test.ts
@@ -73,6 +73,44 @@ describe("論理演算子の空指定", () => {
   });
 });
 
+describe("条件を持たないブランチは論理配列から取り除かれる（Prisma 実測準拠）", () => {
+  test("OR: [{}] は空 OR 扱いで0件", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { OR: [{}] } })).toEqual([]);
+  });
+
+  test("OR: [{}, 実条件] は実条件だけ生きる", () => {
+    const users = looseUsers();
+    expect(
+      names(users.findMany({ where: { OR: [{}, { name: "Alice" }] } })),
+    ).toEqual(["Alice"]);
+  });
+
+  test("OR: [{ age: {} }] も空ブランチ扱いで0件", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { OR: [{ age: {} }] } })).toEqual([]);
+  });
+
+  test("OR: [{ age: {} }, 実条件] は実条件だけ生きる", () => {
+    const users = looseUsers();
+    expect(
+      names(
+        users.findMany({ where: { OR: [{ age: {} }, { name: "Alice" }] } }),
+      ),
+    ).toEqual(["Alice"]);
+  });
+
+  test("AND: [{ age: {} }] は全件", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { AND: [{ age: {} }] } })).toHaveLength(3);
+  });
+
+  test("NOT: [{ age: {} }] は全件", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { NOT: [{ age: {} }] } })).toHaveLength(3);
+  });
+});
+
 describe("論理演算子の空指定とフィールド条件の併用", () => {
   test("フィールド条件 + AND: {} はフィールド条件のみ適用", () => {
     const users = looseUsers();
@@ -111,24 +149,142 @@ describe("論理演算子の空指定のネスト", () => {
     ]);
   });
 
-  test("AND: [{ OR: [] }] は0件", () => {
+  test("AND: [{ OR: [] }] は全件（条件ゼロブランチは捨てられる）", () => {
     const users = looseUsers();
-    expect(users.findMany({ where: { AND: [{ OR: [] }] } })).toEqual([]);
+    expect(users.findMany({ where: { AND: [{ OR: [] }] } })).toHaveLength(3);
   });
 
-  test("OR: [{ AND: [] }] は全件", () => {
+  test("AND: { OR: [] } 単体形も全件", () => {
     const users = looseUsers();
-    expect(names(users.findMany({ where: { OR: [{ AND: [] }] } }))).toEqual([
-      "Alice",
-      "Bob",
-      "Carol",
-    ]);
+    expect(users.findMany({ where: { AND: { OR: [] } } })).toHaveLength(3);
+  });
+
+  test("AND: [{ OR: [] }, 実条件] は実条件だけ生きる", () => {
+    const users = looseUsers();
+    expect(
+      names(
+        users.findMany({ where: { AND: [{ OR: [] }, { name: "Alice" }] } }),
+      ),
+    ).toEqual(["Alice"]);
+  });
+
+  test("NOT: [{ OR: [] }] は全件", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { NOT: [{ OR: [] }] } })).toHaveLength(3);
+  });
+
+  test("AND: [{ OR: [{}] }] も全件（全ブランチ条件ゼロの OR は捨てられる）", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { AND: [{ OR: [{}] }] } })).toHaveLength(3);
+  });
+
+  test("AND: [{ OR: [実条件] }] は実条件が生きる", () => {
+    const users = looseUsers();
+    expect(
+      users.findMany({ where: { AND: [{ OR: [{ name: "Zed" }] }] } }),
+    ).toEqual([]);
+  });
+
+  test("OR: [{ OR: {} }] は単体 dict 形なので GassmaInvalidValueError（Prisma も同様にエラー）", () => {
+    const users = looseUsers();
+    expect(() => users.findMany({ where: { OR: [{ OR: {} }] } })).toThrow(
+      GassmaInvalidValueError,
+    );
   });
 
   test("ネストした OR: {} も GassmaInvalidValueError", () => {
     const users = looseUsers();
     const fn = () => users.findMany({ where: { AND: [{ OR: {} }] } });
     expect(fn).toThrow(GassmaInvalidValueError);
+  });
+});
+
+describe("論理キーだけで条件ゼロになるブランチも取り除かれる（Prisma 実測準拠）", () => {
+  test("OR: [{ AND: [] }] は空 OR 扱いで0件", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { OR: [{ AND: [] }] } })).toEqual([]);
+  });
+
+  test("OR: [{ AND: [{}] }] も0件", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { OR: [{ AND: [{}] }] } })).toEqual([]);
+  });
+
+  test("OR: [{ AND: [{ age: {} }] }] も0件", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { OR: [{ AND: [{ age: {} }] }] } })).toEqual(
+      [],
+    );
+  });
+
+  test("OR: [{ NOT: [] }] / [{ NOT: {} }] / [{ NOT: { age: {} } }] は0件", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { OR: [{ NOT: [] }] } })).toEqual([]);
+    expect(users.findMany({ where: { OR: [{ NOT: {} }] } })).toEqual([]);
+    expect(users.findMany({ where: { OR: [{ NOT: { age: {} } }] } })).toEqual(
+      [],
+    );
+  });
+
+  test("深い入れ子でも条件ゼロなら捨てられる", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { OR: [{ AND: [{ NOT: [] }] }] } })).toEqual(
+      [],
+    );
+    expect(
+      users.findMany({ where: { OR: [{ AND: [{ AND: [{}] }] }] } }),
+    ).toEqual([]);
+  });
+
+  test("条件ゼロのブランチと実条件の併存では実条件だけ生きる", () => {
+    const users = looseUsers();
+    expect(
+      names(
+        users.findMany({ where: { OR: [{ AND: [] }, { name: "Alice" }] } }),
+      ),
+    ).toEqual(["Alice"]);
+  });
+
+  test("実条件を含む AND ブランチは捨てられない", () => {
+    const users = looseUsers();
+    expect(
+      names(users.findMany({ where: { OR: [{ AND: [{ name: "Alice" }] }] } })),
+    ).toEqual(["Alice"]);
+  });
+
+  test("条件ゼロの論理キーとフィールド実条件が混在するブランチは実条件として生きる", () => {
+    const users = looseUsers();
+    expect(
+      names(users.findMany({ where: { OR: [{ AND: [], name: "Alice" }] } })),
+    ).toEqual(["Alice"]);
+  });
+
+  test("NOT: [{ AND: [] }] / NOT: { AND: [] } は全件", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { NOT: [{ AND: [] }] } })).toHaveLength(3);
+    expect(users.findMany({ where: { NOT: { AND: [] } } })).toHaveLength(3);
+  });
+
+  test("NOT: [条件ゼロ, 実条件] は実条件だけ否定される", () => {
+    const users = looseUsers();
+    expect(
+      names(
+        users.findMany({ where: { NOT: [{ age: {} }, { name: "Alice" }] } }),
+      ),
+    ).toEqual(["Bob", "Carol"]);
+  });
+
+  test("AND: [{ AND: [] }] は全件", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { AND: [{ AND: [] }] } })).toHaveLength(3);
+  });
+
+  test("OR: [{ OR: [] }] は0件・実条件と併存なら実条件だけ生きる", () => {
+    const users = looseUsers();
+    expect(users.findMany({ where: { OR: [{ OR: [] }] } })).toEqual([]);
+    expect(
+      names(users.findMany({ where: { OR: [{ OR: [] }, { name: "Alice" }] } })),
+    ).toEqual(["Alice"]);
   });
 });
 

--- a/src/__test__/util/invalidQueryValues.test.ts
+++ b/src/__test__/util/invalidQueryValues.test.ts
@@ -382,11 +382,11 @@ describe("正常な値は従来どおり通る", () => {
     ).toEqual([]);
   });
 
-  test("undefined はエラーにならず従来の挙動のまま", () => {
+  test("undefined はエラーにならず条件未指定と同じ（Prisma 実測準拠）", () => {
     const { typed } = looseUsers();
-    expect(typed.findMany({ where: { age: undefined } })).toHaveLength(0);
+    expect(typed.findMany({ where: { age: undefined } })).toHaveLength(3);
     expect(typed.findMany({ where: { age: { gte: undefined } } })).toHaveLength(
-      0,
+      3,
     );
   });
 

--- a/src/__test__/util/missingArguments.test.ts
+++ b/src/__test__/util/missingArguments.test.ts
@@ -1,4 +1,7 @@
-import { GassmaMissingArgumentError } from "../../errors/argument/argumentError";
+import {
+  GassmaInvalidValueError,
+  GassmaMissingArgumentError,
+} from "../../errors/argument/argumentError";
 import { GassmaClient } from "../../gassma";
 import { skip } from "../../util/skip/skip";
 import {
@@ -41,11 +44,20 @@ describe("delete: where 必須", () => {
     expect(typed.count({})).toBe(3);
   });
 
-  test("where: {} は従来どおり先頭行を削除する（対象外・挙動維持）", () => {
+  test("where: {} は GassmaInvalidValueError（Prisma 実測準拠）", () => {
     const { loose, typed } = looseUsers();
-    const deleted = loose.delete({ where: {} });
-    expect(deleted).toEqual({ id: 1, name: "Alice", age: 20 });
-    expect(typed.count({})).toBe(2);
+    const fn = () => loose.delete({ where: {} });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Invalid value for argument `where`.");
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("Gassma.skip だけで空になった where も同じエラー", () => {
+    const { loose, typed } = looseUsers();
+    expect(() => loose.delete({ where: { name: skip } })).toThrow(
+      GassmaInvalidValueError,
+    );
+    expect(typed.count({})).toBe(3);
   });
 });
 
@@ -120,10 +132,23 @@ describe("update: where / data 必須", () => {
     expectMissing(() => loose.update({ where: { id: 1 } }), "data");
   });
 
-  test("where: {} + data ありは従来どおり先頭行を更新する（対象外・挙動維持）", () => {
+  test("where: {} + data ありは GassmaInvalidValueError（Prisma 実測準拠）", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () => loose.update({ where: {}, data: { age: 99 } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Invalid value for argument `where`.");
+    expect(typed.findMany({ where: { age: 99 } })).toEqual([]);
+  });
+
+  test("upsert の where: {} も同じエラー", () => {
     const { loose } = looseUsers();
-    const result = loose.update({ where: {}, data: { age: 99 } });
-    expect(result).toEqual({ id: 1, name: "Alice", age: 99 });
+    expect(() =>
+      loose.upsert({
+        where: {},
+        create: { id: 4, name: "Dave", age: 50 },
+        update: { age: 50 },
+      }),
+    ).toThrow(GassmaInvalidValueError);
   });
 });
 

--- a/src/__test__/util/skip/normalizeQueryInput.test.ts
+++ b/src/__test__/util/skip/normalizeQueryInput.test.ts
@@ -62,20 +62,51 @@ describe("normalizeQueryInput", () => {
     });
   });
 
-  describe("strict 無効時の undefined（従来挙動の維持）", () => {
-    test("undefined 値のキーはそのまま残す", () => {
+  describe("strict 無効時の undefined（Prisma 実測: dict では無視・配列ではエラー）", () => {
+    test("undefined 値のキーは取り除く", () => {
       const result = normalizeQueryInput(
         { where: { name: undefined, age: 20 } },
         false,
       );
-      expect(result).toEqual({ where: { name: undefined, age: 20 } });
-      expect(Object.keys(result.where)).toContain("name");
+      expect(result).toEqual({ where: { age: 20 } });
+      expect(Object.keys(result.where)).not.toContain("name");
     });
 
-    test("配列内の undefined もそのまま残す", () => {
+    test("深いネストの undefined キーも取り除く", () => {
       expect(
+        normalizeQueryInput(
+          { where: { age: { gte: undefined, lte: 30 } } },
+          false,
+        ),
+      ).toEqual({ where: { age: { lte: 30 } } });
+    });
+
+    test("配列内の undefined は GassmaUndefinedValueError を投げる", () => {
+      expect(
+        catchError(() =>
+          normalizeQueryInput(
+            { where: { age: { in: [1, undefined] } } },
+            false,
+          ),
+        ).name,
+      ).toBe("GassmaUndefinedValueError");
+      expect(() =>
         normalizeQueryInput({ where: { age: { in: [1, undefined] } } }, false),
-      ).toEqual({ where: { age: { in: [1, undefined] } } });
+      ).toThrow("Invalid value for argument `where.age.in[1]`");
+    });
+  });
+
+  describe("undefined / skip だけで空になった dict はリテラルの {} と同じになる", () => {
+    test("剥がされて空になった dict は素の空オブジェクト", () => {
+      const result = normalizeQueryInput({ where: { name: undefined } }, false);
+      expect(result.where).toEqual({});
+      expect(Object.keys(result.where)).toEqual([]);
+    });
+
+    test("skip だけで空になった dict も同じ", () => {
+      expect(normalizeQueryInput({ where: { name: skip } }, false)).toEqual({
+        where: {},
+      });
     });
   });
 

--- a/src/__test__/util/skip/strictUndefinedChecks.test.ts
+++ b/src/__test__/util/skip/strictUndefinedChecks.test.ts
@@ -112,9 +112,9 @@ afterAll(() => {
 });
 
 describe("strictUndefinedChecks 無効（デフォルト）", () => {
-  test("where の undefined は従来挙動（何もマッチしない）を維持する", () => {
+  test("where の undefined は条件未指定と同じ（Prisma 実測準拠）", () => {
     const users = sheetOf(buildClient(), "Users");
-    expect(users.findMany({ where: { name: undefined } })).toEqual([]);
+    expect(users.findMany({ where: { name: undefined } })).toHaveLength(2);
   });
 
   test("where の Gassma.skip はフィルタなしとして扱われる", () => {
@@ -149,11 +149,11 @@ describe("strictUndefinedChecks 無効（デフォルト）", () => {
     expect(result).toEqual({ id: 3, name: "Carol", age: null });
   });
 
-  test("update data の undefined は従来挙動（値が消える）を維持する", () => {
+  test("update data の undefined はフィールド未指定と同じ（Prisma 実測準拠）", () => {
     const users = sheetOf(buildClient(), "Users");
     users.updateMany({ where: { id: 1 }, data: { name: undefined } });
     const after = users.findFirst({ where: { id: 1 } });
-    expect(after).toEqual({ id: 1, age: 20 });
+    expect(after).toEqual({ id: 1, name: "Alice", age: 20 });
   });
 
   test("where 全体の Gassma.skip は where 省略と同じになる", () => {

--- a/src/__test__/util/undefinedArguments.test.ts
+++ b/src/__test__/util/undefinedArguments.test.ts
@@ -1,0 +1,389 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import { GassmaUndefinedValueError } from "../../errors/skip/skipError";
+import { buildTestClient, sheetOf } from "./extends/extendsTestClient";
+import { clearGasGlobals } from "./transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const looseSheet = (name: string, relations = false): any => {
+  const typed = sheetOf(buildTestClient({ relations }), name);
+  const loose: any = typed;
+  return loose;
+};
+
+const names = (rows: { name: string }[]) => rows.map((row) => row.name);
+
+describe("where のフィールド undefined は条件未指定と同じ（Prisma 実測準拠）", () => {
+  test("単独の undefined は全件", () => {
+    const users = looseSheet("Users");
+    expect(users.findMany({ where: { age: undefined } })).toHaveLength(3);
+  });
+
+  test("他の条件と併用なら残りの条件だけ適用", () => {
+    const users = looseSheet("Users");
+    expect(
+      names(users.findMany({ where: { name: "Alice", age: undefined } })),
+    ).toEqual(["Alice"]);
+  });
+
+  test("findFirst でも同じ", () => {
+    const users = looseSheet("Users");
+    expect(users.findFirst({ where: { age: undefined } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 20,
+    });
+  });
+
+  test("count でも同じ", () => {
+    const users = looseSheet("Users");
+    expect(users.count({ where: { age: undefined } })).toBe(3);
+  });
+});
+
+describe("演算子オブジェクト内の undefined はその演算子だけ無視", () => {
+  test("equals: undefined は全件", () => {
+    const users = looseSheet("Users");
+    expect(
+      users.findMany({ where: { age: { equals: undefined } } }),
+    ).toHaveLength(3);
+  });
+
+  test("一部の演算子だけ undefined なら残りを適用", () => {
+    const users = looseSheet("Users");
+    expect(
+      names(users.findMany({ where: { age: { gt: undefined, lt: 35 } } })),
+    ).toEqual(["Alice", "Bob"]);
+  });
+
+  test("in: undefined / notIn: undefined は全件", () => {
+    const users = looseSheet("Users");
+    expect(users.findMany({ where: { age: { in: undefined } } })).toHaveLength(
+      3,
+    );
+    expect(
+      users.findMany({ where: { age: { notIn: undefined } } }),
+    ).toHaveLength(3);
+  });
+});
+
+describe("配列要素の undefined はエラー（Prisma 実測準拠）", () => {
+  test("in の配列内 undefined は GassmaUndefinedValueError", () => {
+    const users = looseSheet("Users");
+    const fn = () =>
+      users.findMany({ where: { age: { in: [20, undefined] } } });
+    expect(fn).toThrow(GassmaUndefinedValueError);
+    expect(fn).toThrow("Invalid value for argument `where.age.in[1]`");
+  });
+
+  test("notIn の配列内 undefined も同様", () => {
+    const users = looseSheet("Users");
+    expect(() =>
+      users.findMany({ where: { age: { notIn: [20, undefined] } } }),
+    ).toThrow(GassmaUndefinedValueError);
+  });
+
+  test("AND / OR / NOT の配列内 undefined も同様", () => {
+    const users = looseSheet("Users");
+    expect(() => users.findMany({ where: { AND: [undefined] } })).toThrow(
+      GassmaUndefinedValueError,
+    );
+    expect(() => users.findMany({ where: { OR: [undefined] } })).toThrow(
+      GassmaUndefinedValueError,
+    );
+    expect(() => users.findMany({ where: { NOT: [undefined] } })).toThrow(
+      GassmaUndefinedValueError,
+    );
+  });
+
+  test("orderBy / distinct の配列内 undefined も同様", () => {
+    const users = looseSheet("Users");
+    expect(() => users.findMany({ orderBy: [undefined] })).toThrow(
+      GassmaUndefinedValueError,
+    );
+    expect(() => users.findMany({ distinct: [undefined] })).toThrow(
+      GassmaUndefinedValueError,
+    );
+  });
+});
+
+describe("論理演算子配下の undefined ブランチ", () => {
+  test("AND: [{ age: undefined }] は全件", () => {
+    const users = looseSheet("Users");
+    expect(
+      users.findMany({ where: { AND: [{ age: undefined }] } }),
+    ).toHaveLength(3);
+  });
+
+  test("OR: [{ age: undefined }] は空ブランチ扱いで0件", () => {
+    const users = looseSheet("Users");
+    expect(users.findMany({ where: { OR: [{ age: undefined }] } })).toEqual([]);
+  });
+
+  test("OR: [{ age: undefined }, 実条件] は実条件だけ生きる", () => {
+    const users = looseSheet("Users");
+    expect(
+      names(
+        users.findMany({
+          where: { OR: [{ age: undefined }, { name: "Alice" }] },
+        }),
+      ),
+    ).toEqual(["Alice"]);
+  });
+
+  test("NOT: { age: undefined } は全件", () => {
+    const users = looseSheet("Users");
+    expect(users.findMany({ where: { NOT: { age: undefined } } })).toHaveLength(
+      3,
+    );
+  });
+
+  test("NOT: [{ age: { gte: undefined } }] は全件", () => {
+    const users = looseSheet("Users");
+    expect(
+      users.findMany({ where: { NOT: [{ age: { gte: undefined } }] } }),
+    ).toHaveLength(3);
+  });
+
+  test("入れ子の論理キーごと条件ゼロになる OR ブランチは捨てられる", () => {
+    const users = looseSheet("Users");
+    expect(
+      users.findMany({ where: { OR: [{ AND: [{ age: undefined }] }] } }),
+    ).toEqual([]);
+    expect(
+      names(
+        users.findMany({
+          where: { OR: [{ AND: [{ age: undefined }] }, { name: "Alice" }] },
+        }),
+      ),
+    ).toEqual(["Alice"]);
+  });
+});
+
+describe("リレーションフィルタの undefined", () => {
+  test("some: undefined はフィルタごと無視", () => {
+    const users = looseSheet("Users", true);
+    expect(
+      users.findMany({ where: { posts: { some: undefined } } }),
+    ).toHaveLength(3);
+  });
+
+  test("some の中の undefined は some: {} と同じ（存在チェック）", () => {
+    const users = looseSheet("Users", true);
+    expect(
+      names(
+        users.findMany({ where: { posts: { some: { title: undefined } } } }),
+      ),
+    ).toEqual(["Alice", "Bob"]);
+  });
+
+  test("is: undefined / isNot: undefined はフィルタごと無視", () => {
+    const posts = looseSheet("Posts", true);
+    expect(
+      posts.findMany({ where: { author: { is: undefined } } }),
+    ).toHaveLength(2);
+    expect(
+      posts.findMany({ where: { author: { isNot: undefined } } }),
+    ).toHaveLength(2);
+  });
+});
+
+describe("cursor の undefined", () => {
+  test("cursor: { id: undefined } は GassmaInvalidValueError", () => {
+    const users = looseSheet("Users");
+    const fn = () =>
+      users.findMany({ cursor: { id: undefined }, orderBy: { id: "asc" } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Invalid value for argument `cursor`.");
+  });
+
+  test("cursor: undefined は cursor 未指定と同じ", () => {
+    const users = looseSheet("Users");
+    expect(users.findMany({ cursor: undefined })).toHaveLength(3);
+  });
+
+  test("リテラルの cursor: {} も同じエラー（Prisma 実測準拠）", () => {
+    const users = looseSheet("Users");
+    expect(() => users.findMany({ cursor: {}, take: 2 })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+});
+
+describe("orderBy の undefined", () => {
+  test("orderBy: { age: undefined } は並び替えなし", () => {
+    const users = looseSheet("Users");
+    expect(names(users.findMany({ orderBy: { age: undefined } }))).toEqual([
+      "Alice",
+      "Bob",
+      "Carol",
+    ]);
+  });
+
+  test("配列内の { age: undefined } エントリは無視され残りで並ぶ", () => {
+    const users = looseSheet("Users");
+    expect(
+      names(users.findMany({ orderBy: [{ age: undefined }, { id: "desc" }] })),
+    ).toEqual(["Carol", "Bob", "Alice"]);
+  });
+
+  test("orderBy: {} は並び替えなし", () => {
+    const users = looseSheet("Users");
+    expect(users.findMany({ orderBy: {} })).toHaveLength(3);
+  });
+
+  test("orderBy: undefined は未指定と同じ", () => {
+    const users = looseSheet("Users");
+    expect(users.findMany({ orderBy: undefined })).toHaveLength(3);
+  });
+});
+
+describe("select / distinct / take / skip の undefined", () => {
+  test("select の一部キーが undefined ならそのキーだけ落ちる", () => {
+    const users = looseSheet("Users");
+    expect(users.findMany({ select: { name: true, age: undefined } })).toEqual([
+      { name: "Alice" },
+      { name: "Bob" },
+      { name: "Carol" },
+    ]);
+  });
+
+  test("select の全キーが undefined なら GassmaInvalidValueError", () => {
+    const users = looseSheet("Users");
+    const fn = () => users.findMany({ select: { age: undefined } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Invalid value for argument `select`.");
+  });
+
+  test("リテラルの select: {} も同じエラー（Prisma 実測準拠）", () => {
+    const users = looseSheet("Users");
+    expect(() => users.findMany({ select: {} })).toThrow(
+      GassmaInvalidValueError,
+    );
+    expect(() =>
+      users.update({ where: { id: 1 }, select: {}, data: { age: 21 } }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("キーが1つでも残る select は通る", () => {
+    const users = looseSheet("Users");
+    expect(users.findMany({ select: { name: true } })).toHaveLength(3);
+  });
+
+  test("distinct: undefined / take: undefined / skip: undefined は未指定と同じ", () => {
+    const users = looseSheet("Users");
+    expect(
+      users.findMany({ distinct: undefined, take: undefined, skip: undefined }),
+    ).toHaveLength(3);
+  });
+});
+
+describe("groupBy having の undefined", () => {
+  test("having のフィールド undefined はフィルタなし", () => {
+    const users = looseSheet("Users");
+    expect(
+      users.groupBy({
+        by: ["age"],
+        having: { age: undefined },
+        _count: { _all: true },
+      }),
+    ).toHaveLength(3);
+  });
+
+  test("having の演算子 undefined はその演算子だけ無視", () => {
+    const users = looseSheet("Users");
+    expect(
+      users.groupBy({
+        by: ["age"],
+        having: { age: { equals: undefined } },
+        _count: { _all: true },
+      }),
+    ).toHaveLength(3);
+  });
+
+  test("having で実条件が残れば適用される", () => {
+    const users = looseSheet("Users");
+    const result = users.groupBy({
+      by: ["age"],
+      having: { age: { equals: 20, gt: undefined } },
+      _count: { _all: true },
+    });
+    expect(result).toEqual([{ age: 20, _count: { _all: 1 } }]);
+  });
+});
+
+describe("update / delete / upsert の where が undefined だけで空になる場合", () => {
+  test("update は GassmaInvalidValueError", () => {
+    const users = looseSheet("Users");
+    const fn = () =>
+      users.update({ where: { id: undefined }, data: { age: 99 } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow("Invalid value for argument `where`.");
+  });
+
+  test("delete も同様", () => {
+    const users = looseSheet("Users");
+    expect(() => users.delete({ where: { id: undefined } })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+
+  test("upsert も同様", () => {
+    const users = looseSheet("Users");
+    expect(() =>
+      users.upsert({
+        where: { id: undefined },
+        create: { id: 4, name: "Dave", age: 50 },
+        update: { age: 50 },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("実条件が残る update は通る", () => {
+    const users = looseSheet("Users");
+    const result = users.update({
+      where: { id: 1, name: undefined },
+      data: { age: 21 },
+    });
+    expect(result).toEqual({ id: 1, name: "Alice", age: 21 });
+  });
+});
+
+describe("updateMany / deleteMany の where の undefined は全件対象（Prisma 実測準拠）", () => {
+  test("updateMany({ where: { age: undefined } }) は全件更新", () => {
+    const users = looseSheet("Users");
+    const result = users.updateMany({
+      where: { age: undefined },
+      data: { age: 99 },
+    });
+    expect(result).toEqual({ count: 3 });
+  });
+
+  test("deleteMany({ where: { age: undefined } }) は全件削除", () => {
+    const users = looseSheet("Users");
+    const result = users.deleteMany({ where: { age: undefined } });
+    expect(result).toEqual({ count: 3 });
+    expect(users.count({})).toBe(0);
+  });
+});
+
+describe("data の undefined はフィールド未指定と同じ（Prisma 実測準拠）", () => {
+  test("update の data の undefined フィールドは更新されない", () => {
+    const users = looseSheet("Users");
+    const result = users.update({
+      where: { id: 1 },
+      data: { name: undefined, age: 21 },
+    });
+    expect(result).toEqual({ id: 1, name: "Alice", age: 21 });
+  });
+
+  test("create の data の undefined フィールドは未指定と同じ", () => {
+    const users = looseSheet("Users");
+    const result = users.create({
+      data: { id: 4, name: "Dave", age: undefined },
+    });
+    expect(result).toEqual({ id: 4, name: "Dave", age: null });
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -1,4 +1,7 @@
-import { GassmaMissingArgumentError } from "./errors/argument/argumentError";
+import {
+  GassmaInvalidValueError,
+  GassmaMissingArgumentError,
+} from "./errors/argument/argumentError";
 import {
   GassmaFindSelectOmitConflictError,
   NotFoundError,
@@ -76,6 +79,7 @@ import { resolveCount } from "./util/relation/resolveCount";
 import { resolveInclude } from "./util/relation/resolveInclude";
 import { resolveWhereRelation } from "./util/relation/whereRelation/resolveWhereRelation";
 import { normalizeQueryInput } from "./util/skip/normalizeQueryInput";
+import { validateEmptySelect } from "./util/validate/validateEmptySelect";
 import { validateOrderByKeys } from "./util/validate/validateOrderByKeys";
 import {
   type ValidatedOperation,
@@ -198,7 +202,17 @@ class GassmaController {
       this.strictUndefinedChecks,
     );
     validateTopLevelKeys(operation, normalized);
+    validateEmptySelect(normalized);
     return normalized;
+  }
+
+  // Prisma 実測(2026-08-03): 単一行操作の空の where はエラー
+  // ("needs at least one of `id` arguments")。undefined / Gassma.skip だけで
+  // 空になった場合も同じ扱い
+  private assertWhereHasCondition(where: Record<string, unknown>): void {
+    if (Object.keys(where).length === 0) {
+      throw new GassmaInvalidValueError("where", "at least one condition");
+    }
   }
 
   private relationNames(): string[] {
@@ -897,6 +911,7 @@ class GassmaController {
     if (updateData.where === undefined) {
       throw new GassmaMissingArgumentError("where");
     }
+    this.assertWhereHasCondition(updateData.where);
     if (updateData.data === undefined) {
       throw new GassmaMissingArgumentError("data");
     }
@@ -1111,6 +1126,7 @@ class GassmaController {
     if (upsertData.where === undefined) {
       throw new GassmaMissingArgumentError("where");
     }
+    this.assertWhereHasCondition(upsertData.where);
     if (upsertData.create === undefined) {
       throw new GassmaMissingArgumentError("create");
     }
@@ -1164,6 +1180,7 @@ class GassmaController {
     if (deleteData.where === undefined) {
       throw new GassmaMissingArgumentError("where");
     }
+    this.assertWhereHasCondition(deleteData.where);
     if (deleteData.include && deleteData.select) {
       throw new GassmaIncludeSelectConflictError();
     }

--- a/src/util/andOrNot/and.ts
+++ b/src/util/andOrNot/and.ts
@@ -3,6 +3,7 @@ import type { HitRowData } from "../../types/hitRowDataType";
 import { getWantFindIndexFromTitles } from "../core/getWantFindIndex";
 import { rowMatchesWhereFields } from "../core/rowMatchesWhereFields";
 import { isLogicMatch } from "./entry";
+import { isVacuousBranch } from "./vacuousBranch";
 
 const isAndMatch = (
   rowsData: HitRowData[],
@@ -12,6 +13,8 @@ const isAndMatch = (
   let resultRowsData: HitRowData[] = rowsData.concat();
 
   whereArray.forEach((where) => {
+    if (isVacuousBranch(where)) return;
+
     const wantFindIndex = getWantFindIndexFromTitles(titles, where);
 
     resultRowsData = resultRowsData.filter((row) =>

--- a/src/util/andOrNot/not.ts
+++ b/src/util/andOrNot/not.ts
@@ -3,6 +3,7 @@ import type { HitRowData } from "../../types/hitRowDataType";
 import { getWantFindIndexFromTitles } from "../core/getWantFindIndex";
 import { rowMatchesWhereFields } from "../core/rowMatchesWhereFields";
 import { isLogicMatch } from "./entry";
+import { isVacuousBranch } from "./vacuousBranch";
 
 const isNotMatch = (
   rowsData: HitRowData[],
@@ -17,6 +18,7 @@ const isNotMatch = (
     const hasLogicKey = "OR" in where || "AND" in where || "NOT" in where;
 
     if (wantFindIndex.length === 0 && !hasLogicKey) return;
+    if (isVacuousBranch(where)) return;
 
     hasCondition = true;
 

--- a/src/util/andOrNot/or.ts
+++ b/src/util/andOrNot/or.ts
@@ -3,6 +3,7 @@ import type { HitRowData } from "../../types/hitRowDataType";
 import { getWantFindIndexFromTitles } from "../core/getWantFindIndex";
 import { rowMatchesWhereFields } from "../core/rowMatchesWhereFields";
 import { isLogicMatch } from "./entry";
+import { isVacuousBranch } from "./vacuousBranch";
 
 const isOrMatch = (
   rowsData: HitRowData[],
@@ -12,6 +13,8 @@ const isOrMatch = (
   let resultRowsData: HitRowData[] = [];
 
   whereArray.forEach((where) => {
+    if (isVacuousBranch(where)) return;
+
     const wantFindIndex = getWantFindIndexFromTitles(titles, where);
 
     let findedData = rowsData.filter((row) =>

--- a/src/util/andOrNot/vacuousBranch.ts
+++ b/src/util/andOrNot/vacuousBranch.ts
@@ -1,0 +1,24 @@
+import type { WhereUse } from "../../types/coreTypes";
+import { isDict } from "../other/isDict";
+
+// Prisma 実測(2026-08-03, prisma-test/vacuousProbe.ts, emptyLiteralProbe.ts):
+// (1) 条件を1つも生成しないブランチは AND/OR/NOT の配列から取り除かれる
+// (2) 空になった OR は恒偽、空の AND/NOT は恒真
+// AND/NOT/OR とも空配列・全ブランチ条件ゼロは条件ゼロとして再帰的に扱う。
+// OR の単体 dict 形は配列必須エラーの対象なので条件ゼロにしない(Prisma も同様にエラー)
+const isVacuousLogicValue = (value: unknown): boolean => {
+  if (Array.isArray(value))
+    return value.every((branch) => isDict(branch) && isVacuousBranch(branch));
+  if (isDict(value)) return isVacuousBranch(value);
+  return false;
+};
+
+const isVacuousBranch = (where: WhereUse): boolean =>
+  Object.keys(where).every((key) => {
+    const value = where[key];
+    if (key === "OR") return Array.isArray(value) && isVacuousLogicValue(value);
+    if (key === "AND" || key === "NOT") return isVacuousLogicValue(value);
+    return isDict(value) && Object.keys(value).length === 0;
+  });
+
+export { isVacuousBranch };

--- a/src/util/find/findMany.ts
+++ b/src/util/find/findMany.ts
@@ -39,10 +39,13 @@ const findManyFunc = (
   });
 
   // 適用順は Prisma 実測: orderBy → (take 負数は反転順で) cursor → distinct → skip → take
+  // 空のエントリ({})は Prisma 実測どおり無視する
   if (orderBy)
     findDataDictArray = orderByFunc(
       findDataDictArray,
-      Array.isArray(orderBy) ? orderBy : [orderBy],
+      (Array.isArray(orderBy) ? orderBy : [orderBy]).filter(
+        (entry) => Object.keys(entry).length > 0,
+      ),
     );
 
   const cursor = "cursor" in findData ? findData.cursor : null;

--- a/src/util/skip/normalizeQueryInput.ts
+++ b/src/util/skip/normalizeQueryInput.ts
@@ -16,8 +16,7 @@ const normalizeArray = (
   values.map((value, index) => {
     const itemPath = `${path}[${index}]`;
     if (isSkipValue(value)) throw new GassmaSkipInArrayError(itemPath);
-    if (value === undefined && strict)
-      throw new GassmaUndefinedValueError(itemPath);
+    if (value === undefined) throw new GassmaUndefinedValueError(itemPath);
     return normalizeValue(value, strict, itemPath);
   });
 
@@ -31,8 +30,10 @@ const normalizeDict = (
     const value = dict[key];
     if (isSkipValue(value)) return;
     const valuePath = joinPath(path, key);
-    if (value === undefined && strict)
-      throw new GassmaUndefinedValueError(valuePath);
+    if (value === undefined) {
+      if (strict) throw new GassmaUndefinedValueError(valuePath);
+      return;
+    }
     result[key] = normalizeValue(value, strict, valuePath);
   });
   return result;

--- a/src/util/validate/validateEmptySelect.ts
+++ b/src/util/validate/validateEmptySelect.ts
@@ -1,0 +1,13 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import { isDict } from "../other/isDict";
+
+// Prisma 実測(2026-08-03): select は空を許さない("must not be empty")
+const validateEmptySelect = (input: unknown): void => {
+  if (!isDict(input)) return;
+  const select = input.select;
+  if (isDict(select) && Object.keys(select).length === 0) {
+    throw new GassmaInvalidValueError("select", "at least one selected field");
+  }
+};
+
+export { validateEmptySelect };

--- a/src/util/validate/validateFieldKeys.ts
+++ b/src/util/validate/validateFieldKeys.ts
@@ -1,4 +1,7 @@
-import { GassmaUnknownArgumentError } from "../../errors/argument/argumentError";
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../errors/argument/argumentError";
 import { validateQueryScalar } from "./validateQueryValues";
 
 const validateFieldKeys = (keys: string[], titles: string[]): void => {
@@ -20,6 +23,10 @@ const validateCursorKeys = (
   cursor: Record<string, unknown>,
   titles: string[],
 ): void => {
+  // Prisma 実測(2026-08-03): 空の cursor はエラー("needs at least one of `id` arguments")
+  if (Object.keys(cursor).length === 0) {
+    throw new GassmaInvalidValueError("cursor", "at least one column");
+  }
   validateFieldKeys(Object.keys(cursor), titles);
   Object.entries(cursor).forEach(([key, value]) => {
     if (value === undefined) return;


### PR DESCRIPTION
#214 のレビュー中に見つかった `where: { col: undefined }` の差異への対応です。調べたところ **`undefined` の扱いは全域でずれていた**ため、まとめて Prisma に合わせました。

すべて **Prisma 7.4.1 + SQLite で発行 SQL 付きに実測**してから実装しています。

## 発端

```js
findMany({ where: { age: undefined } })                  // gassma: 0件   Prisma: 全件
findMany({ where: { name: "Alice", age: undefined } })   // gassma: 0件   Prisma: Alice
findMany({ where: {} })                                  // gassma: 全件  Prisma: 全件（一致）
```

「未指定」として扱われるのは **`where` 全体が `undefined` のときだけ**で、フィールド単位では「何にも一致しない条件」になっていました。

## 直したもの（main との before / after は実測値）

| クエリ | 修正前 | 修正後 | Prisma |
|---|---|---|---|
| `where: { age: undefined }` | **0件** | 全件 | 全件 |
| `where: { name:"Alice", age: undefined }` | **0件** | Alice | Alice |
| `where: { age: { gt: undefined, lt: 30 } }` | 0件 | `lt` だけ適用 | `lt` だけ適用 |
| `where: { age: { in: undefined } }` | **生 TypeError** | 無視 | 無視 |
| `where: { age: { in: [1, undefined] } }` | 黙って無視 | エラー | エラー |
| `where: { AND: [undefined] }` | **生 TypeError** | エラー | エラー |
| `orderBy: {}` | **生 TypeError でクラッシュ** | 無視 | 無視 |
| `distinct: [undefined]` | **生 TypeError** | エラー | エラー |
| `posts: { some: undefined }` | 存在チェックに化ける | 無視 | 無視 |

### サイレントなデータ破壊が2件消えました

```js
update({ where: { id: 1 }, data: { age: undefined } })
// 修正前: age 列の値が消える        修正後: age は更新対象外（Prisma と同じ）

update({ where: { id: Gassma.skip }, data: {...} })
delete({ where: { id: Gassma.skip } })
// 修正前: 先頭行を黙って更新／削除   修正後: エラー
```

`Gassma.skip` で `where` が空になったとき**先頭行を書き換えていた**のは、#192〜#199 で塞いできた「1文字違いで無関係な行が壊れる」経路と同じ家系です。

## 方針: Prisma と同じ「入口で剥がす」

Prisma のシリアライザは **undefined のキーをリクエストに載せません**（SQL に痕跡が残らないことを確認）。gassma も同じ段でやります。

全 15 操作が通る `normalizeQueryInput` で dict の undefined キーを除去し、配列内の undefined はエラーにしました。これだけで `where` / 演算子 / リレーションフィルタ / `orderBy` / `distinct` / `having` / `data` が**一括で直ります**。個別の比較ロジックには手を入れていません。

## 空オブジェクトの扱いも揃えました

undefined を剥がすと `{ col: undefined }` は `{}` になります。**そこで初めて、空オブジェクトの扱いが Prisma とかなり違うことが分かりました。**

### 1. 条件ゼロのブランチは論理配列から捨てられる

Prisma の規則は2つで、実測した SQL がそのまま証拠になります。

```
where: { OR: [{ label: {} }] }               → WHERE 1=0    （ブランチを捨て、空 OR は恒偽）
where: { OR: [{ label: {} }, {label:"A"}] }  → WHERE label = ?
where: { NOT: [{ label: {} }] }              → WHERE 1=1    （空 AND / NOT は恒真）
where: { AND: [{ OR: [] }] }                 → WHERE 1=1
where: { OR: [{ AND: [{}] }] }               → WHERE 1=0    （再帰的に条件ゼロ）
```

**(1) 条件を1つも生成しないブランチは AND/OR/NOT の配列から取り除く。(2) 空になった `OR` は恒偽、空の `AND`/`NOT` は恒真。** `OR: [{ OR: [] }]` が 0件なのは (1) で全ブランチが消えた結果 (2) が効いているためで、一貫しています。

修正前の gassma は `OR: [{}]` が全件、`NOT: [{col:{}}]` が 0件と**真逆**でした。`src/util/andOrNot/vacuousBranch.ts` で再帰的に判定するようにしています。

### 2. 空の where / select / cursor はエラー

| 呼び出し | Prisma |
|---|---|
| `update` / `delete` / `upsert` の `where: {}` | エラー「needs at least one of \`id\` arguments」 |
| `select: {}` | エラー「The \`select\` statement must not be empty」 |
| `cursor: {}` | エラー |
| `findMany({ where: {} })` / `updateMany({ where: {} })` | **エラーではない**（全件・全件更新） |
| `include: {}` / `omit: {}` / `orderBy: {}` / `orderBy: []` | 無視 |

gassma は `update`/`delete` の `where: {}` が**先頭行を対象にしていました**。この挙動は `missingArguments.test.ts` が「対象外・挙動維持」として明示固定していたものですが、`Gassma.skip` の件と同じ危険があるため**ユーザー判断のうえ Prisma に合わせています**。該当テスト2件はテスト名ごと差し替えました。

## 実装

| ファイル | 内容 |
|---|---|
| `util/skip/normalizeQueryInput.ts` | 非 strict 時に dict の undefined キーを除去。配列要素の undefined は `GassmaUndefinedValueError`（strict の挙動は不変） |
| `util/andOrNot/vacuousBranch.ts` **新規** | 条件ゼロのブランチ判定（論理キーを再帰） |
| `util/andOrNot/{and,or,not}.ts` | 条件ゼロのブランチをスキップ（各 +2〜3行） |
| `util/validate/validateEmptySelect.ts` **新規** | 空 select を入口 1 箇所で全 15 操作分 |
| `util/validate/validateFieldKeys.ts` | 空 cursor をエラーに |
| `util/find/findMany.ts` | `orderBy` の空エントリをスキップ（従来はクラッシュ） |
| `gassmaController.ts` | `update`/`delete`/`upsert` の空 where をエラーに（+15行） |

**新規エラークラスは追加していません**（既存の `GassmaUndefinedValueError` / `GassmaInvalidValueError` で足ります）。`as` 追加なし・`for...of` なし・全ファイル 200 行以内。

## 検証結果

- `npm test`: **2,813件 全 green**（2,742 → +71）
- 往復契約テスト3スイート31件 green、**期待値は無変更**
- `tsc --noEmit` / lint（警告48件・ベースラインと同数） / format / `verify:bundle`（公開シンボル57件）pass

### 期待値を変更した既存テスト（8件・すべて理由あり）

| テスト | 変更 | 根拠 |
|---|---|---|
| `normalizeQueryInput`「undefined 値のキーはそのまま残す」 | 取り除く | 素通しがバグの根本原因。Prisma のシリアライザは落とす |
| 同「配列内の undefined もそのまま残す」 | エラー | Prisma は default モードでもエラー |
| `strictUndefinedChecks`「where の undefined は何もマッチしない」 | 全件 | 本 PR の主題 |
| 同「update data の undefined は値が消える」 | フィールド未指定扱い | データ破壊の解消 |
| `invalidQueryValues`「undefined は従来の挙動のまま」 | 全件 | 同上 |
| `missingArguments`「where: {} は先頭行を削除（対象外・挙動維持）」 | エラー | ユーザー判断で Prisma に合わせた |
| 同「where: {} + data は先頭行を更新（対象外・挙動維持）」 | エラー | 同上 |
| `emptyLogicalOperators`「AND: [{ OR: [] }] は0件」 | 全件 | Prisma 実測（`WHERE 1=1`） |

いずれも「**従来挙動の維持**」を明示していたテストで、本 PR がまさにその挙動を Prisma に合わせるものです。

## 対応できなかった点

**`create({ data: { 必須列: undefined } })`** は Prisma だと「Argument is missing」エラーですが、gassma は**実行時に列の必須／任意を知らない**ため合わせられません。現状は `null` が入ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)