### PR TITLE
fix: 数値演算の結果を検証する

### DIFF
--- a/src/__test__/util/create/createManyDefaultsValidation.test.ts
+++ b/src/__test__/util/create/createManyDefaultsValidation.test.ts
@@ -1,0 +1,85 @@
+import { GassmaInvalidValueError } from "../../../errors/argument/argumentError";
+import { buildTestClient, sheetOf } from "../extends/extendsTestClient";
+
+const usersWithDefault = (
+  defaultValue: any,
+): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const client = buildTestClient({
+    defaults: { Users: { age: () => defaultValue } },
+  });
+  const typed = sheetOf(client, "Users");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+describe("defaults が返した書けない値もエラーになる", () => {
+  test("createMany: defaults の NaN はエラーになり1行も追加されない", () => {
+    const { loose, typed } = usersWithDefault(Number.NaN);
+    const fn = () => loose.createMany({ data: [{ id: 9, name: "Zed" }] });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received NaN.",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("createManyAndReturn: defaults の NaN はエラーになり追加されない", () => {
+    const { loose, typed } = usersWithDefault(Number.NaN);
+    expect(() =>
+      loose.createManyAndReturn({ data: [{ id: 9, name: "Zed" }] }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("createMany: defaults の Invalid Date はエラーになり追加されない", () => {
+    const { loose, typed } = usersWithDefault(new Date("nope"));
+    expect(() => loose.createMany({ data: [{ id: 9, name: "Zed" }] })).toThrow(
+      "Invalid value for argument `age`. Expected a valid Date, but the provided Date object is invalid.",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("createMany: defaults のオブジェクトはエラーになり追加されない", () => {
+    const { loose, typed } = usersWithDefault({ nested: 1 });
+    expect(() => loose.createMany({ data: [{ id: 9, name: "Zed" }] })).toThrow(
+      "Invalid value for argument `age`. Expected a scalar value, but received an object.",
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("create: defaults の NaN はエラーになり追加されない", () => {
+    const { loose, typed } = usersWithDefault(Number.NaN);
+    expect(() => loose.create({ data: { id: 9, name: "Zed" } })).toThrow(
+      GassmaInvalidValueError,
+    );
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("upsert(作成分岐): defaults の NaN はエラーになり追加されない", () => {
+    const { loose, typed } = usersWithDefault(Number.NaN);
+    expect(() =>
+      loose.upsert({
+        where: { id: 999 },
+        create: { id: 999, name: "Zed" },
+        update: { name: "Zed" },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(typed.count({})).toBe(3);
+  });
+
+  test("createMany: 明示した値が defaults を上書きしていれば通る", () => {
+    const { loose, typed } = usersWithDefault(Number.NaN);
+    loose.createMany({ data: [{ id: 9, name: "Zed", age: 5 }] });
+    expect(typed.count({})).toBe(4);
+  });
+
+  test("createMany: 書ける defaults はそのまま入る", () => {
+    const { loose, typed } = usersWithDefault(7);
+    loose.createMany({ data: [{ id: 9, name: "Zed" }] });
+    expect(typed.findFirst({ where: { id: 9 } })).toEqual({
+      id: 9,
+      name: "Zed",
+      age: 7,
+    });
+  });
+});

--- a/src/__test__/util/extends/extendsTestClient.ts
+++ b/src/__test__/util/extends/extendsTestClient.ts
@@ -1,5 +1,6 @@
 import { GassmaClient } from "../../../gassma";
 import { GassmaController } from "../../../gassmaController";
+import type { GassmaClientOptions } from "../../../types/relationTypes";
 
 type MockRange = {
   getValues: () => unknown[][];
@@ -53,7 +54,10 @@ const makeSheet = (name: string, initial: unknown[][]): MockSheet => {
   };
 };
 
-const buildTestClient = (options?: { relations?: boolean }): GassmaClient => {
+const buildTestClient = (options?: {
+  relations?: boolean;
+  defaults?: GassmaClientOptions["defaults"];
+}): GassmaClient => {
   const sheets = [
     makeSheet("Users", [
       ["id", "name", "age"],
@@ -82,8 +86,13 @@ const buildTestClient = (options?: { relations?: boolean }): GassmaClient => {
   Object.assign(globalThis, {
     SpreadsheetApp: { getActiveSpreadsheet: () => mockSpreadsheet },
   });
-  if (!options?.relations) return new GassmaClient();
+  if (!options?.relations) {
+    return options?.defaults
+      ? new GassmaClient({ defaults: options.defaults })
+      : new GassmaClient();
+  }
   return new GassmaClient({
+    ...(options.defaults ? { defaults: options.defaults } : {}),
     relations: {
       Users: {
         posts: {

--- a/src/__test__/util/update/numberOperationResult.test.ts
+++ b/src/__test__/util/update/numberOperationResult.test.ts
@@ -1,0 +1,202 @@
+import { GassmaInvalidValueError } from "../../../errors/argument/argumentError";
+import { buildTestClient, sheetOf } from "../extends/extendsTestClient";
+
+const looseUsers = (options?: {
+  relations?: boolean;
+}): { loose: any; typed: ReturnType<typeof sheetOf> } => {
+  const typed = sheetOf(buildTestClient(options), "Users");
+  const loose: any = typed;
+  return { loose, typed };
+};
+
+const aliceUnchanged = (typed: ReturnType<typeof sheetOf>) => {
+  expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+    id: 1,
+    name: "Alice",
+    age: 20,
+  });
+};
+
+describe("ゼロ除算の結果はセルに書かれない", () => {
+  test("updateMany: divide: 0 は Infinity になるのでエラー", () => {
+    const { loose, typed } = looseUsers();
+    const fn = () =>
+      loose.updateMany({ where: { id: 1 }, data: { age: { divide: 0 } } });
+    expect(fn).toThrow(GassmaInvalidValueError);
+    expect(fn).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received Infinity.",
+    );
+    aliceUnchanged(typed);
+  });
+
+  test("update: divide: 0 はエラーになり行が更新されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.update({ where: { id: 1 }, data: { age: { divide: 0 } } }),
+    ).toThrow(GassmaInvalidValueError);
+    aliceUnchanged(typed);
+  });
+
+  test("updateManyAndReturn: divide: 0 はエラーになり行が更新されない", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.updateManyAndReturn({
+        where: { id: 1 },
+        data: { age: { divide: 0 } },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    aliceUnchanged(typed);
+  });
+
+  test("現在値が 0 のときの divide: 0 は NaN になるのでエラー", () => {
+    const { loose, typed } = looseUsers();
+    loose.update({ where: { id: 1 }, data: { age: 0 } });
+    expect(() =>
+      loose.update({ where: { id: 1 }, data: { age: { divide: 0 } } }),
+    ).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received NaN.",
+    );
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 0,
+    });
+  });
+
+  test("divide: -0 は -Infinity になるのでエラー", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.updateMany({ where: { id: 1 }, data: { age: { divide: -0 } } }),
+    ).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received -Infinity.",
+    );
+    aliceUnchanged(typed);
+  });
+
+  test("数値でないセルへの divide: 0 は NaN になるのでエラー", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.updateMany({ where: { id: 1 }, data: { name: { divide: 0 } } }),
+    ).toThrow(
+      "Invalid value for argument `name`. Expected a finite number, but received NaN.",
+    );
+    aliceUnchanged(typed);
+  });
+});
+
+describe("桁あふれした演算結果もセルに書かれない", () => {
+  test("multiply がオーバーフローするとエラー", () => {
+    const { loose, typed } = looseUsers();
+    expect(() =>
+      loose.updateMany({
+        where: { id: 1 },
+        data: { age: { multiply: 1e308 } },
+      }),
+    ).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received Infinity.",
+    );
+    aliceUnchanged(typed);
+  });
+
+  test("increment がオーバーフローするとエラー", () => {
+    const { loose, typed } = looseUsers();
+    loose.update({ where: { id: 1 }, data: { age: 1e308 } });
+    expect(() =>
+      loose.update({ where: { id: 1 }, data: { age: { increment: 1e308 } } }),
+    ).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received Infinity.",
+    );
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 1e308,
+    });
+  });
+
+  test("decrement がオーバーフローするとエラー", () => {
+    const { loose, typed } = looseUsers();
+    loose.update({ where: { id: 1 }, data: { age: -1e308 } });
+    expect(() =>
+      loose.update({ where: { id: 1 }, data: { age: { decrement: 1e308 } } }),
+    ).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received -Infinity.",
+    );
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: -1e308,
+    });
+  });
+});
+
+describe("リレーションのある経路でも書かれない", () => {
+  test("update: リレーション定義があっても divide: 0 はエラー", () => {
+    const { loose, typed } = looseUsers({ relations: true });
+    expect(() =>
+      loose.update({ where: { id: 1 }, data: { age: { divide: 0 } } }),
+    ).toThrow(GassmaInvalidValueError);
+    aliceUnchanged(typed);
+  });
+
+  test("updateMany: リレーション定義があっても divide: 0 はエラー", () => {
+    const { loose, typed } = looseUsers({ relations: true });
+    expect(() =>
+      loose.updateMany({ where: { id: 1 }, data: { age: { divide: 0 } } }),
+    ).toThrow(GassmaInvalidValueError);
+    aliceUnchanged(typed);
+  });
+
+  test("nested update を伴う divide: 0 は子も書き換えない", () => {
+    const client = buildTestClient({ relations: true });
+    const users: any = sheetOf(client, "Users");
+    const posts = sheetOf(client, "Posts");
+    expect(() =>
+      users.update({
+        where: { id: 1 },
+        data: {
+          age: { divide: 0 },
+          posts: { update: { where: { id: 101 }, data: { title: "変更後" } } },
+        },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    expect(posts.findFirst({ where: { id: 101 } })).toEqual({
+      id: 101,
+      authorId: 1,
+      title: "Post A",
+    });
+  });
+
+  test("upsert(更新分岐): divide: 0 はエラーになり更新されない", () => {
+    const { loose, typed } = looseUsers({ relations: true });
+    expect(() =>
+      loose.upsert({
+        where: { id: 1 },
+        create: { id: 1, name: "Alice", age: 20 },
+        update: { age: { divide: 0 } },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+    aliceUnchanged(typed);
+  });
+});
+
+describe("有限に収まる演算は従来どおり通る", () => {
+  test("divide: 2 は通る", () => {
+    const { loose, typed } = looseUsers();
+    loose.updateMany({ where: { id: 1 }, data: { age: { divide: 2 } } });
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: "Alice",
+      age: 10,
+    });
+  });
+
+  test("数値でないセルへの increment は 0 起点で通る", () => {
+    const { loose, typed } = looseUsers();
+    loose.updateMany({ where: { id: 1 }, data: { name: { increment: 3 } } });
+    expect(typed.findFirst({ where: { id: 1 } })).toEqual({
+      id: 1,
+      name: 3,
+      age: 20,
+    });
+  });
+});

--- a/src/__test__/util/update/resolveNumberOperation.test.ts
+++ b/src/__test__/util/update/resolveNumberOperation.test.ts
@@ -1,3 +1,4 @@
+import { GassmaInvalidValueError } from "../../../errors/argument/argumentError";
 import {
   resolveNumberOperation,
   resolveNumberOperations,
@@ -5,28 +6,45 @@ import {
 
 describe("resolveNumberOperation", () => {
   it("increment で値が加算される", () => {
-    expect(resolveNumberOperation(1, { increment: 5 })).toBe(6);
+    expect(resolveNumberOperation(1, { increment: 5 }, "count")).toBe(6);
   });
 
   it("decrement で値が減算される", () => {
-    expect(resolveNumberOperation(6, { decrement: 3 })).toBe(3);
+    expect(resolveNumberOperation(6, { decrement: 3 }, "count")).toBe(3);
   });
 
   it("multiply で値が乗算される", () => {
-    expect(resolveNumberOperation(3, { multiply: 2 })).toBe(6);
+    expect(resolveNumberOperation(3, { multiply: 2 }, "count")).toBe(6);
   });
 
   it("divide で値が除算される", () => {
-    expect(resolveNumberOperation(6, { divide: 4 })).toBe(1.5);
+    expect(resolveNumberOperation(6, { divide: 4 }, "count")).toBe(1.5);
   });
 
   it("現在値が number でない場合は 0 をベースにする", () => {
-    expect(resolveNumberOperation("hello", { increment: 5 })).toBe(5);
+    expect(resolveNumberOperation("hello", { increment: 5 }, "count")).toBe(5);
   });
 
   it("現在値が null/undefined の場合は 0 をベースにする", () => {
-    expect(resolveNumberOperation(null, { increment: 10 })).toBe(10);
-    expect(resolveNumberOperation(undefined, { decrement: 3 })).toBe(-3);
+    expect(resolveNumberOperation(null, { increment: 10 }, "count")).toBe(10);
+    expect(resolveNumberOperation(undefined, { decrement: 3 }, "count")).toBe(
+      -3,
+    );
+  });
+
+  it("結果が Infinity になる場合は列名付きでエラーになる", () => {
+    expect(() => resolveNumberOperation(20, { divide: 0 }, "age")).toThrow(
+      GassmaInvalidValueError,
+    );
+    expect(() => resolveNumberOperation(20, { divide: 0 }, "age")).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received Infinity.",
+    );
+  });
+
+  it("結果が NaN になる場合はエラーになる", () => {
+    expect(() => resolveNumberOperation(0, { divide: 0 }, "age")).toThrow(
+      "Invalid value for argument `age`. Expected a finite number, but received NaN.",
+    );
   });
 });
 

--- a/src/util/create/createManyFunc.ts
+++ b/src/util/create/createManyFunc.ts
@@ -5,6 +5,7 @@ import { getWantUpdateIndexFromTitles } from "../core/getWantUpdateIndex";
 import { escapeFormulaInjectionRow } from "../core/escapeFormulaInjection";
 import { unwrapRawCell } from "../raw/raw";
 import { validateDataColumns } from "../validate/validateDataColumns";
+import { validateWritableRow } from "../validate/validateWritableRow";
 import { resolveWriter } from "../write/sheetWriter";
 
 type PrepareCreateManyData = (data: CreateManyData) => CreateManyData;
@@ -44,6 +45,10 @@ function createManyFunc(
 
   const data = (prepareData ? prepareData(createManyData) : createManyData)
     .data;
+
+  data.forEach((row) => {
+    validateWritableRow(row);
+  });
 
   const newData = data.map((row) => {
     const wantCreateIndex = getWantUpdateIndexFromTitles(titles, row);

--- a/src/util/update/nestedWrite/resolveNestedUpdate.ts
+++ b/src/util/update/nestedWrite/resolveNestedUpdate.ts
@@ -79,9 +79,10 @@ const resolveNestedUpdate = (
     );
     const updatedRow = firstRow.row.map((cell, cellIndex) => {
       if (!wantUpdateIndex.includes(cellIndex)) return cell;
-      const value = updateInput.data[String(titles[cellIndex])];
+      const columnName = String(titles[cellIndex]);
+      const value = updateInput.data[columnName];
       if (isNumberOperation(value)) {
-        return resolveNumberOperation(cell, value);
+        return resolveNumberOperation(cell, value, columnName);
       }
       return value;
     });
@@ -122,9 +123,10 @@ const resolveNestedUpdate = (
   const wantUpdateIndex = getWantUpdateIndexFromTitles(titles, enrichedData);
   const updatedRow = firstRow.row.map((cell, cellIndex) => {
     if (!wantUpdateIndex.includes(cellIndex)) return cell;
-    const value = enrichedData[String(titles[cellIndex])];
+    const columnName = String(titles[cellIndex]);
+    const value = enrichedData[columnName];
     if (isNumberOperation(value)) {
-      return resolveNumberOperation(cell, value);
+      return resolveNumberOperation(cell, value, columnName);
     }
     return value;
   });

--- a/src/util/update/resolveNumberOperation.ts
+++ b/src/util/update/resolveNumberOperation.ts
@@ -1,4 +1,5 @@
 import type { NumberOperation } from "../../types/coreTypes";
+import { validateWritableValue } from "../validate/validateWritableValue";
 
 const NUMBER_OPERATION_KEYS = ["increment", "decrement", "multiply", "divide"];
 
@@ -7,16 +8,26 @@ const isNumberOperation = (value: unknown): value is NumberOperation =>
   value !== null &&
   Object.keys(value).some((key) => NUMBER_OPERATION_KEYS.includes(key));
 
-const resolveNumberOperation = (
-  currentValue: unknown,
+const applyNumberOperation = (
+  base: number,
   operation: NumberOperation,
 ): number => {
-  const base = typeof currentValue === "number" ? currentValue : 0;
   if (operation.increment !== undefined) return base + operation.increment;
   if (operation.decrement !== undefined) return base - operation.decrement;
   if (operation.multiply !== undefined) return base * operation.multiply;
   if (operation.divide !== undefined) return base / operation.divide;
   return base;
+};
+
+const resolveNumberOperation = (
+  currentValue: unknown,
+  operation: NumberOperation,
+  columnName: string,
+): number => {
+  const base = typeof currentValue === "number" ? currentValue : 0;
+  const result = applyNumberOperation(base, operation);
+  validateWritableValue(columnName, result);
+  return result;
 };
 
 const resolveNumberOperations = (
@@ -26,7 +37,7 @@ const resolveNumberOperations = (
   const resolved: Record<string, unknown> = { ...currentRecord };
   Object.entries(data).forEach(([key, value]) => {
     if (isNumberOperation(value)) {
-      resolved[key] = resolveNumberOperation(currentRecord[key], value);
+      resolved[key] = resolveNumberOperation(currentRecord[key], value, key);
     } else {
       resolved[key] = value;
     }

--- a/src/util/update/updateMany.ts
+++ b/src/util/update/updateMany.ts
@@ -69,9 +69,10 @@ function updateManyFunc(
   const updates = findedData.map((row) => {
     const updatedRow = row.row.map((cell, cellIndex) => {
       if (!wantUpdateIndex.includes(cellIndex)) return cell;
-      const value = data[String(titles[cellIndex])];
+      const columnName = String(titles[cellIndex]);
+      const value = data[columnName];
       if (isNumberOperation(value)) {
-        return resolveNumberOperation(cell, value);
+        return resolveNumberOperation(cell, value, columnName);
       }
       return value;
     });

--- a/src/util/validate/validateWritableRow.ts
+++ b/src/util/validate/validateWritableRow.ts
@@ -1,0 +1,9 @@
+import { validateWritableValue } from "./validateWritableValue";
+
+const validateWritableRow = (row: Record<string, unknown>): void => {
+  Object.entries(row).forEach(([key, value]) => {
+    validateWritableValue(key, value);
+  });
+};
+
+export { validateWritableRow };


### PR DESCRIPTION
#211 のやり残しです。**入力は検証していましたが、演算の「結果」は誰も見ていませんでした。**

## 問題

```js
updateMany({ where: { id: 1 }, data: { age: { divide: 0 } } })
// 修正前: { count: 1 } — エラーにならない
// 読み直すと age が 20 → null に。データが黙って消える
```

**直値の NaN は #211 が正しく弾きます**（`{ age: { multiply: NaN } }` → エラー）。しかし `{ divide: 0 }` は**入力が完全に正当な `0`** なので通過し、そこから出てきた `Infinity` / `NaN` をチェックする場所がありませんでした。

## Prisma の実測（判断の根拠）

```
Int  (必須) + divide: 0  → PrismaClientKnownRequestError
                            Null constraint violation on the fields: (`reqInt`)
Int? (任意) + divide: 0  → { count: 1 } で成功。値が null に。エラーなし
Float(必須) + divide: 0  → 同じく Null constraint violation
```

**Prisma に「ゼロ除算チェック」は存在しません。** SQLite が `x / 0` を NULL で返し、それが **NOT NULL 制約**に引っかかっているだけです。**任意列では何も止まらず黙って NULL になります。**

**gassma はシートに NOT NULL 制約が無いので、全列が「任意列」と同じ振る舞いになります。** つまり修正前の gassma は、Prisma の任意列と完全に同じ挙動でした。

追従しない判断は `prisma-nan-behavior` の方針どおりです。

> 「null に変換」は**まさに Prisma がやっていて問題視されている挙動**（サイレントなデータ消失）。NaN は「空」ではなく「数値として解釈できなかった」という意味なので、null にすると事実と違う記録が残る。

なお **PostgreSQL は `division_by_zero` エラーを投げます**（SQLite が NULL を返すのは SQLite の仕様）。厳格な DB での Prisma の意味論に寄せることにもなります。

## 検証位置 — 4経路の合流点

**`resolveNumberOperation` の内部**に置きました。演算の適用を `applyNumberOperation` に切り出し、その結果を `validateWritableValue` に通します。

| 経路 | 場所 |
|---|---|
| `updateMany` / `updateManyAndReturn` | `updateMany.ts:75` |
| `update` / `upsert`（更新分岐）の非ネスト経路 | `resolveNestedUpdate.ts:85` |
| 同・ネスト経路 | `resolveNestedUpdate.ts:129` |
| onUpdate カスケードの予測値（`resolveNumberOperations`） | `gassmaController.ts` 3箇所 + `upsert.ts:88` |

**この4経路すべてがこの1関数を通り、ここ以外に演算結果が生まれる場所はありません。** 網羅が構造的に保証されます。

副次効果として **fail-fast が保たれます**。リレーションがある場合、controller / upsert の予測値計算が `resolveNestedUpdate` より前に走るので、**ネスト書き込みで子行を先に書いてしまう前に throw**します（テストで実証済み）。

**シートの読み書きは1回も増えていません**（純粋な JS の演算のみ）。

## メッセージは列名で報告します

```
Invalid value for argument `age`. Expected a finite number, but received Infinity.
```

**`divide` ではなく `age`** にした理由は3つです。

- 利用者が `data` に書いたのは `{ age: {...} }` で、**書き込み先の列**が壊れたという事実そのものを指す
- **#211 の直値 NaN（`{ age: NaN }`）と完全に同じ文面**になる。同じ「セルに NaN が入る」現象で、入口の違いによって文面が変わらない
- `` `age.divide` `` も検討しましたが、**`divide` の値は `0` であって `Infinity` ではない**ので事実と食い違います

## `createMany` の検証位置 — 再現しました

`defaults: { Users: { age: () => NaN } }` を設定して `createMany` すると、**エラーにならず NaN が書かれます**。`createManyAndReturn` も同様。Invalid Date・オブジェクトも素通りでした。

**`create` と `upsert`（作成分岐）は既に塞がっていました** — `resolveNestedCreate` が `prepare` を適用した後に `createFunc` を呼ぶためです。`createMany` だけ順序が逆でした。

**修正は「移動」ではなく「追加」にしました。**

報告どおり `validateDataColumns` を `prepareData` の後ろに移すと、`applyCreateManyPreprocess` が `stripIgnoredFields` で ignore 列を落とした後に検証することになり、**`@ignore` 列を明示的に渡したときの `GassmaUnknownArgumentError` が消えて黙って無視される**という**別の黙殺を作ってしまいます**。

そこで既存の列名検査はそのままにし、`prepareData` の直後に**値だけを見るパス**（`validateWritableRow`、9行）を足しています。**往復回数は不変**です（`prepareData` はシートを読まず、`getTitle` は既に上で1回呼ばれている）。

## 網羅確認（修正後・実測）

| 入力 | 現在値 | 結果 |
|---|---|---|
| `{ divide: 0 }` | `age = 20` | `` `age` ``: received **Infinity** |
| `{ divide: 0 }` | `age = 0` | `` `age` ``: received **NaN** |
| `{ divide: 0 }` | `name = "Alice"`（非数値セル） | `` `name` ``: received **NaN**（0 起点なので 0/0） |
| `{ divide: -0 }` | `age = 20` | `` `age` ``: received **-Infinity** |
| `{ multiply: 1e308 }` | `age = 20` | `` `age` ``: received **Infinity**（桁あふれ） |
| `{ increment: 1e308 }` | `age = 1e308` | `` `age` ``: received **Infinity** |
| `{ increment: 1e308 }` | `age = 20` | **OK** → `1e+308`（結果が有限なので通す） |
| `{ multiply: Infinity }` / `{ increment: NaN }` | — | `` `multiply` `` / `` `increment` ``（**入力側**で #211 が弾く。従来どおり） |

**THROW したケースではセルが無変化**であることも確認済みです（`age` が 20 のまま）。`{ divide: 2 }` などの正常系、非数値セルへの `{ increment: 3 }`（0 起点で 3 になる既存仕様）も維持されています。

## 検証結果

- `npm test`: **3,065件 全 green**（3,040 → +25、新規2スイート）
- 往復契約テスト3スイート31件 green、**該当ファイルの `git diff` が空**
- `tsc --noEmit` / lint（警告48件・ベースラインと同数） / format / `verify:bundle`（公開シンボル57件）pass
- **既存テストの期待値変更はゼロ**

変更した既存テストは2ファイルですが、いずれも期待値ではありません。`resolveNumberOperation.test.ts` は第3引数 `columnName` を足したことによる**シグネチャ追従**（`toBe(...)` は全て元のまま）、`extendsTestClient.ts` は `defaults` オプションの追加（既存の呼び出しは全て無引数か `{relations:true}`）です。

## 判断が必要で実装しなかった点

**1. 直値エラーのキーが不統一です。**

`{ age: { increment: NaN } }` は `` `increment` ``、結果由来は `` `age` `` になります。「入力が悪い → 演算子キー」「結果が悪い → 列名」という切り分けなので、**どちらが原因かをメッセージで区別できる**という利点はあります。統一するかは仕様判断なので触っていません。

**2. `autoincrement` が NaN を返す経路は未検証です。**

`createMany` 側は今回の `validateWritableRow` で結果的に塞がりましたが、`generateAutoincrementValues` が ScriptProperties の壊れた値から NaN を作る経路自体は未検証・未修正です。

**3. `{ increment: 1e308 }` が `age=20` で通る**のは「結果が有限なら通す」という規則の帰結です。Prisma にも制限は無いので仕様追加はしていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)