### PR TITLE
fix: take / skip / limit の NaN・Infinity を拒否する

### DIFF
--- a/src/__test__/util/find/findUtil/applySkipTake.test.ts
+++ b/src/__test__/util/find/findUtil/applySkipTake.test.ts
@@ -66,4 +66,40 @@ describe("applySkipTake", () => {
       "Value can only be positive",
     );
   });
+
+  test("should throw for NaN skip", () => {
+    expect(() => applySkipTake(data, NaN, null)).toThrow(
+      "Invalid value for argument `skip`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("should throw for Infinity skip", () => {
+    expect(() => applySkipTake(data, Infinity, null)).toThrow(
+      "Invalid value for argument `skip`. Expected a finite number, but received Infinity.",
+    );
+  });
+
+  test("should throw for -Infinity skip", () => {
+    expect(() => applySkipTake(data, -Infinity, null)).toThrow(
+      "Invalid value for argument `skip`. Expected a finite number, but received -Infinity.",
+    );
+  });
+
+  test("should throw for NaN take", () => {
+    expect(() => applySkipTake(data, null, NaN)).toThrow(
+      "Invalid value for argument `take`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("should throw for Infinity take", () => {
+    expect(() => applySkipTake(data, null, Infinity)).toThrow(
+      "Invalid value for argument `take`. Expected a finite number, but received Infinity.",
+    );
+  });
+
+  test("should throw for -Infinity take", () => {
+    expect(() => applySkipTake(data, null, -Infinity)).toThrow(
+      "Invalid value for argument `take`. Expected a finite number, but received -Infinity.",
+    );
+  });
 });

