### PR TITLE
fix: セルに入れられないオブジェクトを拒否する

### DIFF
--- a/src/__test__/util/validate/validateQueryValues.test.ts
+++ b/src/__test__/util/validate/validateQueryValues.test.ts
@@ -1,4 +1,5 @@
 import { GassmaInvalidValueError } from "../../../errors/argument/argumentError";
+import { FieldRef } from "../../../util/filterConditions/fieldRef";
 import { raw } from "../../../util/raw/raw";
 import { validateQueryValues } from "../../../util/validate/validateQueryValues";
 import {
@@ -49,6 +50,29 @@ describe("validateQueryValues", () => {
   test("should throw for a Gassma.raw value inside where", () => {
     expect(() => validateQueryValues({ name: raw("=A1") })).toThrow(
       "Invalid value for argument `name`. Expected a scalar value, but received a Gassma.raw value.",
+    );
+  });
+
+  test("should accept a FieldRef as a direct value and inside an operator dict", () => {
+    const fieldRef = new FieldRef("Posts", "rating");
+    expect(() => validateQueryValues({ viewCount: fieldRef })).not.toThrow();
+    expect(() =>
+      validateQueryValues({ viewCount: { gt: fieldRef } }),
+    ).not.toThrow();
+    expect(() =>
+      validateQueryValues({ viewCount: { in: [fieldRef] } }),
+    ).not.toThrow();
+  });
+
+  test("should throw for a Map as a direct value and inside an operator dict", () => {
+    expect(() => validateQueryValues({ name: new Map() })).toThrow(
+      "Invalid value for argument `name`. Expected a scalar value, but received a Map.",
+    );
+    expect(() => validateQueryValues({ name: { gt: new Set() } })).toThrow(
+      "Invalid value for argument `gt`. Expected a scalar value, but received a Set.",
+    );
+    expect(() => validateQueryValues({ name: { in: [/re/] } })).toThrow(
+      "Invalid value for argument `in`. Expected a scalar value, but received a RegExp.",
     );
   });
 });

--- a/src/__test__/util/validate/validateWritableValue.test.ts
+++ b/src/__test__/util/validate/validateWritableValue.test.ts
@@ -1,4 +1,6 @@
 import { GassmaInvalidValueError } from "../../../errors/argument/argumentError";
+import { FieldRef } from "../../../util/filterConditions/fieldRef";
+import { raw } from "../../../util/raw/raw";
 import { validateWritableValue } from "../../../util/validate/validateWritableValue";
 import {
   createCrossRealmDate,
@@ -56,7 +58,63 @@ describe("validateWritableValue", () => {
   });
 });
 
