### PR TITLE
fix: プレーンオブジェクトの判定をプロトタイプで行う

### DIFF
--- a/src/__test__/util/constructorColumn.test.ts
+++ b/src/__test__/util/constructorColumn.test.ts
@@ -1,0 +1,189 @@
+import { GassmaClient } from "../../gassma";
+import { GassmaController } from "../../gassmaController";
+import { skip } from "../../util/skip/skip";
+
+type MockRange = {
+  getValues: () => unknown[][];
+  setValues: (values: unknown[][]) => void;
+};
+
+const makeSheet = (name: string, initial: unknown[][]) => {
+  const data = initial.map((row) => [...row]);
+  return {
+    getName: () => name,
+    getLastRow: () => data.length,
+    getLastColumn: () => data[0].length,
+    getRange: (
+      row: number,
+      col: number,
+      numRows: number,
+      numCols: number,
+    ): MockRange => ({
+      getValues: () =>
+        data
+          .slice(row - 1, row - 1 + numRows)
+          .map((r) => r.slice(col - 1, col - 1 + numCols)),
+      setValues: (values) => {
+        values.forEach((rowValues, i) => {
+          while (data.length < row + i) {
+            data.push(Array(data[0].length).fill(""));
+          }
+          rowValues.forEach((value, j) => {
+            data[row - 1 + i][col - 1 + j] = value;
+          });
+        });
+      },
+    }),
+    getDataRange: () => ({ getValues: () => data }),
+    deleteRow: (rowIndex: number) => {
+      data.splice(rowIndex - 1, 1);
+    },
+    deleteRows: (rowPosition: number, howMany: number) => {
+      data.splice(rowPosition - 1, howMany);
+    },
+  };
+};
+
+const buildThingsClient = (): GassmaClient => {
+  const sheets = [
+    makeSheet("Things", [
+      ["id", "constructor"],
+      [1, "alpha"],
+      [2, "beta"],
+      [3, "gamma"],
+    ]),
+  ];
+  Object.assign(globalThis, {
+    SpreadsheetApp: {
+      getActiveSpreadsheet: () => ({
+        getId: () => "constructor-column-spreadsheet",
+        getSheets: () => sheets,
+        getSheetByName: (name: string) =>
+          sheets.find((sheet) => sheet.getName() === name) ?? null,
+      }),
+    },
+  });
+  return new GassmaClient();
+};
+
+const thingsSheet = (): { loose: any; typed: GassmaController } => {
+  const client = buildThingsClient();
+  const record = Object.assign<Record<string, unknown>, GassmaClient>(
+    {},
+    client,
+  );
+  const controller = record.Things;
+  if (!(controller instanceof GassmaController)) {
+    throw new Error("controller not found: Things");
+  }
+  return { loose: controller, typed: controller };
+};
+
+afterEach(() => {
+  Object.assign(globalThis, { SpreadsheetApp: undefined });
+});
+
+describe("constructor という名前の列を持つシート", () => {
+  test("where のスカラー一致で絞り込める", () => {
+    const { loose } = thingsSheet();
+    expect(loose.findMany({ where: { constructor: "alpha" } })).toEqual([
+      { id: 1, constructor: "alpha" },
+    ]);
+  });
+
+  test("where のフィルタ演算子が効く", () => {
+    const { loose } = thingsSheet();
+    expect(
+      loose.findMany({ where: { constructor: { contains: "et" } } }),
+    ).toEqual([{ id: 2, constructor: "beta" }]);
+  });
+
+  test("where の未知列 typo は今まで通り弾かれる", () => {
+    const { loose } = thingsSheet();
+    expect(() => loose.deleteMany({ where: { constructer: "alpha" } })).toThrow(
+      "Unknown argument `constructer`",
+    );
+    expect(loose.count({})).toBe(3);
+  });
+
+  test("AND ブランチ内の未知列 typo も弾かれ deleteMany が誤爆しない", () => {
+    const { loose } = thingsSheet();
+    expect(() =>
+      loose.deleteMany({
+        where: { AND: [{ constructor: "alpha", nmae: "zzz" }] },
+      }),
+    ).toThrow("Unknown argument `nmae`");
+    expect(loose.count({})).toBe(3);
+  });
+
+  test("where の skip は条件ごと取り除かれる", () => {
+    const { loose } = thingsSheet();
+    expect(loose.findMany({ where: { constructor: skip } })).toEqual([
+      { id: 1, constructor: "alpha" },
+      { id: 2, constructor: "beta" },
+      { id: 3, constructor: "gamma" },
+    ]);
+  });
+
+  test("orderBy で並べ替えられる", () => {
+    const { loose } = thingsSheet();
+    expect(
+      loose
+        .findMany({ orderBy: { constructor: "desc" } })
+        .map((row: any) => row.id),
+    ).toEqual([3, 2, 1]);
+  });
+
+  test("orderBy の未知の指定は今まで通り弾かれる", () => {
+    const { loose } = thingsSheet();
+    expect(() =>
+      loose.findMany({ orderBy: { constructor: { srot: "asc" } } }),
+    ).toThrow("Unknown argument `srot`");
+  });
+
+  test("data で書き込める", () => {
+    const { loose } = thingsSheet();
+    expect(loose.create({ data: { id: 4, constructor: "delta" } })).toEqual({
+      id: 4,
+      constructor: "delta",
+    });
+    expect(loose.findMany({ where: { constructor: "delta" } })).toEqual([
+      { id: 4, constructor: "delta" },
+    ]);
+  });
+
+  test("data の未知列 typo は今まで通り弾かれる", () => {
+    const { loose } = thingsSheet();
+    expect(() =>
+      loose.create({ data: { id: 4, constructer: "delta" } }),
+    ).toThrow("Unknown argument `constructer`");
+    expect(loose.count({})).toBe(3);
+  });
+
+  test("update の data で更新できる", () => {
+    const { loose } = thingsSheet();
+    expect(
+      loose.update({ where: { id: 2 }, data: { constructor: "beta2" } }),
+    ).toEqual({ id: 2, constructor: "beta2" });
+    expect(loose.findFirst({ where: { id: 2 } })).toEqual({
+      id: 2,
+      constructor: "beta2",
+    });
+  });
+
+  test("select で列を選べる", () => {
+    const { loose } = thingsSheet();
+    expect(
+      loose.findMany({ where: { id: 1 }, select: { constructor: true } }),
+    ).toEqual([{ constructor: "alpha" }]);
+  });
+
+  test("AND / NOT の中でも扱える", () => {
+    const { loose } = thingsSheet();
+    expect(
+      loose.findMany({
+        where: { AND: [{ constructor: "alpha" }], NOT: { id: 3 } },
+      }),
+    ).toEqual([{ id: 1, constructor: "alpha" }]);
+  });
+});

