### PR TITLE
test: 新しい検証コードをライブラリ境界越しに検証する

### DIFF
--- a/src/__test__/util/find/findUtil/applyDistinct.test.ts
+++ b/src/__test__/util/find/findUtil/applyDistinct.test.ts
@@ -1,4 +1,8 @@
 import { applyDistinct } from "../../../../util/find/findUtil/applyDistinct";
+import {
+  createCrossRealmDate,
+  createCrossRealmValue,
+} from "../../../consts/crossRealm";
 
 describe("applyDistinct", () => {
   test("should keep first occurrence for a single column", () => {
@@ -122,5 +126,56 @@ describe("applyDistinct", () => {
       ];
       expect(applyDistinct(rows, ["a", "b"])).toEqual(rows);
     });
+  });
+});
+
+describe("applyDistinct with cross-realm Dates", () => {
+  test("should collapse a cross-realm Date with a same-realm Date of the same time", () => {
+    const result = applyDistinct(
+      [
+        { id: 1, v: new Date("2024-01-01T00:00:00.000Z") },
+        { id: 2, v: createCrossRealmDate("2024-01-01T00:00:00.000Z") },
+      ],
+      ["v"],
+    );
+    expect(result.map((row) => row.id)).toEqual([1]);
+  });
+
+  test("should collapse two cross-realm Dates with the same time", () => {
+    const result = applyDistinct(
+      [
+        { id: 1, v: createCrossRealmDate("2024-01-01T00:00:00.000Z") },
+        { id: 2, v: createCrossRealmDate("2024-01-01T00:00:00.000Z") },
+      ],
+      ["v"],
+    );
+    expect(result.map((row) => row.id)).toEqual([1]);
+  });
+
+  test("should keep cross-realm Dates with different times as separate rows", () => {
+    const rows = [
+      { id: 1, v: createCrossRealmDate("2024-01-01T00:00:00.000Z") },
+      { id: 2, v: createCrossRealmDate("2024-01-02T00:00:00.000Z") },
+    ];
+    expect(applyDistinct(rows, ["v"]).map((row) => row.id)).toEqual([1, 2]);
+  });
+
+  test("should not collapse a cross-realm Date with its ISO string", () => {
+    const rows = [
+      { id: 1, v: createCrossRealmDate("2024-01-01T00:00:00.000Z") },
+      { id: 2, v: "2024-01-01T00:00:00.000Z" },
+    ];
+    expect(applyDistinct(rows, ["v"])).toEqual(rows);
+  });
+
+  test("should collapse a cross-realm Invalid Date with a same-realm Invalid Date", () => {
+    const result = applyDistinct(
+      [
+        { id: 1, v: new Date("invalid") },
+        { id: 2, v: createCrossRealmValue<Date>('new Date("nope")') },
+      ],
+      ["v"],
+    );
+    expect(result.map((row) => row.id)).toEqual([1]);
   });
 });

--- a/src/__test__/util/groupby/groupbyUtil/by.test.ts
+++ b/src/__test__/util/groupby/groupbyUtil/by.test.ts
@@ -1,5 +1,8 @@
 import { byClassification } from "../../../../util/groupby/groubyUtil/by";
