### PR TITLE
fix: take / skip / limit の null を拒否する

### DIFF
--- a/src/__test__/util/invalidPaginationValues.test.ts
+++ b/src/__test__/util/invalidPaginationValues.test.ts
@@ -219,16 +219,6 @@ describe("include の take/skip の非有限数はエラー", () => {
 });
 
 describe("現状維持の固定(仕様変更しない)", () => {
-  test("findMany の take: null は無視して全件", () => {
-    const loose = looseUsers();
-    expect(loose.findMany({ take: null })).toHaveLength(3);
-  });
-
-  test("findMany の skip: null は無視して全件", () => {
-    const loose = looseUsers();
-    expect(loose.findMany({ skip: null })).toHaveLength(3);
-  });
-
   test("findMany の take: undefined は無視して全件", () => {
     const loose = looseUsers();
     expect(loose.findMany({ take: undefined })).toHaveLength(3);
@@ -253,21 +243,6 @@ describe("現状維持の固定(仕様変更しない)", () => {
     const loose = looseUsers();
     const result = loose.findMany({ take: -2 });
     expect(result.map((row: any) => row.name)).toEqual(["Bob", "Carol"]);
-  });
-
-  test("updateMany の limit: null は無視して全件更新", () => {
-    const loose = looseUsers();
-    const result = loose.updateMany({
-      where: {},
-      data: { name: "x" },
-      limit: null,
-    });
-    expect(result).toEqual({ count: 3 });
-  });
-
-  test("deleteMany の limit: null は無視して全件削除", () => {
-    const loose = looseUsers();
-    expect(loose.deleteMany({ where: {}, limit: null })).toEqual({ count: 3 });
   });
 
   test("deleteMany の limit: 2.5 は2件削除", () => {

--- a/src/__test__/util/nullPaginationValues.test.ts
+++ b/src/__test__/util/nullPaginationValues.test.ts
@@ -1,0 +1,205 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import { IncludeInvalidOptionTypeError } from "../../errors/relation/relationValidationError";
+import { buildTestClient, sheetOf } from "./extends/extendsTestClient";
+import { clearGasGlobals } from "./transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const looseUsers = (options?: { relations?: boolean }): any => {
+  const typed = sheetOf(buildTestClient(options), "Users");
+  const loose: any = typed;
+  return loose;
+};
+
+const loosePosts = (): any => {
+  const typed = sheetOf(buildTestClient({ relations: true }), "Posts");
+  const loose: any = typed;
+  return loose;
+};
+
+describe("findMany の take/skip の null はエラー", () => {
+  test("take: null はエラー", () => {
+    const loose = looseUsers();
+    const fn = () => loose.findMany({ take: null });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `take`. Expected a number, but received null.",
+    );
+  });
+
+  test("skip: null はエラー", () => {
+    const loose = looseUsers();
+    const fn = () => loose.findMany({ skip: null });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `skip`. Expected a number, but received null.",
+    );
+  });
+
+  test("リレーション orderBy 経路でも take: null はエラー", () => {
+    const loose = loosePosts();
+    expect(() =>
+      loose.findMany({ orderBy: { author: { name: "asc" } }, take: null }),
+    ).toThrow(
+      "Invalid value for argument `take`. Expected a number, but received null.",
+    );
+  });
+
+  test("リレーション orderBy 経路でも skip: null はエラー", () => {
+    const loose = loosePosts();
+    expect(() =>
+      loose.findMany({ orderBy: { author: { name: "asc" } }, skip: null }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("take: undefined は従来どおり無視して全件", () => {
+    const loose = looseUsers();
+    expect(loose.findMany({ take: undefined })).toHaveLength(3);
+  });
+});
+
+describe("findFirst の take/skip の null はエラー", () => {
+  test("skip: null はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.findFirst({ skip: null })).toThrow(
+      "Invalid value for argument `skip`. Expected a number, but received null.",
+    );
+  });
+
+  test("take: null はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.findFirst({ take: null })).toThrow(
+      "Invalid value for argument `take`. Expected a number, but received null.",
+    );
+  });
+
+  test("findFirstOrThrow の skip: null もエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.findFirstOrThrow({ skip: null })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+});
+
+describe("count の take/skip の null はエラー", () => {
+  test("take: null はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.count({ take: null })).toThrow(GassmaInvalidValueError);
+  });
+
+  test("skip: null はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.count({ skip: null })).toThrow(
+      "Invalid value for argument `skip`. Expected a number, but received null.",
+    );
+  });
+});
+
+describe("aggregate の take/skip の null はエラー", () => {
+  test("take: null はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.aggregate({ _max: { age: true }, take: null })).toThrow(
+      "Invalid value for argument `take`. Expected a number, but received null.",
+    );
+  });
+
+  test("skip: null はエラー", () => {
+    const loose = looseUsers();
+    expect(() => loose.aggregate({ _max: { age: true }, skip: null })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+});
+
+describe("groupBy の take/skip の null はエラー", () => {
+  test("take: null はエラー", () => {
+    const loose = looseUsers();
+    expect(() =>
+      loose.groupBy({ by: ["age"], _min: { age: true }, take: null }),
+    ).toThrow(
+      "Invalid value for argument `take`. Expected a number, but received null.",
+    );
+  });
+
+  test("skip: null はエラー", () => {
+    const loose = looseUsers();
+    expect(() =>
+      loose.groupBy({ by: ["age"], _min: { age: true }, skip: null }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+});
+
+describe("updateMany 系の limit の null はエラー", () => {
+  test("updateMany の limit: null はエラー(黙って全件更新しない)", () => {
+    const loose = looseUsers();
+    const fn = () =>
+      loose.updateMany({ where: {}, data: { name: "x" }, limit: null });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `limit`. Expected a number, but received null.",
+    );
+  });
+
+  test("updateManyAndReturn の limit: null はエラー", () => {
+    const loose = looseUsers();
+    expect(() =>
+      loose.updateManyAndReturn({
+        where: {},
+        data: { name: "x" },
+        limit: null,
+      }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("limit: null で更新は一切走らない", () => {
+    const loose = looseUsers();
+    expect(() =>
+      loose.updateMany({ where: {}, data: { name: "x" }, limit: null }),
+    ).toThrow();
+    expect(loose.findMany({ where: { name: "x" } })).toHaveLength(0);
+  });
+});
+
+describe("deleteMany の limit の null はエラー", () => {
+  test("limit: null はエラー(黙って全件削除しない)", () => {
+    const loose = looseUsers();
+    const fn = () => loose.deleteMany({ where: {}, limit: null });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `limit`. Expected a number, but received null.",
+    );
+  });
+
+  test("limit: null で削除は一切走らない", () => {
+    const loose = looseUsers();
+    expect(() => loose.deleteMany({ where: {}, limit: null })).toThrow();
+    expect(loose.findMany()).toHaveLength(3);
+  });
+});
+
+describe("include の take/skip の null はエラー", () => {
+  test("take: null はエラー", () => {
+    const loose = looseUsers({ relations: true });
+    const fn = () => loose.findMany({ include: { posts: { take: null } } });
+    expect(fn).toThrow(IncludeInvalidOptionTypeError);
+    expect(fn).toThrow('Include "posts": option "take" must be a number');
+  });
+
+  test("skip: null はエラー", () => {
+    const loose = looseUsers({ relations: true });
+    expect(() =>
+      loose.findMany({ include: { posts: { skip: null } } }),
+    ).toThrow('Include "posts": option "skip" must be a number');
+  });
+
+  test("ネストした include の take: null もエラー", () => {
+    const loose = looseUsers({ relations: true });
+    expect(() =>
+      loose.findMany({
+        include: { posts: { include: { comments: { take: null } } } },
+      }),
+    ).toThrow('Include "comments": option "take" must be a number');
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -80,6 +80,7 @@ import { resolveInclude } from "./util/relation/resolveInclude";
 import { resolveWhereRelation } from "./util/relation/whereRelation/resolveWhereRelation";
 import { normalizeQueryInput } from "./util/skip/normalizeQueryInput";
 import { validateEmptySelect } from "./util/validate/validateEmptySelect";
+import { validateNullPagination } from "./util/validate/validateNullPagination";
 import { validateOrderByKeys } from "./util/validate/validateOrderByKeys";
 import {
   type ValidatedOperation,
@@ -202,6 +203,7 @@ class GassmaController {
       this.strictUndefinedChecks,
     );
     validateTopLevelKeys(operation, normalized);
+    validateNullPagination(operation, normalized);
     validateEmptySelect(normalized);
     return normalized;
   }

--- a/src/util/validate/validateNullPagination.ts
+++ b/src/util/validate/validateNullPagination.ts
@@ -1,0 +1,30 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import { isDict } from "../other/isDict";
+import type { ValidatedOperation } from "./validateTopLevelKeys";
+
+// Prisma 実測: take / skip / limit の null は「Argument must not be null」エラー
+const NULL_REJECTED_KEYS: Partial<Record<ValidatedOperation, string[]>> = {
+  findMany: ["take", "skip"],
+  findFirst: ["take", "skip"],
+  count: ["take", "skip"],
+  aggregate: ["take", "skip"],
+  groupBy: ["take", "skip"],
+  updateMany: ["limit"],
+  updateManyAndReturn: ["limit"],
+  deleteMany: ["limit"],
+};
+
+const validateNullPagination = (
+  operation: ValidatedOperation,
+  input: unknown,
+): void => {
+  const keys = NULL_REJECTED_KEYS[operation];
+  if (!keys || !isDict(input)) return;
+
+  keys.forEach((key) => {
+    if (input[key] !== null) return;
+    throw new GassmaInvalidValueError(key, "a number, but received null");
+  });
+};
+
+export { validateNullPagination };


### PR DESCRIPTION
#216 で「残る差異」として挙げた **`null`** への対応です。これでページング系オプションの Prisma 追随が完了します。

## これは公開仕様の変更ではありません

**#216 の時点で「gassma の公開型が `number | null | undefined` で null を明示的に許容している」と書きましたが、誤りでした。**

```ts
// src/index.d.ts（公開型）
take?: number | SkipValue;      // ← null は入っていない
skip?: number | SkipValue;
limit?: number | SkipValue;

// cli の生成型
take?: number;  skip?: number;  limit?: number;
```

`null` を許容しているのは `applySkipTake` などの**内部シグネチャだけ**でした。到達できるのは **TS を経由しない JS から**のみで、#192〜#199 で塞いできた「型では防げるが実行時に黙って通る」穴と同じ性質です。**公開型の変更は不要です。**

## 問題

**書き込み側が黙って全件に効いていました。**

```js
updateMany({ data: {...}, limit: null })   // 修正前: { count: 3 } — 全行を更新
deleteMany({ limit: null })                // 修正前: { count: 3 } — 全行を削除
```

呼び出し側は件数を制限したつもりでいるのに、`limit` が丸ごと消えます。読み取り側も `take: null` で全件返っていました。

## 検証位置 — ここでなければ壊れます

**`normalizeInput`（`validateTopLevelKeys` の直後）に置きました。** ここは**全9操作の利用者入力が必ず通る唯一の共通入口**です。

**`applySkipTake` で一律に null を弾く実装は成立しません。内部コードが null を渡しているからです。**

```ts
// findFirst は明示的に null を渡す
applySkipTake(rows, skip, null)

// groupBy は undefined を null に正規化する
skip || null
```

`normalizeInput` はこれらの**すべてより手前**なので、そこで見える `null` は**利用者が明示的に渡したものだけ**です。位置だけで内部 null と区別でき、フラグも文脈も要りません。#196 の「検証位置を間違えると届かない／往復契約テストが落ちる」と同じ構図でした。

実装は許可キーの宣言表です（`validateTopLevelKeys` と同じ形）。

```ts
const NULL_REJECTED_KEYS = {
  findMany: ["take", "skip"],   findFirst: ["take", "skip"],
  count: ["take", "skip"],      aggregate: ["take", "skip"],
  groupBy: ["take", "skip"],    updateMany: ["limit"],
  updateManyAndReturn: ["limit"], deleteMany: ["limit"],
};
```

## 全経路の修正前・修正後（実測）

| 経路 | 修正前 | 修正後 |
|---|---|---|
| `findMany` の `take` / `skip` | 全件 | `GassmaInvalidValueError` |
| `findFirst` / `findFirstOrThrow` の `take` / `skip` | 先頭行 | 同上 |
| `count` / `aggregate` / `groupBy` の `take` / `skip` | 無視 | 同上 |
| **`updateMany` / `updateManyAndReturn` の `limit`** | **全件更新** | 同上 |
| **`deleteMany` の `limit`** | **全件削除** | 同上 |
| `include` の `take` / `skip` | **既にエラーだった**（#216 の `validateNumberOption` が `typeof !== "number"` で null も弾く） | 変更なし・テストで固定 |

`findFirst` の `take: null` は `GassmaFindFirstTakeError`（`1 \| -1` 限定）にもならず、**`null === undefined` 扱いで黙って無視**されていました。

メッセージは #211 / #214 / #216 と同形式です。

```
Invalid value for argument `take`. Expected a number, but received null.
```

## 内部シグネチャ

**`applySkipTake` の `number | null | undefined` はそのまま残しました。** 上記のとおり内部から null が渡るためです。narrow すると `findFirst` と `groupBy` が壊れます。

## 検証結果

- `npm test`: **2,875件 全 green**（2,857 → +18）
- 往復契約テスト3スイート31件 green、**期待値は無変更**
- `tsc --noEmit` / lint（警告48件・ベースラインと同数） / format / `verify:bundle`（公開シンボル57件・エラークラス47件）pass

**内部 null の経路が壊れていないことを個別に確認しています**（引数なしの `findMany` / `skip` なしの `groupBy` / `skip` なしの `aggregate` / 通常の `findFirst`）。

### 削除した既存テスト4件

`invalidPaginationValues.test.ts` の「現状維持の固定」describe 内にあった、**#216 で「null は無視」を明示的に固定していた4件**です。

| テスト | 削除理由 |
|---|---|
| `findMany` の `take: null` は無視して全件 | 本 PR がまさにこの挙動を覆す。新ファイル `nullPaginationValues.test.ts` でエラー仕様として固定し直し |
| `findMany` の `skip: null` は無視して全件 | 同上 |
| `updateMany` の `limit: null` は無視して全件更新 | 同上 |
| `deleteMany` の `limit: null` は無視して全件削除 | 同上 |

それ以外の既存テストは**期待値含め無変更**です。

## 別途見つかった差異（**本 PR では未対応**）

**`cursor` / `distinct` / `orderBy` / `where` に `null` を渡すと、いずれも黙って無視されます**（`if (cursor)` のような truthy ガードのため）。

**Prisma 側の挙動を実測していないため触っていません。** 塞ぐなら上の表にキーを足すだけですが、`expected` の文言が型ごとに変わります。実測のうえ判断をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)