### PR TITLE
chore: ライブラリバージョンを 8 にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gassma",
-  "version": "7",
+  "version": "8",
   "description": "GASsma is Google Apps Script(GAS) of SpreadSheet library that can be used like prisma.",
   "types": "src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
**GAS ライブラリの v8 は発行・デプロイ済みですが、`package.json` が 7 のままでした。**

```diff
- "version": "7",
+ "version": "8",
```

## これは飾りではありません

`gassma bootstrap` が**新規プロジェクトに設定するライブラリのバージョンを、このファイルから読みます。**

```ts
// gassma-cli/packages/cli/src/bootstrap/env/fetchLatestLibraryVersion.ts
const GASSMA_PACKAGE_JSON_URL =
  "https://raw.githubusercontent.com/akahoshi1421/gassma/main/package.json";
```

取得は2段構えで、**1段目は `clasp list-versions` の最大値**（正しく 8 が取れます）、**2段目のフォールバックがこの `package.json`** です。

つまり **clasp が使えない環境で `gassma bootstrap` を実行すると、新規プロジェクトの `appsscript.json` が v7 に固定されます。** #208〜#223 の修正がすべて入っていない版です。

## 確認したこと

```
npx clasp versions   →  Found 8 versions.
```

サーバー上のバージョン8を実際に取得して、`runtimeVersion: "V8"` であることと、**バンドルがローカルの最新ビルドとバイト単位で一致**していることも確認済みです（485,465 bytes）。

## バージョン管理の整理

この `version` は **npm 用ではなく「GAS ライブラリの発行番号」のミラー**です（npm には publish していません）。GAS のバージョンはデプロイのたびに増える整数なので、**デプロイのたびにここも上げる必要があります**。

なお **gassma-cli の npm バージョンとは別軸**です。cli は semver で、`bootstrap` がライブラリのバージョンを実行時に取得する作りになっているため、番号を揃える必要はありません（揃えると、変更が無くてもデプロイのたびにメジャーを上げることになり、semver の意味が消えます）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)