### PR TITLE
fix: 構造を受け取る引数の null を拒否する

### DIFF
--- a/src/__test__/util/nullArgumentValues.test.ts
+++ b/src/__test__/util/nullArgumentValues.test.ts
@@ -1,0 +1,522 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import { WhereRelationInvalidFilterError } from "../../errors/relation/whereRelationError";
+import { buildTestClient, sheetOf } from "./extends/extendsTestClient";
+import { clearGasGlobals } from "./transaction/transactionTestClient";
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+const users = (): any => sheetOf(buildTestClient({ relations: true }), "Users");
+const posts = (): any => sheetOf(buildTestClient({ relations: true }), "Posts");
+
+const expectNullError = (fn: () => unknown, argumentName: string): void => {
+  expect(fn).toThrow(GassmaInvalidValueError);
+  expect(fn).toThrow(
+    new RegExp(
+      `Invalid value for argument \`${argumentName}\`\\..*but received null\\.`,
+    ),
+  );
+};
+
+describe("トップレベル引数の null はエラー", () => {
+  test("findMany の where: null", () => {
+    expectNullError(() => users().findMany({ where: null }), "where");
+  });
+
+  test("findMany の orderBy: null", () => {
+    expectNullError(() => users().findMany({ orderBy: null }), "orderBy");
+  });
+
+  test("findMany の distinct: null", () => {
+    expectNullError(() => users().findMany({ distinct: null }), "distinct");
+  });
+
+  test("findMany の cursor: null", () => {
+    expectNullError(() => users().findMany({ cursor: null }), "cursor");
+  });
+
+  test("findFirst の where: null", () => {
+    expectNullError(() => users().findFirst({ where: null }), "where");
+  });
+
+  test("findFirstOrThrow の where: null", () => {
+    expectNullError(() => users().findFirstOrThrow({ where: null }), "where");
+  });
+
+  test("count の where: null", () => {
+    expectNullError(() => users().count({ where: null }), "where");
+  });
+
+  test("aggregate の where: null", () => {
+    expectNullError(
+      () => users().aggregate({ where: null, _count: { id: true } }),
+      "where",
+    );
+  });
+
+  test("deleteMany の where: null は全件削除せずエラー", () => {
+    const loose = users();
+    expectNullError(() => loose.deleteMany({ where: null }), "where");
+    expect(loose.findMany()).toHaveLength(3);
+  });
+
+  test("delete の where: null", () => {
+    expectNullError(() => users().delete({ where: null }), "where");
+  });
+
+  test("update の where: null", () => {
+    expectNullError(
+      () => users().update({ where: null, data: { name: "X" } }),
+      "where",
+    );
+  });
+
+  test("updateMany の where: null は全件更新せずエラー", () => {
+    const loose = users();
+    expectNullError(
+      () => loose.updateMany({ where: null, data: { name: "X" } }),
+      "where",
+    );
+    expect(loose.findMany({ where: { name: "Alice" } })).toHaveLength(1);
+  });
+
+  test("groupBy の by: null", () => {
+    expectNullError(() => users().groupBy({ by: null }), "by");
+  });
+
+  test("groupBy の having: null", () => {
+    expectNullError(
+      () => users().groupBy({ by: ["name"], having: null }),
+      "having",
+    );
+  });
+
+  test("groupBy の where: null", () => {
+    expectNullError(
+      () => users().groupBy({ by: ["name"], where: null }),
+      "where",
+    );
+  });
+
+  test("create の data: null", () => {
+    expectNullError(() => users().create({ data: null }), "data");
+  });
+
+  test("createMany の data: null", () => {
+    expectNullError(() => users().createMany({ data: null }), "data");
+  });
+
+  test("createManyAndReturn の data: null", () => {
+    expectNullError(() => users().createManyAndReturn({ data: null }), "data");
+  });
+
+  test("update の data: null", () => {
+    expectNullError(
+      () => users().update({ where: { id: 1 }, data: null }),
+      "data",
+    );
+  });
+
+  test("updateMany の data: null", () => {
+    expectNullError(
+      () => users().updateMany({ where: { id: 1 }, data: null }),
+      "data",
+    );
+  });
+
+  test("updateManyAndReturn の data: null", () => {
+    expectNullError(
+      () => users().updateManyAndReturn({ where: { id: 1 }, data: null }),
+      "data",
+    );
+  });
+
+  test("upsert の create: null", () => {
+    expectNullError(
+      () => users().upsert({ where: { id: 9 }, create: null, update: {} }),
+      "create",
+    );
+  });
+
+  test("upsert の update: null", () => {
+    expectNullError(
+      () => users().upsert({ where: { id: 1 }, create: {}, update: null }),
+      "update",
+    );
+  });
+});
+
+describe("配列要素の null はエラー", () => {
+  test("distinct: [null]", () => {
+    expectNullError(() => users().findMany({ distinct: [null] }), "distinct");
+  });
+
+  test("by: [null]", () => {
+    expectNullError(() => users().groupBy({ by: [null] }), "by");
+  });
+
+  test("where の AND: [null]", () => {
+    expectNullError(() => users().findMany({ where: { AND: [null] } }), "AND");
+  });
+
+  test("where の OR: [null]", () => {
+    expectNullError(() => users().findMany({ where: { OR: [null] } }), "OR");
+  });
+
+  test("createMany の data: [null]", () => {
+    expectNullError(() => users().createMany({ data: [null] }), "data");
+  });
+
+  test("orderBy: [null] は従来どおり GassmaInvalidValueError", () => {
+    expect(() => users().findMany({ orderBy: [null] })).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+});
+
+describe("where の中の構造位置の null はエラー", () => {
+  test("AND: null", () => {
+    expectNullError(() => users().findMany({ where: { AND: null } }), "AND");
+  });
+
+  test("OR: null", () => {
+    expectNullError(() => users().findMany({ where: { OR: null } }), "OR");
+  });
+
+  test("NOT: null", () => {
+    expectNullError(() => users().findMany({ where: { NOT: null } }), "NOT");
+  });
+
+  test("入れ子の AND の中の OR: null", () => {
+    expectNullError(
+      () => users().findMany({ where: { AND: [{ OR: null }] } }),
+      "OR",
+    );
+  });
+
+  test("to-many リレーションの some: null", () => {
+    expectNullError(
+      () => users().findMany({ where: { posts: { some: null } } }),
+      "some",
+    );
+  });
+
+  test("to-many リレーションの every: null", () => {
+    expectNullError(
+      () => users().findMany({ where: { posts: { every: null } } }),
+      "every",
+    );
+  });
+
+  test("to-many リレーションの none: null", () => {
+    expectNullError(
+      () => users().findMany({ where: { posts: { none: null } } }),
+      "none",
+    );
+  });
+
+  test("some の中の AND: null", () => {
+    expectNullError(
+      () => users().findMany({ where: { posts: { some: { AND: null } } } }),
+      "AND",
+    );
+  });
+
+  test("contains: null", () => {
+    expectNullError(
+      () => users().findMany({ where: { name: { contains: null } } }),
+      "contains",
+    );
+  });
+
+  test("startsWith: null", () => {
+    expectNullError(
+      () => users().findMany({ where: { name: { startsWith: null } } }),
+      "startsWith",
+    );
+  });
+
+  test("endsWith: null", () => {
+    expectNullError(
+      () => users().findMany({ where: { name: { endsWith: null } } }),
+      "endsWith",
+    );
+  });
+
+  test("gt: null", () => {
+    expectNullError(
+      () => users().findMany({ where: { age: { gt: null } } }),
+      "gt",
+    );
+  });
+
+  test("gte / lt / lte: null", () => {
+    expectNullError(
+      () => users().findMany({ where: { age: { gte: null } } }),
+      "gte",
+    );
+    expectNullError(
+      () => users().findMany({ where: { age: { lt: null } } }),
+      "lt",
+    );
+    expectNullError(
+      () => users().findMany({ where: { age: { lte: null } } }),
+      "lte",
+    );
+  });
+
+  test("deleteMany の where の中の contains: null でも全件削除しない", () => {
+    const loose = users();
+    expectNullError(
+      () => loose.deleteMany({ where: { name: { contains: null } } }),
+      "contains",
+    );
+    expect(loose.findMany()).toHaveLength(3);
+  });
+
+  test("having の中の集計演算子の null", () => {
+    expectNullError(
+      () =>
+        users().groupBy({
+          by: ["name"],
+          having: { age: { _count: { gt: null } } },
+        }),
+      "gt",
+    );
+  });
+
+  test("to-many リレーションへの null は従来どおりリレーションのエラー", () => {
+    expect(() => users().findMany({ where: { posts: null } })).toThrow(
+      WhereRelationInvalidFilterError,
+    );
+  });
+});
+
+describe("cursor の中の null はエラー", () => {
+  test("cursor: { id: null }", () => {
+    expectNullError(() => users().findMany({ cursor: { id: null } }), "id");
+  });
+});
+
+describe("nested write の動詞の null はエラー", () => {
+  test("create の中の create: null", () => {
+    expectNullError(
+      () =>
+        users().create({
+          data: { id: 9, name: "X", age: 1, posts: { create: null } },
+        }),
+      "create",
+    );
+  });
+
+  test("create の中の connect: null", () => {
+    expectNullError(
+      () =>
+        users().create({
+          data: { id: 9, name: "X", age: 1, posts: { connect: null } },
+        }),
+      "connect",
+    );
+  });
+
+  test("create の中の connectOrCreate: null", () => {
+    expectNullError(
+      () =>
+        users().create({
+          data: { id: 9, name: "X", age: 1, posts: { connectOrCreate: null } },
+        }),
+      "connectOrCreate",
+    );
+  });
+
+  test("connectOrCreate の中の create: null", () => {
+    expectNullError(
+      () =>
+        users().create({
+          data: {
+            id: 9,
+            name: "X",
+            age: 1,
+            posts: { connectOrCreate: { where: { id: 101 }, create: null } },
+          },
+        }),
+      "create",
+    );
+  });
+
+  test("update の中の set: null", () => {
+    expectNullError(
+      () =>
+        users().update({ where: { id: 1 }, data: { posts: { set: null } } }),
+      "set",
+    );
+  });
+
+  test("update の中の disconnect: null", () => {
+    expectNullError(
+      () =>
+        users().update({
+          where: { id: 1 },
+          data: { posts: { disconnect: null } },
+        }),
+      "disconnect",
+    );
+  });
+
+  test("update の中の delete: null", () => {
+    expectNullError(
+      () =>
+        users().update({ where: { id: 1 }, data: { posts: { delete: null } } }),
+      "delete",
+    );
+  });
+
+  test("update の中の deleteMany: null", () => {
+    expectNullError(
+      () =>
+        users().update({
+          where: { id: 1 },
+          data: { posts: { deleteMany: null } },
+        }),
+      "deleteMany",
+    );
+  });
+
+  test("update の中の updateMany: null", () => {
+    expectNullError(
+      () =>
+        users().update({
+          where: { id: 1 },
+          data: { posts: { updateMany: null } },
+        }),
+      "updateMany",
+    );
+  });
+
+  test("update の中の update: null", () => {
+    expectNullError(
+      () =>
+        users().update({ where: { id: 1 }, data: { posts: { update: null } } }),
+      "update",
+    );
+  });
+
+  test("動詞の配列要素の null", () => {
+    expectNullError(
+      () =>
+        users().update({
+          where: { id: 1 },
+          data: { posts: { connect: [null] } },
+        }),
+      "connect",
+    );
+  });
+});
+
+describe("数値操作の null はエラー", () => {
+  test("increment: null", () => {
+    expectNullError(
+      () =>
+        users().update({
+          where: { id: 1 },
+          data: { age: { increment: null } },
+        }),
+      "increment",
+    );
+  });
+
+  test("decrement / multiply / divide: null", () => {
+    expectNullError(
+      () =>
+        users().update({
+          where: { id: 1 },
+          data: { age: { decrement: null } },
+        }),
+      "decrement",
+    );
+    expectNullError(
+      () =>
+        users().update({ where: { id: 1 }, data: { age: { multiply: null } } }),
+      "multiply",
+    );
+    expectNullError(
+      () =>
+        users().update({ where: { id: 1 }, data: { age: { divide: null } } }),
+      "divide",
+    );
+  });
+});
+
+describe("値の位置の null は従来どおり有効", () => {
+  test("where: { col: null }", () => {
+    expect(users().findMany({ where: { name: null } })).toEqual([]);
+  });
+
+  test("where: { col: { equals: null } }", () => {
+    expect(users().findMany({ where: { name: { equals: null } } })).toEqual([]);
+  });
+
+  test("where: { col: { not: null } }", () => {
+    expect(users().findMany({ where: { name: { not: null } } })).toHaveLength(
+      3,
+    );
+  });
+
+  test("to-one リレーションの null / is / isNot", () => {
+    expect(posts().findMany({ where: { author: null } })).toEqual([]);
+    expect(posts().findMany({ where: { author: { is: null } } })).toEqual([]);
+    expect(
+      posts().findMany({ where: { author: { isNot: null } } }),
+    ).toHaveLength(2);
+  });
+
+  test("to-one リレーションの中の列の null", () => {
+    expect(posts().findMany({ where: { author: { name: null } } })).toEqual([]);
+  });
+
+  test("data: { col: null }", () => {
+    const loose = users();
+    expect(loose.update({ where: { id: 1 }, data: { age: null } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: null,
+    });
+  });
+
+  test("create の data の列の null", () => {
+    const loose = users();
+    expect(loose.create({ data: { id: 9, name: "Zed", age: null } })).toEqual({
+      id: 9,
+      name: "Zed",
+      age: null,
+    });
+  });
+
+  test("having: { col: null }", () => {
+    expect(users().groupBy({ by: ["age"], having: { age: null } })).toEqual([]);
+  });
+
+  test("in / notIn の null は今回の対象外で従来どおり", () => {
+    expect(users().findMany({ where: { age: { in: [null] } } })).toEqual([]);
+  });
+
+  test("select / include / omit の null は従来どおり無視", () => {
+    expect(users().findMany({ select: null })).toHaveLength(3);
+    expect(posts().findMany({ include: null })).toHaveLength(2);
+    expect(users().findMany({ omit: null })).toHaveLength(3);
+  });
+
+  test("nested write の中の子の列の null", () => {
+    const loose = users();
+    const created = loose.create({
+      data: {
+        id: 9,
+        name: "Zed",
+        age: 1,
+        posts: { create: { id: 900, title: null } },
+      },
+    });
+    expect(created.id).toBe(9);
+  });
+});

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -80,6 +80,7 @@ import { resolveInclude } from "./util/relation/resolveInclude";
 import { resolveWhereRelation } from "./util/relation/whereRelation/resolveWhereRelation";
 import { normalizeQueryInput } from "./util/skip/normalizeQueryInput";
 import { validateEmptySelect } from "./util/validate/validateEmptySelect";
+import { validateNullArguments } from "./util/validate/validateNullArguments";
 import { validateNullPagination } from "./util/validate/validateNullPagination";
 import { validateOrderByKeys } from "./util/validate/validateOrderByKeys";
 import {
@@ -204,6 +205,7 @@ class GassmaController {
     );
     validateTopLevelKeys(operation, normalized);
     validateNullPagination(operation, normalized);
+    validateNullArguments(operation, normalized);
     validateEmptySelect(normalized);
     return normalized;
   }

--- a/src/util/validate/nullArgumentPolicy.ts
+++ b/src/util/validate/nullArgumentPolicy.ts
@@ -1,0 +1,57 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+
+// Prisma 実測: 構造を受け取るキーの null は "Argument must not be null" エラー。
+// 値を受け取る位置(equals / not / is / isNot / 列名そのもの)の null は
+// "NULL と等しい" という正当な意味なのでここには載せない。
+const EXPECTED_BY_KEY: Record<string, string> = {
+  where: "an object",
+  having: "an object",
+  cursor: "an object",
+  orderBy: "an object or an array",
+  distinct: "a field name or an array of field names",
+  by: "a field name or an array of field names",
+  data: "an object or an array",
+  AND: "an object or an array",
+  OR: "an object or an array",
+  NOT: "an object or an array",
+  some: "an object",
+  every: "an object",
+  none: "an object",
+  contains: "a string",
+  startsWith: "a string",
+  endsWith: "a string",
+  gt: "a comparable value",
+  gte: "a comparable value",
+  lt: "a comparable value",
+  lte: "a comparable value",
+  increment: "a number",
+  decrement: "a number",
+  multiply: "a number",
+  divide: "a number",
+  create: "an object or an array",
+  createMany: "an object",
+  connect: "an object or an array",
+  connectOrCreate: "an object or an array",
+  set: "an object or an array",
+  disconnect: "a boolean or an object",
+  delete: "a boolean or an object",
+  update: "an object or an array",
+  deleteMany: "an object or an array",
+  updateMany: "an object or an array",
+};
+
+const STRUCTURAL_KEYS = new Set(Object.keys(EXPECTED_BY_KEY));
+
+// in / notIn の null は nullable 列に対する正当な意味を持つため対象外
+const IGNORED_KEYS = new Set(["in", "notIn"]);
+
+const throwNullArgument = (key: string): never => {
+  const expected = EXPECTED_BY_KEY[key] ?? "a scalar value";
+  throw new GassmaInvalidValueError(key, `${expected}, but received null`);
+};
+
+const isStructuralKey = (key: string): boolean => STRUCTURAL_KEYS.has(key);
+
+const isIgnoredKey = (key: string): boolean => IGNORED_KEYS.has(key);
+
+export { isIgnoredKey, isStructuralKey, throwNullArgument };

--- a/src/util/validate/validateNullArguments.ts
+++ b/src/util/validate/validateNullArguments.ts
@@ -1,0 +1,104 @@
+import { isDict } from "../other/isDict";
+import {
+  isIgnoredKey,
+  isStructuralKey,
+  throwNullArgument,
+} from "./nullArgumentPolicy";
+import type { ValidatedOperation } from "./validateTopLevelKeys";
+
+type ArgumentShape = "value" | "list" | "cursor" | "deep";
+
+const ARGUMENT_SHAPES: Record<string, ArgumentShape> = {
+  orderBy: "value",
+  distinct: "list",
+  by: "list",
+  cursor: "cursor",
+  where: "deep",
+  having: "deep",
+  data: "deep",
+  create: "deep",
+  update: "deep",
+};
+
+const NULL_CHECKED_ARGUMENTS: Partial<Record<ValidatedOperation, string[]>> = {
+  findMany: ["where", "orderBy", "cursor", "distinct"],
+  findFirst: ["where", "orderBy", "cursor", "distinct"],
+  count: ["where", "orderBy", "cursor"],
+  aggregate: ["where", "orderBy", "cursor"],
+  groupBy: ["by", "where", "having", "orderBy"],
+  create: ["data"],
+  createMany: ["data"],
+  createManyAndReturn: ["data"],
+  update: ["where", "data"],
+  updateMany: ["where", "data"],
+  updateManyAndReturn: ["where", "data"],
+  upsert: ["where", "create", "update"],
+  delete: ["where"],
+  deleteMany: ["where"],
+};
+
+const walkNested = (node: Record<string, unknown>): void => {
+  Object.entries(node).forEach(([key, value]) => {
+    if (isIgnoredKey(key)) return;
+    if (value === null) {
+      if (isStructuralKey(key)) throwNullArgument(key);
+      return;
+    }
+    if (Array.isArray(value)) {
+      walkNestedList(key, value);
+      return;
+    }
+    if (isDict(value)) walkNested(value);
+  });
+};
+
+const walkNestedList = (key: string, values: unknown[]): void => {
+  values.forEach((item) => {
+    if (item === null) {
+      if (isStructuralKey(key)) throwNullArgument(key);
+      return;
+    }
+    if (isDict(item)) walkNested(item);
+  });
+};
+
+const rejectNullCursorValues = (cursor: Record<string, unknown>): void => {
+  Object.entries(cursor).forEach(([key, value]) => {
+    if (value === null) throwNullArgument(key);
+  });
+};
+
+const validateArgument = (key: string, value: unknown): void => {
+  const shape = ARGUMENT_SHAPES[key];
+  if (shape === "value") return;
+  if (Array.isArray(value)) {
+    value.forEach((item) => {
+      if (item === null) throwNullArgument(key);
+      if (shape === "deep" && isDict(item)) walkNested(item);
+    });
+    return;
+  }
+  if (!isDict(value)) return;
+  if (shape === "cursor") {
+    rejectNullCursorValues(value);
+    return;
+  }
+  if (shape === "deep") walkNested(value);
+};
+
+const validateNullArguments = (
+  operation: ValidatedOperation,
+  input: unknown,
+): void => {
+  const keys = NULL_CHECKED_ARGUMENTS[operation];
+  if (!keys || !isDict(input)) return;
+
+  keys.forEach((key) => {
+    const value = input[key];
+    if (value === undefined) return;
+    if (value === null) throwNullArgument(key);
+    validateArgument(key, value);
+  });
+};
+
+export { validateNullArguments };


### PR DESCRIPTION
#217（`take`/`skip`/`limit` の null）で「別途見つかった差異」として挙げた件の対応です。**調べたら4つでは済みませんでした。**

Prisma 7.4.1 + SQLite で**発行 SQL 付きに全ケース実測**してから実装しています。

## 問題

```js
deleteMany({ where: null })      // 修正前: { count: 3 } — 全行削除
```

`if (where)` のような truthy ガードが `null` を「渡されなかった」として扱うため、**条件がゼロ個になって恒真に化けます**。

## Prisma の規則 — `null` の可否は「位置」で決まる

実測して分かったのは、`null` を一律で弾いてはいけないということでした。

| 位置 | Prisma | 例 |
|---|---|---|
| **構造の位置** | **エラー**（SQL 発行なし） | トップレベル引数、`AND`/`OR`/`NOT`、to-many フィルタ、nested write の動詞、演算子、配列の要素 |
| **値の位置** | **`IS NULL` として正当** | `where:{col:null}`、`equals`/`not`、`data:{col:null}`、to-one の `is`/`isNot`、`having:{col:null}` |
| **`select`/`include`/`omit` の直下** | **黙って無視**（型に `\| null` があり意図的） | `select: cond ? {...} : null` を許すため |

`select`/`include`/`omit` は gassma も既に無視しているので**変更していません**。

## 修正前・修正後（全経路を実測）

| 入力 | 修正前 | 修正後 |
|---|---|---|
| `findMany({ where: null })` | 全件 | `` Expected an object, but received null `` |
| `findMany({ orderBy: null })` | 全件 | `` Expected an object or an array... `` |
| `findMany({ distinct: null })` / `[null]` | 全件 / **生 TypeError** | `` Expected a field name or an array of field names... `` |
| `findMany({ cursor: null })` | 全件 | `` Expected an object... `` |
| `cursor: { id: null }` | 0件 | `` Expected a scalar value... `` |
| `where: { AND: null }` / `OR` / `NOT` | 全件 | `` Expected an object or an array... `` |
| `where: { AND: [null] }` | **生 TypeError** | 同上 |
| `groupBy({ by: null })` / `by: [null]` | **`[{}]` が返る** | `` Expected a field name or an array... `` |
| `groupBy({ having: null })` | 全件 | `` Expected an object... `` |
| `where: { posts: { some: null } }` | **2件返る** | `` Expected an object... ``（`every`/`none` も） |
| `where: { name: { contains: null } }` | 0件 | `` Expected a string... ``（`startsWith`/`endsWith` も） |
| `where: { age: { gt: null } }` | **全件** | `` Expected a comparable value... ``（`gte`/`lt`/`lte` も） |
| **`deleteMany({ where: null })`** | **全件削除** | エラー・3件残存を確認 |
| `updateMany({ data: null })` / `create` / `update` | **生 TypeError** | `` Expected an object or an array... `` |
| `createMany({ data: [null] })` | **生 TypeError** | 同上 |
| **nested write の動詞に null**（`create`/`connect`/`connectOrCreate`/`set`/`disconnect`/`delete`/`update`/`deleteMany`/`updateMany`） | **黙って無視して成功** | 各動詞名でエラー |
| `data: { age: { increment: null } }` | **黙って無視** | `` Expected a number... ``（`decrement`/`multiply`/`divide` も） |

再帰も確認しています（`where:{AND:[{OR:null}]}`、`where:{posts:{some:{AND:null}}}`、`connectOrCreate:{where:{...},create:null}`、`connect:[null]`、`having:{age:{_count:{gt:null}}}`）。

## 設計 — 許可リストではなく拒否リストにした理由

当初は「`where` の子 dict は演算子ノードだから中を再帰的に検査する」という**構造推論**を考えましたが、これだと壊れるケースが見つかりました。

```js
where: { author: { name: null } }   // to-one 省略記法の中の列 null = 正当な IS NULL
```

構造推論では `author` の中身を「演算子オブジェクト」と誤認して `name: null` を弾いてしまいます。そこで **「既定は許可、既知の構造キーだけ拒否」**という拒否リストに反転しました。

```ts
const EXPECTED_BY_KEY = {
  where: "an object",   having: "an object",   cursor: "an object",
  orderBy: "an object or an array",
  AND: "an object or an array", OR: ..., NOT: ...,
  some: "an object", every: "an object", none: "an object",
  contains: "a string", gt: "a comparable value", increment: "a number",
  create: "an object or an array", connect: ..., set: ..., disconnect: ...,
  // …
};
const IGNORED_KEYS = new Set(["in", "notIn"]);   // 値の位置として正当
```

`equals` / `not` / `is` / `isNot` / 列名は**リストに載せないだけ**で無傷です。副次的に、**`where` 側と `data` 側の再帰が同一の1関数に畳めました**。

## 検証位置

**`normalizeInput`（`gassmaController.ts`）に1行追加**しました。#217 と同じ位置です。

- **内部 null との区別**: `groupby.ts` の `skip || null` や `findFirst` の `applySkipTake(rows, skip, null)` といった内部正規化より**手前**なので、内部が作る null はここを通りません
- **往復回数**: シート読み込みより前なので契約テストに触れません

`validateNullPagination`（#217）とは別ファイルにしました。あちらはメッセージが数値専用（`Expected a number`）で、#217 のテストが文言を固定しているためです。

## 値の位置が無傷であることの確認

私の側でも個別に実測しました。**すべて修正前と同一です。**

```
where:{age:null}            → 0件      where:{author:null}          → 0件
where:{age:{equals:null}}   → 0件      where:{author:{is:null}}     → 0件
where:{age:{not:null}}      → 3件      where:{author:{isNot:null}}  → 2件
where:{author:{name:null}}  → 0件      data:{age:null}              → {count:1}
select:null / include:null  → 3件（無視）
```

`where:{posts:null}` は従来どおり `WhereRelationInvalidFilterError`、`orderBy:[null]` も従来どおり `GassmaInvalidValueError` です。

## 検証結果

- `npm test`: **3,000件 全 green**（2,930 → +70）
- 往復契約テスト3スイート31件 green、**期待値は無変更**
- `tsc --noEmit` / lint（警告48件・ベースラインと同数） / format / `verify:bundle`（公開シンボル57件）pass
- **既存テストの変更・期待値変更はゼロ**。新規エラークラスも不要でした

## 判断が必要で実装しなかった点

**1. キー名で判定する方式の原理的な限界。**

`contains` / `gt` / `set` / `create` / `where` などと**同名の列**に `null` を渡すと、誤って拒否されます。実行時に列名を知らない位置で検査する以上、「引数キーの位置か値の位置か」で分ける方針では避けられません。

**2. `where: { col: { in: [null] } }` は対象外のままです。**

現状 0件を返し、Prisma（エラー）と食い違っています。`in: null` は Prisma では **nullable 列なら `IS NULL`** という正当な意味を持つので、**「拒否」ではなく「意味の実装」**になります。`in`/`notIn` 一族はまとめて別タスクにするのが安全と判断しました。

**3. スカラーの `set` は未実装です。**

`data: { col: { set: 5 } }` は null 以前に `GassmaUnknownArgumentError: Unknown argument \`set\`` になります（既存の差異）。今回 `set` を nested write の動詞として拒否リストに入れたので、**将来スカラーの `set` を実装する際は、列側では `set: null` を許可する分岐が必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)