### PR TITLE
fix: orderBy に配列を渡したとき書いてもいない sort を名指ししない

### DIFF
--- a/src/__test__/util/find/orderByArrayValue.test.ts
+++ b/src/__test__/util/find/orderByArrayValue.test.ts
@@ -1,0 +1,189 @@
+import { GassmaClient } from "../../../gassma";
+import { GassmaInvalidValueError } from "../../../errors/argument/argumentError";
+import { separateRelationOrderBy } from "../../../util/find/findUtil/separateRelationOrderBy";
+import { createCrossRealmValue } from "../../consts/crossRealm";
+import {
+  buildTestClient,
+  clearSpreadsheetApp,
+  sheetOf,
+} from "../extends/extendsTestClient";
+
+afterEach(() => {
+  clearSpreadsheetApp();
+});
+
+const looseSheet = (name: string): any =>
+  sheetOf(buildTestClient({ relations: true }), name);
+
+const orderByErrorMessage =
+  'Invalid value for argument `orderBy`. Expected "asc" | "desc".';
+
+describe("orderBy のスカラー列に配列を渡した場合", () => {
+  test("空配列は orderBy を名指しした GassmaInvalidValueError になる", () => {
+    const users = looseSheet("Users");
+    const fn = () => users.findMany({ orderBy: { name: [] } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(orderByErrorMessage);
+  });
+
+  test("要素入り配列も同じエラーになる", () => {
+    const users = looseSheet("Users");
+    const fn = () => users.findMany({ orderBy: { name: ["asc"] } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(orderByErrorMessage);
+  });
+
+  test("orderBy 配列の要素の中の配列値も同じエラーになる", () => {
+    const users = looseSheet("Users");
+    const fn = () => users.findMany({ orderBy: [{ name: ["desc"] }] });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(orderByErrorMessage);
+  });
+});
+
+describe("orderBy の正常系は変わらない", () => {
+  test('{ name: "asc" } で昇順ソートされる', () => {
+    const users = looseSheet("Users");
+    const result = users.findMany({ orderBy: { name: "asc" } });
+    expect(result.map((row: { name: string }) => row.name)).toEqual([
+      "Alice",
+      "Bob",
+      "Carol",
+    ]);
+  });
+
+  test('{ name: { sort: "desc" } } で降順ソートされる', () => {
+    const users = looseSheet("Users");
+    const result = users.findMany({ orderBy: { name: { sort: "desc" } } });
+    expect(result.map((row: { name: string }) => row.name)).toEqual([
+      "Carol",
+      "Bob",
+      "Alice",
+    ]);
+  });
+
+  test("リレーションの orderBy は正常に動く", () => {
+    const posts = looseSheet("Posts");
+    const result = posts.findMany({ orderBy: { author: { name: "desc" } } });
+    expect(result.map((row: { id: number }) => row.id)).toEqual([102, 101]);
+  });
+});
+
+describe("orderBy のリレーションキーに不正な値を渡した場合", () => {
+  const authorErrorMessage =
+    "Invalid value for argument `author`. Expected a relation orderBy object.";
+
+  test("空配列はリレーション用のエラーになる", () => {
+    const posts = looseSheet("Posts");
+    const fn = () => posts.findMany({ orderBy: { author: [] } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(authorErrorMessage);
+  });
+
+  test("Date もリレーション用のエラーになる", () => {
+    const posts = looseSheet("Posts");
+    const fn = () => posts.findMany({ orderBy: { author: new Date() } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(authorErrorMessage);
+  });
+});
+
+describe("別 realm の配列でも同じエラーになる", () => {
+  test("別 realm の空配列", () => {
+    const users = looseSheet("Users");
+    const fn = () =>
+      users.findMany({ orderBy: { name: createCrossRealmValue("[]") } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(orderByErrorMessage);
+  });
+
+  test("別 realm の要素入り配列", () => {
+    const users = looseSheet("Users");
+    const fn = () =>
+      users.findMany({ orderBy: { name: createCrossRealmValue("['asc']") } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(orderByErrorMessage);
+  });
+});
+
+describe("separateRelationOrderBy の配列値の分類", () => {
+  test("配列値は scalar 側に分類され hasRelationOrderBy は false のまま", () => {
+    const arrayValue: any = ["asc"];
+    const result = separateRelationOrderBy([{ name: arrayValue }]);
+    expect(result.scalarOrderBy).toEqual([{ name: ["asc"] }]);
+    expect(result.relationOrderBy).toEqual([]);
+    expect(result.hasRelationOrderBy).toBe(false);
+  });
+
+  test("空配列値も scalar 側に分類される", () => {
+    const arrayValue: any = [];
+    const result = separateRelationOrderBy([{ name: arrayValue }]);
+    expect(result.scalarOrderBy).toEqual([{ name: [] }]);
+    expect(result.hasRelationOrderBy).toBe(false);
+  });
+});
+
+describe("sort / nulls という名前の列", () => {
+  const buildSortColumnClient = (): GassmaClient => {
+    const data = [
+      ["id", "sort", "nulls"],
+      [1, "b", "y"],
+      [2, "a", "z"],
+      [3, "c", "x"],
+    ];
+    const sheet = {
+      getName: () => "Items",
+      getLastRow: () => data.length,
+      getLastColumn: () => data[0].length,
+      getRange: (
+        row: number,
+        col: number,
+        numRows: number,
+        numCols: number,
+      ) => ({
+        getValues: () =>
+          data
+            .slice(row - 1, row - 1 + numRows)
+            .map((r) => r.slice(col - 1, col - 1 + numCols)),
+        setValues: () => {},
+      }),
+      getDataRange: () => ({ getValues: () => data }),
+      deleteRow: () => {},
+      deleteRows: () => {},
+    };
+    const mockSpreadsheet = {
+      getId: () => "test-sort-column-spreadsheet",
+      getSheets: () => [sheet],
+      getSheetByName: (name: string) => (name === "Items" ? sheet : null),
+    };
+    Object.assign(globalThis, {
+      SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
+    });
+    return new GassmaClient();
+  };
+
+  test('orderBy: { sort: "asc" } で sort 列でソートできる', () => {
+    const items: any = sheetOf(buildSortColumnClient(), "Items");
+    const result = items.findMany({ orderBy: { sort: "asc" } });
+    expect(result.map((row: { id: number }) => row.id)).toEqual([2, 1, 3]);
+  });
+
+  test('orderBy: { nulls: "desc" } で nulls 列でソートできる', () => {
+    const items: any = sheetOf(buildSortColumnClient(), "Items");
+    const result = items.findMany({ orderBy: { nulls: "desc" } });
+    expect(result.map((row: { id: number }) => row.id)).toEqual([2, 1, 3]);
+  });
+
+  test('orderBy: { sort: { sort: "desc" } } も動く', () => {
+    const items: any = sheetOf(buildSortColumnClient(), "Items");
+    const result = items.findMany({ orderBy: { sort: { sort: "desc" } } });
+    expect(result.map((row: { id: number }) => row.id)).toEqual([3, 1, 2]);
+  });
+
+  test("sort 列に配列を渡しても orderBy を名指ししたエラーになる", () => {
+    const items: any = sheetOf(buildSortColumnClient(), "Items");
+    const fn = () => items.findMany({ orderBy: { sort: [] } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(orderByErrorMessage);
+  });
+});

--- a/src/util/find/findUtil/orderBy.ts
+++ b/src/util/find/findUtil/orderBy.ts
@@ -19,7 +19,8 @@ type ParsedOrderByEntry = [
 const isSortOrderInput = (
   value: "asc" | "desc" | SortOrderInput | RelationOrderBy,
 ): value is SortOrderInput => {
-  return typeof value === "object" && value !== null && "sort" in value;
+  // biome-ignore lint/suspicious/noPrototypeBuiltins: Object.hasOwn は ES2022 のため target ES2019 ではコンパイルできない
+  return isDict(value) && Object.prototype.hasOwnProperty.call(value, "sort");
 };
 
 const isScalarDirection = (

--- a/src/util/find/findUtil/separateRelationOrderBy.ts
+++ b/src/util/find/findUtil/separateRelationOrderBy.ts
@@ -1,4 +1,5 @@
 import type { OrderBy } from "../../../types/coreTypes";
+import { isDict } from "../../other/isDict";
 
 type SeparateResult = {
   scalarOrderBy: OrderBy[];
@@ -7,7 +8,8 @@ type SeparateResult = {
 };
 
 const isRelationOrderByValue = (value: unknown): boolean => {
-  return typeof value === "object" && value !== null && !("sort" in value);
+  // biome-ignore lint/suspicious/noPrototypeBuiltins: Object.hasOwn は ES2022 のため target ES2019 ではコンパイルできない
+  return isDict(value) && !Object.prototype.hasOwnProperty.call(value, "sort");
 };
 
 const separateRelationOrderBy = (orderByArr: OrderBy[]): SeparateResult => {


### PR DESCRIPTION
#218 の監査で挙がった `"sort" in value` の件です。**結果が壊れるバグではなく、エラーメッセージの問題**でした。

## 問題

```js
findMany({ orderBy: { name: [] } })
// → Invalid value for argument `sort`. Expected "asc" | "desc".
```

**利用者は `sort` なんて書いていません。** `name` に配列を渡しただけです。

原因は**配列が `Array.prototype.sort` を継承している**ことです。

```js
"sort" in []           // → true    ← 継承したメソッドを in が拾う
"sort" in {}           // → false
```

`isSortOrderInput` が `"sort" in value` で判定しているため、**配列が SortOrderInput として解釈**され、その中の `value.sort`（＝`Array.prototype.sort` という関数）を検証して落ちます。誤判定がメッセージに漏れ出た形です。

## 経路の実測

```
1. validateOrderByKeys      → isRelationOrderByValue([]) が "sort" in [] で false
                              → スカラー扱い、titles.includes("name") が真で素通り
2. separateRelationOrderBy  → 同じ述語でスカラー側に分類
3. parseOrderByEntry        → isSortOrderInput([]) が true  ← ここで誤判定
4. SORT_INPUT_KEYS チェック  → Object.keys([]) は [] なので何も検出せず素通り
5. isScalarDirection(value.sort)  → 継承した関数 → GassmaInvalidValueError("sort", ...)
```

**手前のバリデーションは配列を弾いていません。** 最終段が誤判定して `sort` を名指ししていました。

## 直し方 — 自前プロパティ判定 + `isDict` ガード

```ts
// 修正前
return typeof value === "object" && value !== null && "sort" in value;

// 修正後
return isDict(value) && Object.prototype.hasOwnProperty.call(value, "sort");
```

**`isDict` のガードが必要です。** 単純に `in` を `hasOwnProperty` に置換しただけの版も試したところ、**`orderBy: { author: [] }` が正しいエラーから生の `TypeError` に劣化**しました。配列が「`sort` を持たないオブジェクト＝リレーション値」と判定されてリレーション解決に流れ込み、`Object.keys([])[0]` が `undefined` になるためです。

`isDict` は配列を除外する **realm 安全**な既存ユーティリティで、`orderBy.ts` では既に使われています。**述語は2つあるので両方直しました**（片方だけだと判定が食い違います）。

`Object.hasOwn` は使えません。tsconfig が `target: ES2019` / `lib: ["ES2021"]` で、**TS2550 でコンパイル不能**になることを確認済みです（`Object.hasOwn` は ES2022）。`biome-ignore lint/suspicious/noPrototypeBuiltins` を付けています。これを外すと lint 警告が 48 → 50 に増え、かつ `lint:fix` が `Object.hasOwn` に自動書き換えしてビルドを壊すためです。

## 新しいメッセージは追加していません

述語を直すと、配列は `parseOrderByEntry` 末尾の**既存の catch-all** に落ちます。

```
Invalid value for argument `orderBy`. Expected "asc" | "desc".
```

**同じ経路の他の不正値がすでにこの文言を出しています**（`orderBy: { name: {} }` と `orderBy: { name: new Date() }` は修正前からこれ）。配列だけが誤判定で分岐していたので、正しく分類すれば自動的に横並びになります。新しい文字列を作らないので、**メッセージを固定している既存テストが1件も動きません**。

## 修正前・修正後（実測）

| 入力 | 修正前 | 修正後 |
|---|---|---|
| `orderBy: { name: [] }` | ``argument `sort`.`` ← **バグ** | ``argument `orderBy`. Expected "asc" \| "desc".`` |
| `orderBy: { name: ["asc"] }` | ``Unknown argument `0`.`` | 同上 |
| `orderBy: [{ name: ["desc"] }]` | ``Unknown argument `0`.`` | 同上 |
| **`orderBy: { author: new Date() }`** | **生の `TypeError`** | ``argument `author`. Expected a relation orderBy object.`` |
| `orderBy: { author: [] }` | 正しいエラー | 不変 |
| `orderBy: { name: "asc" }` | 正常 | 不変 |
| `orderBy: { name: { sort: "desc" } }` | 正常 | 不変 |
| `orderBy: { author: { name: "asc" } }` | 正常 | 不変 |

**`orderBy: { author: new Date() }` の生 TypeError が副次的に解消**しています。

### `sort` / `nulls` という名前の列は影響を受けません

述語は**キーではなく値の形**を見るためです。`orderBy: { sort: "asc" }` の値は文字列 `"asc"` なので判定対象になりません。専用のモックシートを用意して確認済みです。

## 検証結果

- `npm test`: **2,946件 全 green**（2,930 → +16、すべて新規ファイル）
- 往復契約テスト31件 green、**ファイル自体を触っていません**（`git status` に現れない）
- `tsc --noEmit` / lint（警告48件・ベースラインと同数） / format / `verify:bundle` pass
- **既存テストの変更ゼロ**。本体の差分は2ファイル計7行です

新規テストには**別 realm の配列**（`createCrossRealmValue("[]")`）も含めています。

## 判断が必要で実装しなかった点

**リレーション先のソート列が `sort` という名前だと今も誤判定します。**

```js
orderBy: { author: { sort: "asc" } }
// → Invalid value for argument `author`. Expected a relation orderBy object.
```

値が自前プロパティ `sort` を持つため SortOrderInput と解釈されます。**修正前後で挙動は同じ**（今回の変更の影響外）です。直すには「値の形」ではなく「キーがリレーション名か」を先に見る分類に変える必要があり、仕様判断が要るため触っていません。

なお **`resolveCount.ts:144` の `"select" in value` は同型ではありません。** `Array.prototype` に `select` は存在しないので `"select" in []` は `false` です。#218 での指摘は誤りで、**触っていません**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)