--- a/src/__test__/util/invalidPaginationValues.test.ts
+++ b/src/__test__/util/invalidPaginationValues.test.ts
@@ -1,0 +1,277 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import {
+  GassmaFindFirstTakeError,
+  GassmaSkipNegativeError,
+} from "../../errors/find/findError";
+import { IncludeInvalidOptionTypeError } from "../../errors/relation/relationValidationError";
+import { buildTestClient, sheetOf } from "./extends/extendsTestClient";
+import { clearGasGlobals } from "./transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const looseUsers = (options?: { relations?: boolean }): any => {
+  const typed = sheetOf(buildTestClient(options), "Users");
+  const loose: any = typed;
+  return loose;
+};
+
+describe("findMany の take の非有限数はエラー", () => {
+  test("take: NaN はエラー", () => {
+    const loose = looseUsers();
+    const fn = () => loose.findMany({ take: NaN });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `take`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("take: Infinity はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.findMany({ take: Infinity })).toThrow(
+      "Invalid value for argument `take`. Expected a finite number, but received Infinity.",
+    );
+  });
+
+  test("take: -Infinity はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.findMany({ take: -Infinity })).toThrow(
+      "Invalid value for argument `take`. Expected a finite number, but received -Infinity.",
+    );
+  });
+});
+
+describe("findMany の skip の非有限数はエラー", () => {
+  test("skip: NaN はエラー", () => {
+    const loose = looseUsers();
+    const fn = () => loose.findMany({ skip: NaN });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `skip`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("skip: Infinity はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.findMany({ skip: Infinity })).toThrow(
+      "Invalid value for argument `skip`. Expected a finite number, but received Infinity.",
+    );
+  });
+
+  test("skip: -Infinity はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.findMany({ skip: -Infinity })).toThrow(
+      "Invalid value for argument `skip`. Expected a finite number, but received -Infinity.",
+    );
+  });
+});
+
+describe("findFirst のページング非有限数", () => {
+  test("skip: NaN はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.findFirst({ skip: NaN })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+
+  test("take: NaN は既存の GassmaFindFirstTakeError のまま", () => {
+    const loose = looseUsers();
+    expect(() => loose.findFirst({ take: NaN })).toThrow(
+      GassmaFindFirstTakeError,
+    );
+  });
+
+  test("take: Infinity は既存の GassmaFindFirstTakeError のまま", () => {
+    const loose = looseUsers();
+    expect(() => loose.findFirst({ take: Infinity })).toThrow(
+      GassmaFindFirstTakeError,
+    );
+  });
+});
+
+describe("count の take/skip の非有限数はエラー", () => {
+  test("take: NaN はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.count({ take: NaN })).toThrow(GassmaInvalidValueError);
+  });
+
+  test("skip: Infinity はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.count({ skip: Infinity })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+});
+
+describe("aggregate の take/skip の非有限数はエラー", () => {
+  test("skip: NaN はエラー(黙って無視しない)", () => {
+    const loose = looseUsers();
+    expect(() => loose.aggregate({ _max: { age: true }, skip: NaN })).toThrow(
+      "Invalid value for argument `skip`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("take: Infinity はエラー", () => {
+    const loose = looseUsers();
+    expect(() =>
+      loose.aggregate({ _max: { age: true }, take: Infinity }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+});
+
+describe("groupBy の take/skip の非有限数はエラー", () => {
+  test("skip: NaN はエラー(黙って無視しない)", () => {
+    const loose = looseUsers();
+    expect(() =>
+      loose.groupBy({ by: ["age"], _min: { age: true }, skip: NaN }),
+    ).toThrow(
+      "Invalid value for argument `skip`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("take: NaN はエラー", () => {
+    const loose = looseUsers();
+    expect(() =>
+      loose.groupBy({ by: ["age"], _min: { age: true }, take: NaN }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+});
+
+describe("updateMany の limit の非有限数はエラー", () => {
+  test("limit: NaN はエラー", () => {
+    const loose = looseUsers();
+    const fn = () =>
+      loose.updateMany({ where: {}, data: { name: "x" }, limit: NaN });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `limit`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("limit: Infinity はエラー", () => {
+    const loose = looseUsers();
+    expect(() =>
+      loose.updateMany({ where: {}, data: { name: "x" }, limit: Infinity }),
+    ).toThrow(
+      "Invalid value for argument `limit`. Expected a finite number, but received Infinity.",
+    );
+  });
+
+  test("limit: -Infinity はエラー", () => {
+    const loose = looseUsers();
+    expect(() =>
+      loose.updateMany({ where: {}, data: { name: "x" }, limit: -Infinity }),
+    ).toThrow(
+      "Invalid value for argument `limit`. Expected a finite number, but received -Infinity.",
+    );
+  });
+});
+
+describe("deleteMany の limit の非有限数はエラー", () => {
+  test("limit: NaN はエラー(黙って0件削除にしない)", () => {
+    const loose = looseUsers();
+    expect(() => loose.deleteMany({ where: {}, limit: NaN })).toThrow(
+      "Invalid value for argument `limit`. Expected a finite number, but received NaN.",
+    );
+  });
+
+  test("limit: Infinity はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.deleteMany({ where: {}, limit: Infinity })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+});
+
+describe("include の take/skip の非有限数はエラー", () => {
+  test("take: NaN はエラー", () => {
+    const loose = looseUsers({ relations: true });
+    const fn = () => loose.findMany({ include: { posts: { take: NaN } } });
+    expect(fn).toThrow(IncludeInvalidOptionTypeError);
+    expect(fn).toThrow(
+      'Include "posts": option "take" must be a finite number',
+    );
+  });
+
+  test("take: -Infinity はエラー", () => {
+    const loose = looseUsers({ relations: true });
+    expect(() =>
+      loose.findMany({ include: { posts: { take: -Infinity } } }),
+    ).toThrow('Include "posts": option "take" must be a finite number');
+  });
+
+  test("skip: Infinity はエラー", () => {
+    const loose = looseUsers({ relations: true });
+    expect(() =>
+      loose.findMany({ include: { posts: { skip: Infinity } } }),
+    ).toThrow('Include "posts": option "skip" must be a finite number');
+  });
+
+  test("ネストした include の take: NaN もエラー", () => {
+    const loose = looseUsers({ relations: true });
+    expect(() =>
+      loose.findMany({
+        include: { posts: { include: { comments: { take: NaN } } } },
+      }),
+    ).toThrow('Include "comments": option "take" must be a finite number');
+  });
+});
+
+describe("現状維持の固定(仕様変更しない)", () => {
+  test("findMany の take: null は無視して全件", () => {
+    const loose = looseUsers();
+    expect(loose.findMany({ take: null })).toHaveLength(3);
+  });
+
+  test("findMany の skip: null は無視して全件", () => {
+    const loose = looseUsers();
+    expect(loose.findMany({ skip: null })).toHaveLength(3);
+  });
+
+  test("findMany の take: undefined は無視して全件", () => {
+    const loose = looseUsers();
+    expect(loose.findMany({ take: undefined })).toHaveLength(3);
+  });
+
+  test("findMany の take: 2.5 は2件相当", () => {
+    const loose = looseUsers();
+    expect(loose.findMany({ take: 2.5 })).toHaveLength(2);
+  });
+
+  test("findMany の skip: 1.5 は1件スキップ相当", () => {
+    const loose = looseUsers();
+    expect(loose.findMany({ skip: 1.5 })).toHaveLength(2);
+  });
+
+  test("findMany の skip: -1 は GassmaSkipNegativeError", () => {
+    const loose = looseUsers();
+    expect(() => loose.findMany({ skip: -1 })).toThrow(GassmaSkipNegativeError);
+  });
+
+  test("findMany の take: -2 は末尾から2件", () => {
+    const loose = looseUsers();
+    const result = loose.findMany({ take: -2 });
+    expect(result.map((row: any) => row.name)).toEqual(["Bob", "Carol"]);
+  });
+
+  test("updateMany の limit: null は無視して全件更新", () => {
+    const loose = looseUsers();
+    const result = loose.updateMany({
+      where: {},
+      data: { name: "x" },
+      limit: null,
+    });
+    expect(result).toEqual({ count: 3 });
+  });
+
+  test("deleteMany の limit: null は無視して全件削除", () => {
+    const loose = looseUsers();
+    expect(loose.deleteMany({ where: {}, limit: null })).toEqual({ count: 3 });
+  });
+
+  test("deleteMany の limit: 2.5 は2件削除", () => {
+    const loose = looseUsers();
+    expect(loose.deleteMany({ where: {}, limit: 2.5 })).toEqual({ count: 2 });
+  });
+});

--- a/src/__test__/util/relation/validation/validateIncludeOptions.test.ts
+++ b/src/__test__/util/relation/validation/validateIncludeOptions.test.ts
@@ -76,6 +76,18 @@ describe("validateIncludeOptions", () => {
         }),
       ).toThrow('option "take" must be a number');
     });
+
+    it("take が NaN の場合エラーを投げる", () => {
+      expect(() => validateIncludeOptions({ posts: { take: NaN } })).toThrow(
+        'option "take" must be a finite number',
+      );
+    });
+
+    it("take が Infinity の場合エラーを投げる", () => {
+      expect(() =>
+        validateIncludeOptions({ posts: { take: Infinity } }),
+      ).toThrow('option "take" must be a finite number');
+    });
   });
 
   describe("skip の型チェック", () => {
@@ -91,6 +103,18 @@ describe("validateIncludeOptions", () => {
           posts: { skip: "5" as unknown as number },
         }),
       ).toThrow('option "skip" must be a number');
+    });
+
+    it("skip が NaN の場合エラーを投げる", () => {
+      expect(() => validateIncludeOptions({ posts: { skip: NaN } })).toThrow(
+        'option "skip" must be a finite number',
+      );
+    });
+
+    it("skip が -Infinity の場合エラーを投げる", () => {
+      expect(() =>
+        validateIncludeOptions({ posts: { skip: -Infinity } }),
+      ).toThrow('option "skip" must be a finite number');
     });
   });
 

--- a/src/util/aggregate/aggregate.ts
+++ b/src/util/aggregate/aggregate.ts
@@ -13,6 +13,7 @@ import {
 } from "../validate/buildValidatedAggregateSelect";
 import { getSum } from "./aggregateUtil/sum";
 import { ensureAggregateSelection } from "./ensureAggregateSelection";
+import { validateFiniteNumberOption } from "../validate/validateFiniteNumberOption";
 
 const aggregateFunc = (
   gassmaControllerUtil: GassmaControllerUtil,
@@ -24,6 +25,7 @@ const aggregateFunc = (
   const orderBy = "orderBy" in aggregateData ? aggregateData.orderBy : null;
   const take = "take" in aggregateData ? aggregateData.take : null;
   const skip = "skip" in aggregateData ? aggregateData.skip : null;
+  validateFiniteNumberOption("skip", skip);
   const cursor = "cursor" in aggregateData ? aggregateData.cursor : null;
   const validateFieldSelect = (value: Select | null | undefined) =>
     typeof value === "object" && value !== null

--- a/src/util/delete/deleteMany.ts
+++ b/src/util/delete/deleteMany.ts
@@ -2,6 +2,7 @@ import { GassmaLimitNegativeError } from "../../errors/find/findError";
 import type { DeleteData, DeleteManyReturn } from "../../types/findTypes";
 import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
 import { whereFilter } from "../core/whereFilter";
+import { validateFiniteNumberOption } from "../validate/validateFiniteNumberOption";
 import { groupDeleteBlocksDescending } from "../write/rowRuns";
 import { resolveWriter } from "../write/sheetWriter";
 
@@ -13,6 +14,7 @@ const deleteManyFunc = (
 
   const where = deleteData.where ?? {};
   const limit = deleteData.limit;
+  validateFiniteNumberOption("limit", limit);
 
   let findedData = whereFilter(where, gassmaControllerUtil);
 

--- a/src/util/find/findUtil/applyCursorDistinctSkipTake.ts
+++ b/src/util/find/findUtil/applyCursorDistinctSkipTake.ts
@@ -1,3 +1,4 @@
+import { validateFiniteNumberOption } from "../../validate/validateFiniteNumberOption";
 import { applyCursor } from "./applyCursor";
 import { applyDistinct } from "./applyDistinct";
 import { applySkipTake } from "./applySkipTake";
@@ -10,6 +11,8 @@ const applyCursorDistinctSkipTake = (
   skip: number | null | undefined,
   take: number | null | undefined,
 ): Record<string, unknown>[] => {
+  validateFiniteNumberOption("take", take);
+
   const backward = typeof take === "number" && take < 0;
 
   let result = backward ? [...records].reverse() : records;

--- a/src/util/find/findUtil/applySkipTake.ts
+++ b/src/util/find/findUtil/applySkipTake.ts
@@ -1,10 +1,14 @@
 import { GassmaSkipNegativeError } from "../../../errors/find/findError";
+import { validateFiniteNumberOption } from "../../validate/validateFiniteNumberOption";
 
 const applySkipTake = (
   records: Record<string, unknown>[],
   skip: number | null | undefined,
   take: number | null | undefined,
 ): Record<string, unknown>[] => {
+  validateFiniteNumberOption("skip", skip);
+  validateFiniteNumberOption("take", take);
+
   let result = [...records];
 
   if (skip !== null && skip !== undefined && skip < 0) {

--- a/src/util/groupby/groupby.ts
+++ b/src/util/groupby/groupby.ts
@@ -12,6 +12,7 @@ import {
   buildValidatedCountSelect,
   buildValidatedFieldSelect,
 } from "../validate/buildValidatedAggregateSelect";
+import { validateFiniteNumberOption } from "../validate/validateFiniteNumberOption";
 import { byClassification } from "./groubyUtil/by";
 import { havingFilter } from "./groubyUtil/having";
 
@@ -22,6 +23,7 @@ const groupByFunc = (
   const where = groupByData.where || {};
   const orderBy = groupByData.orderBy || null;
   const take = "take" in groupByData ? groupByData.take : null;
+  validateFiniteNumberOption("skip", groupByData.skip);
   const skip = groupByData.skip || null;
   const validateFieldSelect = (value: Select | null | undefined) =>
     typeof value === "object" && value !== null

--- a/src/util/relation/validation/validateIncludeOptions.ts
+++ b/src/util/relation/validation/validateIncludeOptions.ts
@@ -23,6 +23,28 @@ const validateOptionObject = (
   }
 };
 
+const validateNumberOption = (
+  relationName: string,
+  optionName: string,
+  value: unknown,
+): void => {
+  if (value === undefined) return;
+  if (typeof value !== "number") {
+    throw new IncludeInvalidOptionTypeError(
+      relationName,
+      optionName,
+      "a number",
+    );
+  }
+  if (!Number.isFinite(value)) {
+    throw new IncludeInvalidOptionTypeError(
+      relationName,
+      optionName,
+      "a finite number",
+    );
+  }
+};
+
 const validateOrderByOption = (relationName: string, value: unknown): void => {
   if (value === undefined) return;
   if (isObject(value)) return;
@@ -54,13 +76,8 @@ const validateIncludeItem = (relationName: string, value: unknown): void => {
     throw new IncludeSelectIncludeConflictError(relationName);
   }
 
-  if (value.skip !== undefined && typeof value.skip !== "number") {
-    throw new IncludeInvalidOptionTypeError(relationName, "skip", "a number");
-  }
-
-  if (value.take !== undefined && typeof value.take !== "number") {
-    throw new IncludeInvalidOptionTypeError(relationName, "take", "a number");
-  }
+  validateNumberOption(relationName, "skip", value.skip);
+  validateNumberOption(relationName, "take", value.take);
 
   validateOptionObject(relationName, "where", value.where);
   validateOrderByOption(relationName, value.orderBy);

--- a/src/util/update/updateMany.ts
+++ b/src/util/update/updateMany.ts
@@ -7,6 +7,7 @@ import { getWantUpdateIndexFromTitles } from "../core/getWantUpdateIndex";
 import { whereFilter } from "../core/whereFilter";
 import { unwrapRawCell } from "../raw/raw";
 import { validateDataColumns } from "../validate/validateDataColumns";
+import { validateFiniteNumberOption } from "../validate/validateFiniteNumberOption";
 import { groupUpdateRuns } from "../write/rowRuns";
 import { resolveWriter } from "../write/sheetWriter";
 import {
@@ -38,6 +39,7 @@ function updateManyFunc(
   const where = updateData.where ?? {};
   const data = updateData.data;
   const limit = updateData.limit;
+  validateFiniteNumberOption("limit", limit);
 
   const titles = precomputedTitles ?? getTitle(gassmaControllerUtil);
 

--- a/src/util/validate/validateFiniteNumberOption.ts
+++ b/src/util/validate/validateFiniteNumberOption.ts
@@ -1,0 +1,15 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+
+const validateFiniteNumberOption = (
+  argumentName: string,
+  value: number | null | undefined,
+): void => {
+  if (typeof value !== "number") return;
+  if (Number.isFinite(value)) return;
+  throw new GassmaInvalidValueError(
+    argumentName,
+    `a finite number, but received ${String(value)}`,
+  );
+};
+
+export { validateFiniteNumberOption };


### PR DESCRIPTION
#215 のレビュー中に見つかった `skip` / `take` の素通りへの対応です。**#211（書き込み値）・#214（クエリ値）に続く、数値オプションの入口検証**になります。

## 問題

**`Number()` の結果をそのまま `take` に渡すと、ページングが黙って壊れます。**

```js
const take = Number(req.take);        // "abc" だと NaN
findMany({ take })                    // 修正前: 全件返る（ページングが消える）
```

素の JavaScript の比較がすべて false になるためです。

```js
if (take === 0) …      // false
if (take > 0) …        // NaN > 0 も false → 「負の take」の分岐に落ちる
return result.slice(take);   // slice(NaN) は slice(0) = 全件
```

**書き込み側は逆向きに壊れます。**

```js
updateMany({ data: {...}, limit: NaN })   // 修正前: { count: 0 }（黙って何もしない）
deleteMany({ limit: NaN })                // 修正前: { count: 0 }
```

`NaN < 0` が false なので負数ガードを抜け、`slice(0, NaN)` が空配列になります。**読み取りでは「全件」、書き込みでは「ゼロ件」**と、どちらも黙って意図と違う結果になっていました。

## 洗い出した全経路（修正前の実測値）

`applySkipTake` だけの問題ではありませんでした。**10経路**あります。

| 経路 | 修正前 |
|---|---|
| `findMany` の `take` / `skip` | NaN は無視（全件）、`skip: Infinity` は0件、`take: ±Infinity` は全件 |
| `findMany`（リレーション `orderBy` 経路） | 同上 |
| `findFirst` の `skip` | NaN は無視 |
| **`findFirst` の `take`** | **既に `GassmaFindFirstTakeError` で拒否済み**（`1 \| -1` 限定の仕様が非有限数を包含）→ **変更なし・テストで固定のみ** |
| `count` の `take` / `skip` | `findMany` へ転送されるため同じ |
| `aggregate` の `take` / `skip` | `skip: NaN` は `if (skip)` の falsy 判定で**転送前に消える** |
| `groupBy` の `take` / `skip` | `skip: NaN` は `skip \|\| null` で**null 化されて消える** |
| `updateMany` の `limit` | **`{ count: 0 }`（黙って no-op）**、Infinity は全件 |
| `deleteMany` の `limit` | 同上 |
| `include` の `take` / `skip` | NaN take で全件、NaN skip で無視 |

`aggregate` / `groupBy` の `skip` は **falsy 判定で消える**ため、`applySkipTake` に検証を置くだけでは届きませんでした。

## Prisma の実測

`limit` は未実測だったので測りました（`prisma-test/paginationLimitProbe.ts`）。

| 入力 | Prisma |
|---|---|
| `limit: NaN` / `±Infinity`（`updateMany` / `deleteMany`） | **エラー** |
| `include` ネストの `take` / `skip` に NaN / ±Infinity | **エラー** |
| `limit: -1` | エラー「Provided limit (-1) must be a positive integer.」 |
| `limit: 2.5` | **2件**（gassma と一致） |
| `limit: null` | エラー「must not be null」 |

**メッセージは Prisma に追従していません。** Prisma の文言は「Argument \`limit\` is missing.」で**値を渡しているのに「無い」と言われます**が、これは JSON プロトコルが NaN を表現できない副作用（[prisma/prisma#3492](https://github.com/prisma/prisma/issues/3492)）であって意図的な検証ではないためです。#211 / #214 と同じ形に揃えました。

```
Invalid value for argument `take`. Expected a finite number, but received NaN.
```

## 実装

`src/util/validate/validateFiniteNumberOption.ts`（15行）を新設し、**行ループの外・シートを読む前**に差し込みました。

| ファイル | 位置の理由 |
|---|---|
| `applySkipTake.ts` | `findMany` / `findFirst` の skip / `count` / `aggregate`・`groupBy` の take が合流する点 |
| `applyCursorDistinctSkipTake.ts` | `take` を反転（`-take`）する**前**。ここが無いと `take: -Infinity` が「received Infinity」と表示される |
| `aggregate.ts` / `groupby.ts` | falsy フィルタ（`if (skip)` / `skip \|\| null`）の**前** |
| `updateMany.ts` / `deleteMany.ts` | `limit` 取り出し直後（`whereFilter` より前 = シート読みより前） |
| `validateIncludeOptions.ts` | 既存の `typeof` チェックに集約。**親ループの前**に1回 |

**新規エラークラスは追加していません。** 既存の `GassmaInvalidValueError` で足ります。

`include` だけは既存の `IncludeInvalidOptionTypeError` を使いました（`Include "posts": option "take" must be a finite number`）。理由は、include のオプション検証が既にこのクラスの体系で統一されており、**リレーション名が入るのでネスト時にどの `take` か特定できる**ためです。フラットな形式に揃えたい場合は1行で切り替えられます。

## 現状維持（テストで固定）

| 入力 | 挙動 |
|---|---|
| `skip: null` / `take: null` / `limit: null` | **無視**（Prisma はエラーだが、gassma の公開型が `number \| null \| undefined` で **null を明示的に許容**しているため対象外） |
| `take: 2.5` / `skip: 1.5` / `limit: 2.5` | 切り捨て相当（Prisma と一致） |
| `skip: -1` | `GassmaSkipNegativeError` |
| `take: -1` | 末尾から取る既存仕様 |
| `undefined` | 無視 |

## 副次的な変化（エラー → 別のエラー）

`skip: -Infinity` は従来 `GassmaSkipNegativeError`（負数判定に引っかかっていた）、`limit: -Infinity` は `GassmaLimitNegativeError` でしたが、**どちらも `GassmaInvalidValueError` に変わります**。非有限を「負数」より先に弾くほうが一貫すると判断しました。いずれも**エラーからエラーへの変化**で、黙って通っていたものではありません。

## 検証結果

- `npm test`: **2,857件 全 green**（2,813 → +44）
- 往復契約テスト3スイート31件 green、**期待値は無変更**（検証がすべて行ループ外・1クエリ1回である証拠）
- `tsc --noEmit` / lint（警告48件・ベースラインと同数） / format / `verify:bundle`（公開シンボル57件）pass
- **既存テストの期待値変更はゼロ**

## 残る差異

**`null`** です。Prisma はエラー、gassma は無視のままです。合わせるなら公開型の変更になるため別途判断をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)