+describe("validateWritableValue with object values", () => {
+  test("should accept a FieldRef and a Gassma.raw value", () => {
+    expect(() =>
+      validateWritableValue("col", new FieldRef("Posts", "rating")),
+    ).not.toThrow();
+    expect(() => validateWritableValue("col", raw("=A1"))).not.toThrow();
+  });
+
+  test("should throw for a Map, a Set and a RegExp", () => {
+    expect(() => validateWritableValue("col", new Map())).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received a Map.",
+    );
+    expect(() => validateWritableValue("col", new Set())).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received a Set.",
+    );
+    expect(() => validateWritableValue("col", /re/)).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received a RegExp.",
+    );
+  });
+
+  test("should throw for a class instance and a plain object", () => {
+    class Point {
+      x = 1;
+    }
+    expect(() => validateWritableValue("col", new Point())).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received an object.",
+    );
+    expect(() => validateWritableValue("col", Object.create({ a: 1 }))).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received an object.",
+    );
+    expect(() => validateWritableValue("col", {})).toThrow(
+      GassmaInvalidValueError,
+    );
+  });
+
+  test("should throw for an Error and a Promise", () => {
+    expect(() => validateWritableValue("col", new Error("x"))).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received an Error.",
+    );
+    expect(() => validateWritableValue("col", Promise.resolve())).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received a Promise.",
+    );
+  });
+});
+
 describe("validateWritableValue with cross-realm values", () => {
+  test("should throw for a cross-realm Map and plain object", () => {
+    const crossMap = createCrossRealmValue<unknown>("new Map()");
+    expect(() => validateWritableValue("col", crossMap)).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received a Map.",
+    );
+    const crossObject = createCrossRealmValue<unknown>("({ a: 1 })");
+    expect(() => validateWritableValue("col", crossObject)).toThrow(
+      "Invalid value for argument `col`. Expected a scalar value, but received an object.",
+    );
+  });
+
   test("should accept a cross-realm valid Date", () => {
     const crossDate = createCrossRealmDate("2026-07-18T09:30:00.000Z");
     expect(crossDate instanceof Date).toBe(false);

--- a/src/util/validate/validateWritableValue.ts
+++ b/src/util/validate/validateWritableValue.ts
@@ -1,5 +1,15 @@
 import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import { isFieldRef } from "../filterConditions/fieldRef";
 import { isDateValue } from "../other/isDateValue";
+import { isRawValue } from "../raw/raw";
+
+const describeObjectValue = (value: object): string => {
+  const tag = Object.prototype.toString.call(value).slice(8, -1);
+  if (tag === "Object") return "an object";
+  // U は Uint8Array のように子音として読むタグしかないので除く
+  const article = /^[AEIO]/.test(tag) ? "an" : "a";
+  return `${article} ${tag}`;
+};
 
 const validateWritableValue = (key: string, value: unknown): void => {
   if (typeof value === "number" && !Number.isFinite(value)) {
@@ -28,6 +38,18 @@ const validateWritableValue = (key: string, value: unknown): void => {
     throw new GassmaInvalidValueError(
       key,
       `a scalar value, but received a ${typeof value}`,
+    );
+  }
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    !isDateValue(value) &&
+    !isRawValue(value) &&
+    !isFieldRef(value)
+  ) {
+    throw new GassmaInvalidValueError(
+      key,
+      `a scalar value, but received ${describeObjectValue(value)}`,
     );
   }
 };


### PR DESCRIPTION
#211 のやり残しです。**#220 のレビュー中に見つかりました。**

## 問題

`validateWritableValue`（#211）は「セルに入れられない値」として**配列 / 関数 / Symbol / BigInt しか列挙しておらず、それ以外のオブジェクトは全部素通り**していました。

```js
create({ data: { name: new Map() } })   // エラーにならず [object Object] を書き込む
create({ data: { name: new Set() } })   // 同上
create({ data: { name: /re/ } })        // 同上
create({ data: { name: new Foo() } })   // クラスインスタンスも同上
```

`validateQueryValues`（#214）が同じ判定を再利用しているので、**`where` / `having` / `cursor` にも同じ穴**がありました。

## 直し方 — ホワイトリスト

**セルや比較に入っていいオブジェクトは3つだけ**です。それ以外を拒否します。

| 許可 | 理由 |
|---|---|
| `Date` | セルに入る |
| `Gassma.raw`（`RawValue`） | 書き込み側で数式を入れる |
| `FieldRef` | `where: { col: { gt: fields.other } }` の列参照 |

**ここを間違えると `fields` 機能が全部落ちます。** 判定はすべて realm 安全な既存ヘルパ（`isDateValue` / `isRawValue` / `isFieldRef`）で、**新しい `instanceof` は書いていません**。

到達経路を調べたところ、`validateWritableValue` の呼び出し元は**2箇所だけ**でした。

- `validateDataColumns` — `create` / `createMany` / `update` / `updateMany` / nested create の `data` 値と `increment` 等の演算値
- `validateQueryValues` → `validateQueryScalar` — `where` / `having` / `cursor`

**プレーンな `{}` はここに到達しません**（`isDict` が手前で dict と判定して演算オブジェクト経路に振る）。`Map` などが素通りしていたのは、`isDict` が `constructor.name !== "Object"` で false を返すためでした。

## メッセージ

`Object.prototype.toString` のタグから生成しています（realm 安全）。

```
Invalid value for argument `name`. Expected a scalar value, but received a Map.
                                                              ... but received a Set.
                                                              ... but received a RegExp.
                                                              ... but received an Error.
                                                              ... but received an object.   ← クラスインスタンス
```

既存の `received an array` / `received a function` と語形を揃えています。クラスインスタンスはタグが常に `Object` なので、**利用者のクラス名を漏らさず一貫して `an object`** になります。

冠詞は綴りで判定していますが、**`U` は除外**しました。`Uint8Array` のように子音として読むタグしか無いためです（`a Uint8Array` / `an ArrayBuffer` / `an Error` を確認済み）。

## 実測表

| 値 | 修正前 | 修正後 |
|---|---|---|
| 文字列 / 数値 / null / `Date` | 通る | 通る |
| **`FieldRef`** | 通る | **通る** |
| **`Gassma.raw`** | 通る | **通る** |
| `Map` / `Set` / `RegExp` | **通る** | `a Map` / `a Set` / `a RegExp` |
| クラスインスタンス | **通る** | `an object` |
| `Error` / `Promise` / `Uint8Array` | **通る** | `an Error` / `a Promise` / `a Uint8Array` |
| **cross-realm な `Map`** | **通る** | 拒否（`vm` 製の値で実測） |

## `fields` が壊れていないことの確認

既存テスト `filterRowsByWhere.test.ts:77`「FieldRef で他カラム参照比較ができる」が、**まさにこの経路を通って green のまま**です。加えて私の側でも実測しました。

```
where: { age: { gt: fields.id } }       → 通る
where: { age: { equals: fields.id } }   → 通る
create({ data: { name: Gassma.raw("=A1") } })  → 通る（"=A1" が書き込まれる）
```

## 検証結果

- `npm test`: **2,937件 全 green**（2,930 → +7、すべて新規）
- 往復契約テスト3スイート31件 green、**期待値は無変更**
- `tsc --noEmit` / lint（警告48件・ベースラインと同数） / format / `verify:bundle` pass
- **既存テストの期待値変更はゼロ**

## 副作用（意図と整合しているもの）

- **boxed primitive**（`new String("x")` / `new Number(1)`）も拒否されます（`received a String.`）。Prisma も受けないので妥当と考えています
- **`data: { col: { increment: {} } }`** のような演算値のオブジェクトも拒否されます。「オブジェクトをセルに書かせない」という意図と整合します

## 判断が必要で実装しなかった点

**`data` に `FieldRef` を渡すと今も素通りします。**

`resolveFieldRefs` は `where` 系と `connect` の `whereScan` にしか無いため、`data` 経路では解決されず**セルに `[object Object]` 相当が書かれます**。Prisma も `data` への field reference を許しません。

塞ぐには `FieldRef` の許可を `validateQueryScalar` 側（`RawValue` の逆配置）に移す必要があり、**依頼範囲を超える仕様変更**なので触っていません。**修正前も同じ挙動なので退行ではありません。**

## 関連

#220（`isDict` のプロトタイプ判定）で `Object.create({a:1})` がこの穴に合流すると書きましたが、**本 PR でそちらも塞がります**。マージ順はどちらが先でも構いません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)