--- a/src/__test__/util/other/isDict.test.ts
+++ b/src/__test__/util/other/isDict.test.ts
@@ -3,6 +3,7 @@ import {
   createCrossRealmValue,
 } from "../../consts/crossRealm";
 import { isDict } from "../../../util/other/isDict";
+import { FieldRef } from "../../../util/filterConditions/fieldRef";
 
 describe("isDict", () => {
   test("should return true for an object", () => {
@@ -143,11 +144,12 @@ describe("isDict", () => {
     expect(isDict(obj)).toBe(true);
   });
 
-  test("should handle objects with prototype chain", () => {
+  // Object.keys は継承キーを返さないので dict として扱う意味がない
+  test("should return false for objects whose prototype is another object", () => {
     const parent = { parentKey: "parentValue" };
     const child = Object.create(parent);
     child.childKey = "childValue";
-    expect(isDict(child)).toBe(true);
+    expect(isDict(child)).toBe(false);
   });
 
   test("should return false for BigInt values", () => {
@@ -183,5 +185,37 @@ describe("isDict", () => {
   test("should return false for a cross-realm array", () => {
     const crossArray = createCrossRealmValue<unknown[]>("[1, 2, 3]");
     expect(isDict(crossArray)).toBe(false);
+  });
+
+  test("should return true for an object with an own constructor property", () => {
+    expect(isDict({ constructor: "x" })).toBe(true);
+    expect(isDict({ constructor: 1 })).toBe(true);
+    expect(isDict({ constructor: null })).toBe(true);
+    expect(isDict({ constructor: { nested: true } })).toBe(true);
+  });
+
+  test("should return false for a FieldRef", () => {
+    expect(isDict(new FieldRef("Users", "age"))).toBe(false);
+  });
+
+  test("should return true for a cross-realm object with an own constructor property", () => {
+    const crossObject = createCrossRealmValue<Record<string, unknown>>(
+      '({ constructor: "x" })',
+    );
+    expect(isDict(crossObject)).toBe(true);
+  });
+
+  test("should return true for a cross-realm Object.create(null)", () => {
+    const crossBareObject = createCrossRealmValue<Record<string, unknown>>(
+      'Object.assign(Object.create(null), { key: "value" })',
+    );
+    expect(isDict(crossBareObject)).toBe(true);
+  });
+
+  test("should return false for a cross-realm class instance", () => {
+    const crossInstance = createCrossRealmValue<object>(
+      "new (class Foo { constructor() { this.a = 1; } })()",
+    );
+    expect(isDict(crossInstance)).toBe(false);
   });
 });

--- a/src/util/other/isDict.ts
+++ b/src/util/other/isDict.ts
@@ -1,11 +1,10 @@
-const isDict = (val: any): val is Record<string, unknown> => {
-  return (
-    val !== null &&
-    typeof val === "object" &&
-    (val.constructor === Object ||
-      val.constructor === undefined ||
-      val.constructor?.name === "Object")
-  );
+// constructor は自前のプロパティで上書きできるがプロトタイプは隠せない。
+// 別 realm の Object.prototype もその先が null なので realm を跨いでも成立する。
+const isDict = (val: unknown): val is Record<string, unknown> => {
+  if (val === null || typeof val !== "object") return false;
+  const proto = Object.getPrototypeOf(val);
+  if (proto === null) return true;
+  return Object.getPrototypeOf(proto) === null;
 };
 
 export { isDict };


### PR DESCRIPTION
#218 の監査で見つかった `isDict` の穴への対応です。

## 問題

`isDict` は**オブジェクトのプロパティを読んでいました**。

```ts
val.constructor === Object || val.constructor === undefined || val.constructor?.name === "Object"
```

`val.constructor` は**自前のプロパティに上書きされます**。

```js
isDict({})                     // true
isDict({ constructor: "x" })   // false   ← 壊れる
```

つまり **`constructor` という名前の列を持つシート**では、`isDict` を使う全経路が dict をスカラーとして扱います。

## 実害 — typo が黙殺されて行が消える

```js
deleteMany({ where: { AND: [{ constructor: "alpha", nmae: "zzz" }] } })
// 修正前: エラーにならず { count: 1 } を返して1行削除
```

`validateWhereColumns` が `isDict` で AND ブランチを判定しているため、**ブランチ丸ごと未検証で通り、`nmae` の typo が黙殺**されます。#192〜#199 で塞いできたものと同じ形です。

`constructor` 列のシートで12ケース試した結果、**5ケースが壊れていました**。

| 操作 | 修正前 |
|---|---|
| `deleteMany({ where: { AND: [{ constructor: "alpha", nmae: "zzz" }] } })` | **typo 黙殺で1行削除** |
| `findMany({ orderBy: { constructor: "desc" } })` | **正しい入力が `GassmaInvalidValueError` で拒否される** |
| `findMany({ orderBy: { constructor: { srot: "asc" } } })` | 本来の `Unknown argument \`srot\`` が InvalidValue に化ける |
| `findMany({ where: { constructor: Gassma.skip } })` | **skip が剥がされず symbol が漏れる** |
| （`where` のスカラー一致・`contains`・`data`・`select`・`AND`/`NOT` は修正前から正常） | |

修正後は12ケースすべて green です。

## 直し方 — プロトタイプは隠せない

```ts
const isDict = (val: unknown): val is Record<string, unknown> => {
  if (val === null || typeof val !== "object") return false;
  const proto = Object.getPrototypeOf(val);
  if (proto === null) return true;                  // Object.create(null)
  return Object.getPrototypeOf(proto) === null;     // proto が Object.prototype 相当
};
```

**別 realm でも成立します。** 相手の realm の `Object.prototype` も、そのプロトタイプは `null` だからです。副次的に、**realm 対策で入っていた `constructor?.name === "Object"` という文字列比較が不要になりました**（`val: any` も `unknown` に narrow できました）。

`vm` で別 realm の値を作って全ケース検証しています。

```
ケース                        現行    修正後
{}                          true    true
{constructor:"x"}           false   true     ← 直る
Object.create(null)         true    true
new Date() / [1,2] / クラス    false   false
別realm {}                   true    true
別realm {constructor:"x"}    false   true     ← 直る
別realm Date / 配列           false   false
```

## 挙動が変わるもの: `Object.create({a: 1})`

**`true` → `false` になります。** これは既存テスト `isDict.test.ts:146-151` が固定していたので、**期待値とテスト名を変更しました。** 判断の根拠は3つです。

**1. `false` のほうが安全です（実測）。**

```
【修正前】isDict → true = 空の dict 扱い = 条件ゼロ個 = 恒真
  findMany({ where: { name: Object.create({a:1}) } })    → 全3件
  deleteMany({ where: { name: Object.create({a:1}) } })  → { count: 3 }  ← 全件削除

【修正後】isDict → false = スカラー値扱い
  findMany(...)    → 0件
  deleteMany(...)  → { count: 0 }
```

`Object.create({a:1})` は **`a` を自前のプロパティとして持っていません**（`Object.keys` は継承キーを返さない）。gassma は全箇所で `Object.keys` / `Object.entries` で列挙するので、**dict とみなすと「キーが0個 = 恒真フィルタ」に化けます。** つまり**この修正で全件削除の経路が1本塞がっています。**

**2. そのテストは仕様を定めたものではありません。** テスト名が `"should handle objects with prototype chain"` と記述的で、`37def43`（realm 安全な Date 判定）という**無関係なコミットに付随して入った**カバレッジでした。

**3. 代替実装が存在しません。** 「プロトタイプ鎖を遡って `Object.prototype` に到達すれば `true`」という案を検討しましたが、**クラスインスタンスも `Date` も鎖の頂点は `Object.prototype`** なので区別できません。

## 既知の副作用（**本 PR では直しません**）

`create({ data: { name: Object.create({a:1}) } })` が、**エラー → 黙って `[object Object]` を書き込み**に変わります。

ただし**これは新しい穴ではありません。** `validateWritableValue`（#211）は NaN / ±Infinity / Invalid Date / 配列 / 関数 / Symbol / BigInt しか弾いておらず、**任意のオブジェクトは元から素通り**でした。

```js
create({ data: { name: new Map() } })   // 修正前から [object Object] を書き込む
create({ data: { name: new Set() } })   // 同上
create({ data: { name: /re/ } })        // 同上
```

`Object.create({a:1})` はこの**既存の穴に合流するだけ**です。**別 PR（`fix/reject-non-scalar-objects`）で `validateWritableValue` にホワイトリスト方式のオブジェクト拒否を入れて、まとめて塞ぎます。**

## 検証結果

- `npm test`: **2,947件 全 green**（2,930 → +17）
- 往復契約テスト3スイート31件 green、**期待値は無変更**
- `tsc --noEmit` / lint / format / `verify:bundle`（公開シンボル57件）pass
- **既存テストの期待値変更は上記1件のみ**

新規テストは `constructorColumn.test.ts`（12件・`constructor` 列のシートで統合的に）と `isDict.test.ts`（+5件・**別 realm 含む**）です。

## 影響範囲の調査

`isDict` の呼び出し元を全部洗いました。変化は2種類だけです — **A** = `{constructor:"x"}` が `false`→`true`（バグ修正方向）、**B** = `Object.create({a:1})` が `true`→`false`（クエリ入力では発生しない）。

主な A の影響先: `validateTopLevelKeys`（未知キー検証が丸ごとスキップされていた）、`validateDataColumns`（不正値が完全に素通り）、`validateWhereColumns`（**ブランチ丸ごと未検証＝typo 黙殺**）、`normalizeQueryInput`（skip が剥がされない）、`writeBufferGate`、`resolveWhereRelation`、`vacuousBranch` など。

**`RawValue` はクラスインスタンス**（プロトタイプが `RawValue.prototype`）なので **A / B どちらの影響も受けません**。`isDict(v) && !isRawValue(v)` の併用パターンは安全です。

## 別途の提案

`isDict` という名前は、今回まさに「`Object.create({a:1})` は dict じゃないのか？」という混乱を招きました。**`isPlainObject` に改名する PR を、進行中の他の PR がマージされたあとに単独で出す**のが良いと思っています（約20箇所の呼び出し元を書き換えるだけの差分になるため、中身の変更と混ぜたくありません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)