-import { createCrossRealmDate } from "../../../consts/crossRealm";
+import {
+  createCrossRealmDate,
+  createCrossRealmValue,
+} from "../../../consts/crossRealm";
 
 describe("byClassification with Date values", () => {
   test("同時刻・別インスタンスのDateは同一グループになる", () => {
@@ -67,5 +70,62 @@ describe("byClassification with Date values", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toHaveLength(2);
+  });
+
+  test("クロスrealmのDate同士も同時刻なら同一グループになる", () => {
+    const rows = [
+      { at: createCrossRealmDate("2026-07-18T09:30:00.000Z"), v: 1 },
+      { at: createCrossRealmDate("2026-07-18T09:30:00.000Z"), v: 2 },
+    ];
+
+    const result = byClassification(rows, ["at"]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(2);
+  });
+
+  test("クロスrealmのDateとミリ秒差のDateは別グループになる", () => {
+    const rows = [
+      { at: createCrossRealmDate("2026-07-18T09:30:00.000Z"), v: 1 },
+      { at: new Date("2026-07-18T09:30:00.001Z"), v: 2 },
+    ];
+
+    const result = byClassification(rows, ["at"]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("クロスrealmのDateとISO文字列は別グループになる", () => {
+    const rows = [
+      { at: createCrossRealmDate("2026-07-18T09:30:00.000Z"), v: 1 },
+      { at: "2026-07-18T09:30:00.000Z", v: 2 },
+    ];
+
+    const result = byClassification(rows, ["at"]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("クロスrealmのInvalid Dateは同一realmのInvalid Dateと同一グループになる", () => {
+    const rows = [
+      { at: new Date("invalid"), v: 1 },
+      { at: createCrossRealmValue<Date>('new Date("nope")'), v: 2 },
+    ];
+
+    const result = byClassification(rows, ["at"]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(2);
+  });
+
+  test("クロスrealmのInvalid Dateは有効なDateとは別グループになる", () => {
+    const rows = [
+      { at: createCrossRealmValue<Date>('new Date("nope")'), v: 1 },
+      { at: new Date("2026-07-18T09:30:00.000Z"), v: 2 },
+    ];
+
+    const result = byClassification(rows, ["at"]);
+
+    expect(result).toHaveLength(2);
   });
 });

--- a/src/__test__/util/other/isMissingValue.test.ts
+++ b/src/__test__/util/other/isMissingValue.test.ts
@@ -1,0 +1,49 @@
+import { isMissingValue } from "../../../util/other/isMissingValue";
+import {
+  createCrossRealmDate,
+  createCrossRealmValue,
+} from "../../consts/crossRealm";
+
+describe("isMissingValue", () => {
+  test("should return true for null and undefined", () => {
+    expect(isMissingValue(null)).toBe(true);
+    expect(isMissingValue(undefined)).toBe(true);
+  });
+
+  test("should return true for NaN and an Invalid Date", () => {
+    expect(isMissingValue(Number.NaN)).toBe(true);
+    expect(isMissingValue(new Date("nope"))).toBe(true);
+  });
+
+  test("should return false for a valid Date", () => {
+    expect(isMissingValue(new Date("2026-07-18T09:30:00.000Z"))).toBe(false);
+  });
+
+  test("should return false for falsy scalars", () => {
+    expect(isMissingValue(0)).toBe(false);
+    expect(isMissingValue("")).toBe(false);
+    expect(isMissingValue(false)).toBe(false);
+  });
+});
+
+describe("isMissingValue with cross-realm values", () => {
+  test("should return false for a cross-realm valid Date", () => {
+    const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
+    expect(crossDate instanceof Date).toBe(false);
+    expect(isMissingValue(crossDate)).toBe(false);
+  });
+
+  test("should return true for a cross-realm Invalid Date", () => {
+    const crossInvalid = createCrossRealmValue<Date>('new Date("nope")');
+    expect(isMissingValue(crossInvalid)).toBe(true);
+  });
+
+  test("should return false for a cross-realm array and plain object", () => {
+    expect(isMissingValue(createCrossRealmValue<unknown[]>("[1]"))).toBe(false);
+    expect(
+      isMissingValue(
+        createCrossRealmValue<Record<string, unknown>>('{ key: "value" }'),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/__test__/util/other/isValueEqual.test.ts
+++ b/src/__test__/util/other/isValueEqual.test.ts
@@ -283,3 +283,52 @@ describe("containsValue with cross-realm Dates", () => {
     ).toBe(false);
   });
 });
+
+describe("isValueEqual with cross-realm Invalid Dates", () => {
+  test("should return false for a cross-realm Invalid Date vs a same-realm Invalid Date", () => {
+    const crossInvalid = createCrossRealmValue<Date>('new Date("nope")');
+    expect(isValueEqual(crossInvalid, new Date("invalid"))).toBe(false);
+    expect(isValueEqual(new Date("invalid"), crossInvalid)).toBe(false);
+  });
+
+  test("should return false for a cross-realm Invalid Date vs a valid Date", () => {
+    const crossInvalid = createCrossRealmValue<Date>('new Date("nope")');
+    expect(
+      isValueEqual(crossInvalid, new Date("2026-07-18T09:30:00.000Z")),
+    ).toBe(false);
+  });
+});
+
+describe("containsValue with cross-realm Invalid Dates and arrays", () => {
+  test("should find a cross-realm Invalid Date only by its own reference", () => {
+    const crossInvalid = createCrossRealmValue<Date>('new Date("nope")');
+    expect(containsValue([crossInvalid], crossInvalid)).toBe(true);
+    expect(containsValue([new Date("invalid")], crossInvalid)).toBe(false);
+    expect(
+      containsValue(
+        [crossInvalid],
+        createCrossRealmValue<Date>('new Date("nope")'),
+      ),
+    ).toBe(false);
+  });
+
+  test("should not match a cross-realm Invalid Date against a valid Date", () => {
+    const crossInvalid = createCrossRealmValue<Date>('new Date("nope")');
+    expect(
+      containsValue([new Date("2026-07-18T09:30:00.000Z")], crossInvalid),
+    ).toBe(false);
+  });
+
+  test("should handle an Invalid Date inside a cross-realm list by reference", () => {
+    const crossList =
+      createCrossRealmValue<readonly unknown[]>('[new Date("nope")]');
+    expect(containsValue(crossList, crossList[0])).toBe(true);
+    expect(containsValue(crossList, new Date("invalid"))).toBe(false);
+  });
+
+  test("should keep reference identity for a cross-realm array used as a value", () => {
+    const crossArray = createCrossRealmValue<unknown[]>("[1, 2]");
+    expect(containsValue([crossArray], crossArray)).toBe(true);
+    expect(containsValue([crossArray], [1, 2])).toBe(false);
+  });
+});

--- a/src/__test__/util/relation/onUpdate/cascadeUpdatePlan.test.ts
+++ b/src/__test__/util/relation/onUpdate/cascadeUpdatePlan.test.ts
@@ -1,5 +1,9 @@
 import type { ChangedPair } from "../../../../util/relation/onUpdate/cascadeUpdatePlan";
 import { buildCascadeSteps } from "../../../../util/relation/onUpdate/cascadeUpdatePlan";
+import {
+  createCrossRealmDate,
+  createCrossRealmValue,
+} from "../../../consts/crossRealm";
 
 const makeTempFactory = () => {
   let counter = 0;
@@ -231,6 +235,100 @@ describe("buildCascadeSteps", () => {
       { oldValues: ["tmp1"], newValue: 11 },
     ]);
     expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it("クロスrealmのDateの新値も同時刻の同一realmのDateと同じグループにまとまる", () => {
+    const target = new Date("2026-03-01T00:00:00.000Z");
+    const crossTarget = createCrossRealmDate("2026-03-01T00:00:00.000Z");
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: target },
+        { oldValue: 2, newValue: crossTarget },
+      ],
+      makeTempFactory(),
+    );
+
+    expect(steps).toEqual([{ oldValues: [1, 2], newValue: target }]);
+  });
+
+  it("クロスrealmのDateの旧値は同時刻の同一realmの新値の玉突きとして検出される", () => {
+    const crossOld = createCrossRealmDate("2026-01-01T00:00:00.000Z");
+    const sameTimeNew = new Date("2026-01-01T00:00:00.000Z");
+    const factory = makeTempFactory();
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: sameTimeNew },
+        { oldValue: crossOld, newValue: 2 },
+      ],
+      factory,
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [crossOld], newValue: 2 },
+      { oldValues: [1], newValue: sameTimeNew },
+    ]);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("クロスrealmのDateを含む入れ替えも循環として検出され一時値で解決する", () => {
+    const crossA = createCrossRealmDate("2026-01-01T00:00:00.000Z");
+    const sameTimeA = new Date("2026-01-01T00:00:00.000Z");
+    const b = new Date("2026-02-01T00:00:00.000Z");
+    const factory = makeTempFactory();
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: crossA, newValue: b },
+        { oldValue: b, newValue: sameTimeA },
+      ],
+      factory,
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [crossA], newValue: "tmp0" },
+      { oldValues: [b], newValue: sameTimeA },
+      { oldValues: ["tmp0"], newValue: b },
+    ]);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("クロスrealmのInvalid Dateの旧値は同一realmのInvalid Dateと併合されず別グループとして残る", () => {
+    const invalidSame = new Date("invalid");
+    const invalidCross = createCrossRealmValue<Date>('new Date("nope")');
+    const factory = makeTempFactory();
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: invalidSame, newValue: 1 },
+        { oldValue: invalidCross, newValue: 2 },
+      ],
+      factory,
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [invalidSame], newValue: 1 },
+      { oldValues: [invalidCross], newValue: 2 },
+    ]);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("クロスrealmのInvalid Dateの新値は併合されない", () => {
+    const invalidCross = createCrossRealmValue<Date>('new Date("nope")');
+
+    const steps = buildCascadeSteps(
+      [
+        { oldValue: 1, newValue: invalidCross },
+        { oldValue: 2, newValue: invalidCross },
+      ],
+      makeTempFactory(),
+    );
+
+    expect(steps).toEqual([
+      { oldValues: [1], newValue: invalidCross },
+      { oldValues: [2], newValue: invalidCross },
+    ]);
   });
 
   it("どのステップも oldValues が空にならない", () => {

--- a/src/__test__/util/validate/validateQueryValues.test.ts
+++ b/src/__test__/util/validate/validateQueryValues.test.ts
@@ -1,0 +1,154 @@
+import { GassmaInvalidValueError } from "../../../errors/argument/argumentError";
+import { raw } from "../../../util/raw/raw";
+import { validateQueryValues } from "../../../util/validate/validateQueryValues";
+import {
+  createCrossRealmDate,
+  createCrossRealmValue,
+} from "../../consts/crossRealm";
+
+describe("validateQueryValues", () => {
+  test("should accept scalars, a valid Date and operator dicts", () => {
+    expect(() =>
+      validateQueryValues({
+        name: "Tanaka",
+        age: { gt: 20 },
+        createdAt: new Date("2026-07-18T09:30:00.000Z"),
+        id: { in: [1, 2, 3] },
+      }),
+    ).not.toThrow();
+  });
+
+  test("should throw for NaN as a direct value", () => {
+    expect(() => validateQueryValues({ age: Number.NaN })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+
+  test("should throw for an Invalid Date inside an operator dict", () => {
+    expect(() =>
+      validateQueryValues({ createdAt: { gt: new Date("nope") } }),
+    ).toThrow(
+      "Invalid value for argument `gt`. Expected a valid Date, but the provided Date object is invalid.",
+    );
+  });
+
+  test("should throw for an invalid item inside an in list", () => {
+    expect(() => validateQueryValues({ age: { in: [1, Number.NaN] } })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+
+  test("should throw for an invalid value nested under AND / OR / NOT", () => {
+    expect(() =>
+      validateQueryValues({
+        AND: [{ OR: [{ NOT: { age: Infinity } }] }],
+      }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("should throw for a Gassma.raw value inside where", () => {
+    expect(() => validateQueryValues({ name: raw("=A1") })).toThrow(
+      "Invalid value for argument `name`. Expected a scalar value, but received a Gassma.raw value.",
+    );
+  });
+});
+
+describe("validateQueryValues with cross-realm values", () => {
+  test("should accept a cross-realm valid Date as a direct value", () => {
+    const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
+    expect(() => validateQueryValues({ createdAt: crossDate })).not.toThrow();
+  });
+
+  test("should accept a cross-realm valid Date inside an operator dict", () => {
+    const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
+    expect(() =>
+      validateQueryValues({ createdAt: { gte: crossDate } }),
+    ).not.toThrow();
+  });
+
+  test("should throw for a cross-realm Invalid Date as a direct value", () => {
+    const crossInvalid = createCrossRealmValue<Date>('new Date("nope")');
+    expect(() => validateQueryValues({ createdAt: crossInvalid })).toThrow(
+      "Invalid value for argument `createdAt`. Expected a valid Date, but the provided Date object is invalid.",
+    );
+  });
+
+  test("should recognize a cross-realm plain object as an operator dict", () => {
+    const invalidOperators = createCrossRealmValue<Record<string, unknown>>(
+      '{ gt: new Date("nope") }',
+    );
+    expect(() => validateQueryValues({ createdAt: invalidOperators })).toThrow(
+      "Invalid value for argument `gt`. Expected a valid Date, but the provided Date object is invalid.",
+    );
+
+    const validOperators = createCrossRealmValue<Record<string, unknown>>(
+      '{ gt: new Date("2026-07-18T09:30:00.000Z") }',
+    );
+    expect(() =>
+      validateQueryValues({ createdAt: validOperators }),
+    ).not.toThrow();
+  });
+
+  test("should throw for a cross-realm Invalid Date deep under AND / OR / NOT", () => {
+    const crossInvalid = createCrossRealmValue<Date>('new Date("nope")');
+    expect(() =>
+      validateQueryValues({
+        AND: [{ OR: [{ NOT: { createdAt: { lt: crossInvalid } } }] }],
+      }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("should walk a cross-realm object used as a logical branch", () => {
+    const crossBranch = createCrossRealmValue<Record<string, unknown>>(
+      "{ age: Number.NaN }",
+    );
+    expect(() => validateQueryValues({ NOT: crossBranch })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+
+  test("should throw for a cross-realm Invalid Date inside an in list", () => {
+    const crossInvalid = createCrossRealmValue<Date>('new Date("nope")');
+    expect(() =>
+      validateQueryValues({ createdAt: { in: [crossInvalid] } }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("should validate items of a cross-realm array used as an in list", () => {
+    const crossInvalidList =
+      createCrossRealmValue<unknown[]>('[new Date("nope")]');
+    expect(() =>
+      validateQueryValues({ createdAt: { in: crossInvalidList } }),
+    ).toThrow(GassmaInvalidValueError);
+
+    const crossValidList = createCrossRealmValue<unknown[]>(
+      '[new Date("2026-07-18T09:30:00.000Z"), 1, "a"]',
+    );
+    expect(() =>
+      validateQueryValues({ createdAt: { in: crossValidList } }),
+    ).not.toThrow();
+  });
+
+  test("should throw for a cross-realm array as a direct value", () => {
+    const crossArray = createCrossRealmValue<unknown[]>("[1, 2]");
+    expect(() => validateQueryValues({ age: crossArray })).toThrow(
+      "Invalid value for argument `age`. Expected a scalar value, but received an array.",
+    );
+  });
+
+  test("should throw for a cross-realm function, symbol and bigint", () => {
+    expect(() =>
+      validateQueryValues({
+        age: createCrossRealmValue<() => void>("function f() {}"),
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(() =>
+      validateQueryValues({
+        age: createCrossRealmValue<symbol>('Symbol("x")'),
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(() =>
+      validateQueryValues({ age: createCrossRealmValue<bigint>("10n") }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+});

--- a/src/__test__/util/validate/validateWritableValue.test.ts
+++ b/src/__test__/util/validate/validateWritableValue.test.ts
@@ -1,0 +1,100 @@
+import { GassmaInvalidValueError } from "../../../errors/argument/argumentError";
+import { validateWritableValue } from "../../../util/validate/validateWritableValue";
+import {
+  createCrossRealmDate,
+  createCrossRealmValue,
+} from "../../consts/crossRealm";
+
+describe("validateWritableValue", () => {
+  test("should accept scalar values and a valid Date", () => {
+    const values: unknown[] = [
+      "text",
+      42,
+      0,
+      true,
+      false,
+      null,
+      undefined,
+      new Date("2026-07-18T09:30:00.000Z"),
+    ];
+    values.forEach((value) => {
+      expect(() => validateWritableValue("col", value)).not.toThrow();
+    });
+  });
+
+  test("should throw for NaN and Infinity", () => {
+    expect(() => validateWritableValue("col", Number.NaN)).toThrow(
+      GassmaInvalidValueError,
+    );
+    expect(() => validateWritableValue("col", Infinity)).toThrow(
+      "Invalid value for argument `col`. Expected a finite number, but received Infinity.",
+    );
+  });
+
+  test("should throw for an Invalid Date", () => {
+    expect(() => validateWritableValue("col", new Date("nope"))).toThrow(
+      "Invalid value for argument `col`. Expected a valid Date, but the provided Date object is invalid.",
+    );
+  });
+
+  test("should throw for an array", () => {
+    expect(() => validateWritableValue("col", [1, 2])).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received an array.",
+    );
+  });
+
+  test("should throw for a function, a symbol and a bigint", () => {
+    expect(() => validateWritableValue("col", () => 1)).toThrow(
+      GassmaInvalidValueError,
+    );
+    expect(() => validateWritableValue("col", Symbol("x"))).toThrow(
+      GassmaInvalidValueError,
+    );
+    expect(() => validateWritableValue("col", BigInt(1))).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+});
+
+describe("validateWritableValue with cross-realm values", () => {
+  test("should accept a cross-realm valid Date", () => {
+    const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
+    expect(crossDate instanceof Date).toBe(false);
+    expect(() => validateWritableValue("col", crossDate)).not.toThrow();
+  });
+
+  test("should throw for a cross-realm Invalid Date", () => {
+    const crossInvalid = createCrossRealmValue<Date>('new Date("nope")');
+    expect(() => validateWritableValue("col", crossInvalid)).toThrow(
+      "Invalid value for argument `col`. Expected a valid Date, but the provided Date object is invalid.",
+    );
+  });
+
+  test("should throw for a cross-realm array", () => {
+    const crossArray = createCrossRealmValue<unknown[]>("[1, 2]");
+    expect(() => validateWritableValue("col", crossArray)).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received an array.",
+    );
+  });
+
+  test("should throw for a cross-realm function", () => {
+    const crossFn = createCrossRealmValue<() => number>("function f() {}");
+    expect(() => validateWritableValue("col", crossFn)).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received a function.",
+    );
+  });
+
+  test("should throw for a cross-realm symbol", () => {
+    const crossSymbol = createCrossRealmValue<symbol>('Symbol("x")');
+    expect(() => validateWritableValue("col", crossSymbol)).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received a symbol.",
+    );
+  });
+
+  test("should throw for a cross-realm bigint", () => {
+    const crossBigInt = createCrossRealmValue<bigint>("10n");
+    expect(() => validateWritableValue("col", crossBigInt)).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received a bigint.",
+    );
+  });
+});


### PR DESCRIPTION
**プロダクションコードの変更はゼロです。** #211〜#216 で追加した検証コードに、クロス realm の単体テストを 55 件足します。

## なぜ必要か

gassma は GAS の**ライブラリ**として利用者のスクリプトとは別の realm で動くため、利用者が作った `new Date()` は**ライブラリ内で `instanceof Date` が false** になります（#140 で実害になりました）。

対策は入っています。

```ts
// src/util/other/isDateValue.ts
const isDateValue = (value: unknown): value is Date =>
  value instanceof Date ||
  Object.prototype.toString.call(value) === "[object Date]";   // ← 境界越えはこちら
```

**問題は、モックが単一 realm なので `instanceof` で短絡し、2行目がテスト中に一度も実行されないことです。**

#211（書き込み値の拒否）・#214（クエリ値の拒否）・#213（欠損値の判定）は**新しい Date 判定を追加**しましたが、**本番で実際に通る経路のカバレッジがゼロ**でした。これは #182 で「純粋な JS の引数処理なので実機検証は不要」と判断したものとは別のリスクです。

利用者が自分のスクリプトで `new Date()` を作って渡すのは**最も普通の使い方**なので、ここを未検証のまま公開ライブラリを更新するのは避けたいところです。

## やったこと

`src/__test__/consts/crossRealm.ts`（`vm` で別 realm の値を作る既存のフィクスチャ）を使って、以下を検証しています。

| 対象 | 判定内容 |
|---|---|
| `validateWritableValue`（#211） | Invalid Date / 配列 / function / symbol / bigint |
| `validateQueryValues`（#214） | `isDict` 経由の dict 判定 |
| `isMissingValue`（#213） | Invalid Date |
| `applyDistinct` / `by`（#212/#213） | `toLookupKey` の正規化キー |
| `isValueEqual` の `toMembershipKey` | Invalid Date の参照キー化 |
| `cascadeUpdatePlan` の `toPlanKey` | Cascade 計画キー |

**最重要は「別 realm の有効な Date が拒否されないこと」**です。他に Invalid Date が正しく拒否されること、**別 realm の同時刻 Date 2つが `distinct` / `groupBy` / `containsValue` で同一として扱われる**ことも押さえています。

`validateFiniteNumberOption`（#216）は `typeof value !== "number"` と `Number.isFinite` だけで、**数値はプリミティブで realm を持たない**ため対象外としました。

## 誤動作はありませんでした — 空振りでないことも確認済み

見立てどおり `isDateValue` の realm 安全なフォールバックが全経路で効いていました。

**ただし「全部 green」だけでは、テストが実際にフォールバックを通っているか分かりません。** そこで `isDateValue` からフォールバック行を一時的に削除する変異テストを実行しました。

```
（フォールバック削除後）
Test Suites: 18 failed, 197 passed, 215 total
Tests:       38 failed, 2874 passed, 2912 total
```

**38件が落ちる**ので、追加分は確かに `Object.prototype.toString` の経路を通しています。退行が入れば検知されます（削除後は `git checkout` で復元し、プロダクション差分がゼロであることを確認済み）。

## テストの置き場所

`validateWritableValue` / `validateQueryValues` / `isMissingValue` は**単体テストが1件も存在しなかった**ため新規作成し、同一 realm のベースライン + cross-realm の2 describe 構成にしました。残り4件は既存ファイル（`toLookupKey.test.ts` の流儀）に describe を追記しています。既存テストは1件も改変していません。

## 検証結果

- `npm test`: **2,912件 全 green**（2,857 → +55、スイート 212 → 215）
- 往復契約テスト3スイート31件 green
- `tsc --noEmit` / lint（警告48件・ベースラインと同数） / format pass
- **プロダクションコードの差分ゼロ**（`git diff -- src ':!src/__test__'` が空）

## 監査で見つかった別件（**本 PR では未修正**）

`src/` 全体で `instanceof` は**プロダクションコードに2箇所しか残っていません**でした。realm 安全化はほぼ完了しています。ただし副次的に3件見つかりました。

**1. `isDict` は自前の `constructor` プロパティを持つ値を dict と認識しません**（私も実測で確認）。

```js
isDict({})                     // true
isDict({ constructor: "x" })   // false  ← constructor という列があると壊れる
```

cross-realm では `val.constructor === Object` が常に false なので、実質 `constructor?.name === "Object"` だけが機能しています。**`constructor` という名前の列**があると `normalizeQueryInput` / `validateQueryValues` / `vacuousBranch` / `orderBy` が dict をスカラー扱いします。極めて例外的ですが、#192 以降に塞いできた穴と同種です。

**2. `src/util/filterConditions/fieldRef.ts:12` の `value instanceof FieldRef` が唯一の無防備な `instanceof`。** `FieldRef` は必ずライブラリ内で生成されるため現状は安全ですが、バンドルが二重に取り込まれると壊れます（`raw.ts` の `rawBrand`、`skip.ts` も `Symbol.for` でないため同種の潜在リスク）。

**3. `orderBy.ts:22` の `"sort" in value` は配列で誤判定します**（`Array.prototype.sort` を継承するため）。`separateRelationOrderBy.ts:10` と `resolveCount.ts:144` も同型。realm 非依存の別バグです。

いずれも本 PR の範囲外なので**報告のみ**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)