### PR TITLE
chore: README のリファレンス参照先を gassma.io にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ function myFunction() {
 
 ## Official Reference
 
-https://akahoshi1421.github.io/gassma-reference/en
+https://gassma.io/en

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -96,4 +96,4 @@ function myFunction() {
 
 ## 公式リファレンス
 
-https://akahoshi1421.github.io/gassma-reference/
+https://gassma.io/


### PR DESCRIPTION
リファレンスサイトが独自ドメイン **`https://gassma.io`** を取得したので、README のリンクを移します。

```
README.md:99         https://akahoshi1421.github.io/gassma-reference/en  →  https://gassma.io/en
docs/README.ja.md:99 https://akahoshi1421.github.io/gassma-reference/    →  https://gassma.io/
```

apex 直下に配信するので `baseUrl` が `/` になり、`/gassma-reference` のパスが消えます。**日本語版が既定ロケールなので `/` が日本語、`/en` が英語**という対応は変わりません。

**本体リポジトリでの該当はこの2箇所だけ**です（`akahoshi1421.github.io` と `gassma-reference` の両方で全文検索して確認）。ソースコードには一切含まれていませんでした。

関連: gassma-cli #154 / gassma-reference `chore/gassma-io-domain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)