### PR TITLE
fix: groupBy の orderBy / take / skip をグループに適用する

### DIFF
--- a/src/__test__/util/groupby/groupby.test.ts
+++ b/src/__test__/util/groupby/groupby.test.ts
@@ -171,12 +171,11 @@ describe("groupBy functionality tests", () => {
     test("should work with orderBy", () => {
       const result = groupByFunc(getExtendedMockControllerUtil(), {
         by: "住所",
-        orderBy: { 年齢: "desc" },
+        orderBy: { 住所: "desc" },
         _avg: { 年齢: true },
       });
 
-      // orderBy should not affect the grouping results, only the order of processing
-      expectArrayToEqualIgnoringOrder(result, [
+      expect(result).toEqual([
         { 住所: "Tokyo", _avg: { 年齢: (28 + 22 + 28 + 31) / 4 } },
         { 住所: "Osaka", _avg: { 年齢: (35 + 52) / 2 } },
         { 住所: "Kyoto", _avg: { 年齢: (45 + 28) / 2 } },
@@ -186,30 +185,25 @@ describe("groupBy functionality tests", () => {
     test("should work with skip", () => {
       const result = groupByFunc(getExtendedMockControllerUtil(), {
         by: "住所",
+        orderBy: { 住所: "asc" },
         skip: 2,
         _count: { 名前: true },
       });
 
-      // Skip should affect the input data before grouping
-      expectArrayToEqualIgnoringOrder(result, [
-        { 住所: "Tokyo", _count: { 名前: 3 } },
-        { 住所: "Kyoto", _count: { 名前: 2 } },
-        { 住所: "Osaka", _count: { 名前: 1 } },
-      ]);
+      expect(result).toEqual([{ 住所: "Tokyo", _count: { 名前: 4 } }]);
     });
 
     test("should work with take", () => {
       const result = groupByFunc(getExtendedMockControllerUtil(), {
         by: "住所",
-        take: 4,
+        orderBy: { 住所: "asc" },
+        take: 2,
         _count: { 名前: true },
       });
 
-      // Take should limit input data before grouping
-      expectArrayToEqualIgnoringOrder(result, [
-        { 住所: "Tokyo", _count: { 名前: 2 } },
-        { 住所: "Osaka", _count: { 名前: 1 } },
-        { 住所: "Kyoto", _count: { 名前: 1 } },
+      expect(result).toEqual([
+        { 住所: "Kyoto", _count: { 名前: 2 } },
+        { 住所: "Osaka", _count: { 名前: 2 } },
       ]);
     });
   });
@@ -228,6 +222,7 @@ describe("groupBy functionality tests", () => {
     test("should handle take=0", () => {
       const result = groupByFunc(getExtendedMockControllerUtil(), {
         by: "住所",
+        orderBy: { 住所: "asc" },
         take: 0,
         _count: { 名前: true },
       });
@@ -235,9 +230,10 @@ describe("groupBy functionality tests", () => {
       expect(result).toEqual([]);
     });
 
-    test("should handle skip exceeding total records", () => {
+    test("should handle skip exceeding total groups", () => {
       const result = groupByFunc(getExtendedMockControllerUtil(), {
         by: "住所",
+        orderBy: { 住所: "asc" },
         skip: 20,
         _count: { 名前: true },
       });

--- a/src/__test__/util/groupby/groupbyPipeline.test.ts
+++ b/src/__test__/util/groupby/groupbyPipeline.test.ts
@@ -1,0 +1,424 @@
+import {
+  GassmaMissingArgumentError,
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../../errors/argument/argumentError";
+import { groupByFunc } from "../../../util/groupby/groupby";
+import {
+  getExtendedMockControllerUtil,
+  getNullableMockControllerUtil,
+} from "../../consts/mockControllerUtil";
+
+const extended = () => getExtendedMockControllerUtil();
+
+describe("groupBy は orderBy / skip / take をグループに適用する", () => {
+  test("take はグループ数を絞り、集計値を壊さない", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _count: { 名前: true },
+      orderBy: { 住所: "asc" },
+      take: 2,
+    });
+
+    expect(result).toEqual([
+      { 住所: "Kyoto", _count: { 名前: 2 } },
+      { 住所: "Osaka", _count: { 名前: 2 } },
+    ]);
+  });
+
+  test("skip はグループを飛ばし、集計値を壊さない", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _count: { 名前: true },
+      orderBy: { 住所: "asc" },
+      skip: 1,
+    });
+
+    expect(result).toEqual([
+      { 住所: "Osaka", _count: { 名前: 2 } },
+      { 住所: "Tokyo", _count: { 名前: 4 } },
+    ]);
+  });
+
+  test("orderBy はグループの並び順を決める", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _count: { 名前: true },
+      orderBy: { 住所: "desc" },
+    });
+
+    expect(result).toEqual([
+      { 住所: "Tokyo", _count: { 名前: 4 } },
+      { 住所: "Osaka", _count: { 名前: 2 } },
+      { 住所: "Kyoto", _count: { 名前: 2 } },
+    ]);
+  });
+
+  test("having の後に orderBy と take が適用される", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _avg: { 年齢: true },
+      having: { 年齢: { _avg: { lt: 40 } } },
+      orderBy: { 住所: "asc" },
+      take: 1,
+    });
+
+    expect(result).toEqual([{ 住所: "Kyoto", _avg: { 年齢: 36.5 } }]);
+  });
+});
+
+describe("groupBy は集計値でソートできる", () => {
+  test("_count でソートできる", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _count: { 名前: true },
+      orderBy: { _count: { 名前: "desc" } },
+    });
+
+    expect(result).toEqual([
+      { 住所: "Tokyo", _count: { 名前: 4 } },
+      { 住所: "Osaka", _count: { 名前: 2 } },
+      { 住所: "Kyoto", _count: { 名前: 2 } },
+    ]);
+  });
+
+  test("_sum でソートできる", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _sum: { 年齢: true },
+      orderBy: { _sum: { 年齢: "desc" } },
+    });
+
+    expect(result).toEqual([
+      { 住所: "Tokyo", _sum: { 年齢: 109 } },
+      { 住所: "Osaka", _sum: { 年齢: 87 } },
+      { 住所: "Kyoto", _sum: { 年齢: 73 } },
+    ]);
+  });
+
+  test("_avg でソートできる", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _avg: { 年齢: true },
+      orderBy: { _avg: { 年齢: "asc" } },
+    });
+
+    expect(result).toEqual([
+      { 住所: "Tokyo", _avg: { 年齢: 27.25 } },
+      { 住所: "Kyoto", _avg: { 年齢: 36.5 } },
+      { 住所: "Osaka", _avg: { 年齢: 43.5 } },
+    ]);
+  });
+
+  test("_max でソートできる", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _max: { 年齢: true },
+      orderBy: { _max: { 年齢: "desc" } },
+    });
+
+    expect(result).toEqual([
+      { 住所: "Osaka", _max: { 年齢: 52 } },
+      { 住所: "Kyoto", _max: { 年齢: 45 } },
+      { 住所: "Tokyo", _max: { 年齢: 31 } },
+    ]);
+  });
+
+  test("_min でソートできる", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _min: { 年齢: true },
+      orderBy: { _min: { 年齢: "asc" } },
+    });
+
+    expect(result).toEqual([
+      { 住所: "Tokyo", _min: { 年齢: 22 } },
+      { 住所: "Kyoto", _min: { 年齢: 28 } },
+      { 住所: "Osaka", _min: { 年齢: 35 } },
+    ]);
+  });
+
+  test("集計を選択していなくてもその集計でソートできる", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      orderBy: { _count: { 名前: "desc" } },
+    });
+
+    expect(result).toEqual([
+      { 住所: "Tokyo" },
+      { 住所: "Osaka" },
+      { 住所: "Kyoto" },
+    ]);
+  });
+
+  test("by に無い列の集計でもソートできる", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      orderBy: { _max: { 年齢: "desc" } },
+    });
+
+    expect(result).toEqual([
+      { 住所: "Osaka" },
+      { 住所: "Kyoto" },
+      { 住所: "Tokyo" },
+    ]);
+  });
+
+  test("配列で複合ソートできる", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _count: { 名前: true },
+      orderBy: [{ _count: { 名前: "desc" } }, { 住所: "asc" }],
+    });
+
+    expect(result).toEqual([
+      { 住所: "Tokyo", _count: { 名前: 4 } },
+      { 住所: "Kyoto", _count: { 名前: 2 } },
+      { 住所: "Osaka", _count: { 名前: 2 } },
+    ]);
+  });
+});
+
+describe("groupBy の orderBy は by に無い列を拒否する", () => {
+  test("by に無い列は単体でエラー", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        orderBy: { 年齢: "asc" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("配列の一部に by 外の列が混ざってもエラー", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        orderBy: [{ 住所: "asc" }, { 年齢: "asc" }],
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("存在しない列はエラー", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        orderBy: { 存在しない: "asc" },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("集計の中の存在しない列はエラー", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        orderBy: { _count: { 存在しない: "asc" } },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("_count の _all ではソートできない", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { _all: true },
+        orderBy: { _count: { _all: "desc" } },
+      }),
+    ).toThrow(GassmaUnknownArgumentError);
+  });
+
+  test("空の集計オブジェクトはエラー", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        orderBy: { _count: {} },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+
+  test("フィールドを指定しない集計はエラー", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        orderBy: { _count: "desc" },
+      }),
+    ).toThrow(GassmaInvalidValueError);
+  });
+});
+
+describe("groupBy の take / skip は orderBy を要求する", () => {
+  test("take 単体はエラー", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        take: 2,
+      }),
+    ).toThrow(GassmaMissingArgumentError);
+  });
+
+  test("take: 0 単体もエラー", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        take: 0,
+      }),
+    ).toThrow(GassmaMissingArgumentError);
+  });
+
+  test("skip 単体はエラー", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        skip: 3,
+      }),
+    ).toThrow(GassmaMissingArgumentError);
+  });
+
+  test("skip: 0 と take の組み合わせもエラー", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        skip: 0,
+        take: 2,
+      }),
+    ).toThrow(GassmaMissingArgumentError);
+  });
+
+  test("空の orderBy は orderBy として数えない", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        orderBy: {},
+        take: 2,
+      }),
+    ).toThrow(GassmaMissingArgumentError);
+  });
+
+  test("空配列の orderBy も orderBy として数えない", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        orderBy: [],
+        take: 2,
+      }),
+    ).toThrow(GassmaMissingArgumentError);
+  });
+
+  test("空エントリだけの orderBy 配列も orderBy として数えない", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        orderBy: [{}],
+        take: 2,
+      }),
+    ).toThrow(GassmaMissingArgumentError);
+  });
+
+  test("skip: 0 単体はエラーにならず全グループが返る", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _count: { 名前: true },
+      skip: 0,
+    });
+
+    expect(result).toEqual([
+      { 住所: "Tokyo", _count: { 名前: 4 } },
+      { 住所: "Osaka", _count: { 名前: 2 } },
+      { 住所: "Kyoto", _count: { 名前: 2 } },
+    ]);
+  });
+
+  test("非空エントリが1つでもあれば空エントリは無視される", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _count: { 名前: true },
+      orderBy: [{ 住所: "asc" }, {}],
+      take: 2,
+    });
+
+    expect(result).toEqual([
+      { 住所: "Kyoto", _count: { 名前: 2 } },
+      { 住所: "Osaka", _count: { 名前: 2 } },
+    ]);
+  });
+});
+
+describe("groupBy の負の take は反転順のまま返す", () => {
+  test("take: -1 は末尾のグループ", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _count: { 名前: true },
+      orderBy: { 住所: "asc" },
+      take: -1,
+    });
+
+    expect(result).toEqual([{ 住所: "Tokyo", _count: { 名前: 4 } }]);
+  });
+
+  test("take: -2 は反転順のまま2グループ", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _count: { 名前: true },
+      orderBy: { 住所: "asc" },
+      take: -2,
+    });
+
+    expect(result).toEqual([
+      { 住所: "Tokyo", _count: { 名前: 4 } },
+      { 住所: "Osaka", _count: { 名前: 2 } },
+    ]);
+  });
+
+  test("take: -2 と skip の組み合わせ", () => {
+    const result = groupByFunc(extended(), {
+      by: "住所",
+      _count: { 名前: true },
+      orderBy: { 住所: "asc" },
+      take: -2,
+      skip: 1,
+    });
+
+    expect(result).toEqual([
+      { 住所: "Osaka", _count: { 名前: 2 } },
+      { 住所: "Kyoto", _count: { 名前: 2 } },
+    ]);
+  });
+});
+
+describe("groupBy の orderBy は nulls 指定を受け付ける", () => {
+  test("nulls: first", () => {
+    const result = groupByFunc(getNullableMockControllerUtil(), {
+      by: "メモ",
+      _count: { カテゴリ: true },
+      orderBy: { メモ: { sort: "asc", nulls: "first" } },
+    });
+
+    expect(result).toEqual([
+      { メモ: null, _count: { カテゴリ: 1 } },
+      { メモ: "m1", _count: { カテゴリ: 1 } },
+      { メモ: "m2", _count: { カテゴリ: 1 } },
+    ]);
+  });
+
+  test("nulls: last", () => {
+    const result = groupByFunc(getNullableMockControllerUtil(), {
+      by: "メモ",
+      _count: { カテゴリ: true },
+      orderBy: { メモ: { sort: "asc", nulls: "last" } },
+    });
+
+    expect(result).toEqual([
+      { メモ: "m1", _count: { カテゴリ: 1 } },
+      { メモ: "m2", _count: { カテゴリ: 1 } },
+      { メモ: null, _count: { カテゴリ: 1 } },
+    ]);
+  });
+});

--- a/src/__test__/util/read/perCallReadCache.test.ts
+++ b/src/__test__/util/read/perCallReadCache.test.ts
@@ -222,6 +222,17 @@ describe("読み取り専用クエリの往復回数", () => {
     });
     expect(env.totalTrips()).toBe(3);
   });
+
+  test("groupBy は集計 orderBy と take 付きでも3往復", () => {
+    const env = buildEnv(selfRelations);
+    sheetOf(env.client, "Users").groupBy({
+      by: ["parentId"],
+      _count: { id: true },
+      orderBy: { _count: { id: "desc" } },
+      take: 1,
+    });
+    expect(env.totalTrips()).toBe(3);
+  });
 });
 
 describe("キャッシュの寿命(トップレベル呼び出しごとに破棄)", () => {

--- a/src/util/find/findUtil/orderBy.ts
+++ b/src/util/find/findUtil/orderBy.ts
@@ -2,11 +2,7 @@ import {
   GassmaInvalidValueError,
   GassmaUnknownArgumentError,
 } from "../../../errors/argument/argumentError";
-import type {
-  OrderBy,
-  SortOrderInput,
-  RelationOrderBy,
-} from "../../../types/coreTypes";
+import type { OrderBy, SortOrderInput } from "../../../types/coreTypes";
 import { isDict } from "../../other/isDict";
 import { isMissingValue } from "../../other/isMissingValue";
 
@@ -16,22 +12,20 @@ type ParsedOrderByEntry = [
   "first" | "last" | undefined,
 ];
 
-const isSortOrderInput = (
-  value: "asc" | "desc" | SortOrderInput | RelationOrderBy,
-): value is SortOrderInput => {
+const isSortOrderInput = (value: unknown): value is SortOrderInput => {
   // biome-ignore lint/suspicious/noPrototypeBuiltins: Object.hasOwn は ES2022 のため target ES2019 ではコンパイルできない
   return isDict(value) && Object.prototype.hasOwnProperty.call(value, "sort");
 };
 
-const isScalarDirection = (
-  value: "asc" | "desc" | SortOrderInput | RelationOrderBy,
-): value is "asc" | "desc" => {
+const isScalarDirection = (value: unknown): value is "asc" | "desc" => {
   return value === "asc" || value === "desc";
 };
 
 const SORT_INPUT_KEYS = ["sort", "nulls"];
 
-const parseOrderByEntry = (option: OrderBy): ParsedOrderByEntry => {
+const parseOrderByEntry = (
+  option: Record<string, unknown>,
+): ParsedOrderByEntry => {
   const [key, value] = Object.entries(option)[0];
   if (isSortOrderInput(value)) {
     Object.keys(value).forEach((inputKey) => {
@@ -108,15 +102,20 @@ const search = (
   return search(a, b, keys, cnt + 1);
 };
 
+const buildOrderByComparator = (orderByOptions: Record<string, unknown>[]) => {
+  const orderByOptionArray = orderByOptions.map(parseOrderByEntry);
+  return (a: Record<string, unknown>, b: Record<string, unknown>) =>
+    search(a, b, orderByOptionArray);
+};
+
 const orderByFunc = (
   result: Record<string, unknown>[],
   orderByOptions: OrderBy[],
 ) => {
   if (orderByOptions.length === 0) return result;
 
-  const orderByOptionArray = orderByOptions.map(parseOrderByEntry);
-  const sortedResult = result.sort((a, b) => search(a, b, orderByOptionArray));
+  const sortedResult = result.sort(buildOrderByComparator(orderByOptions));
   return sortedResult;
 };
 
-export { orderByFunc };
+export { orderByFunc, buildOrderByComparator };

--- a/src/util/groupby/groubyUtil/groupOrderBy.ts
+++ b/src/util/groupby/groubyUtil/groupOrderBy.ts
@@ -1,0 +1,74 @@
+import type { RowRecord, Select } from "../../../types/coreTypes";
+import { getAvg } from "../../aggregate/aggregateUtil/avg";
+import { getCount } from "../../aggregate/aggregateUtil/count";
+import { getMax } from "../../aggregate/aggregateUtil/max";
+import { getMin } from "../../aggregate/aggregateUtil/min";
+import { getSum } from "../../aggregate/aggregateUtil/sum";
+import { buildOrderByComparator } from "../../find/findUtil/orderBy";
+import { isDict } from "../../other/isDict";
+import type { GroupSortKey } from "./groupOrderByKeys";
+
+const AGGREGATE_GETTERS: Record<
+  string,
+  (rows: Record<string, any>[], select: Select) => unknown
+> = {
+  _avg: getAvg,
+  _count: getCount,
+  _max: getMax,
+  _min: getMin,
+  _sum: getSum,
+};
+
+const readAggregateField = (computed: unknown, field: string): unknown => {
+  if (isDict(computed)) return computed[field];
+  return null;
+};
+
+const aggregateSortValue = (
+  aggregate: string,
+  rows: RowRecord[],
+  field: string,
+): unknown => {
+  const computed = AGGREGATE_GETTERS[aggregate](rows, { [field]: true });
+  return readAggregateField(computed, field);
+};
+
+const buildSortRow = (
+  rows: RowRecord[],
+  result: Record<string, unknown>,
+  sortKeys: GroupSortKey[],
+): Record<string, unknown> => {
+  const sortRow: Record<string, unknown> = {};
+
+  sortKeys.forEach((sortKey) => {
+    sortRow[sortKey.key] =
+      sortKey.aggregate === null
+        ? result[sortKey.field]
+        : aggregateSortValue(sortKey.aggregate, rows, sortKey.field);
+  });
+
+  return sortRow;
+};
+
+const orderGroups = (
+  groups: RowRecord[][],
+  results: Record<string, unknown>[],
+  sortKeys: GroupSortKey[],
+): Record<string, unknown>[] => {
+  if (sortKeys.length === 0) return results;
+
+  const comparator = buildOrderByComparator(
+    sortKeys.map((sortKey) => ({ [sortKey.key]: sortKey.value })),
+  );
+
+  const decoratedGroups = results.map((result, index) => ({
+    result: result,
+    sortRow: buildSortRow(groups[index], result, sortKeys),
+  }));
+
+  decoratedGroups.sort((a, b) => comparator(a.sortRow, b.sortRow));
+
+  return decoratedGroups.map((decoratedGroup) => decoratedGroup.result);
+};
+
+export { orderGroups };

--- a/src/util/groupby/groubyUtil/groupOrderByKeys.ts
+++ b/src/util/groupby/groubyUtil/groupOrderByKeys.ts
@@ -1,0 +1,95 @@
+import {
+  GassmaInvalidValueError,
+  GassmaUnknownArgumentError,
+} from "../../../errors/argument/argumentError";
+import type { OrderBy } from "../../../types/coreTypes";
+import type { GassmaControllerUtil } from "../../../types/gassmaControllerUtilType";
+import { getTitle } from "../../core/getTitle";
+import { isDict } from "../../other/isDict";
+
+const AGGREGATE_KEYS = ["_avg", "_count", "_max", "_min", "_sum"];
+
+type GroupSortKey = {
+  key: string;
+  value: unknown;
+  field: string;
+  aggregate: string | null;
+};
+
+const buildAggregateSortKeys = (
+  aggregate: string,
+  value: unknown,
+  availableFields: string[],
+): GroupSortKey[] => {
+  if (!isDict(value)) {
+    throw new GassmaInvalidValueError(aggregate, "an object of fields");
+  }
+
+  const fields = Object.keys(value);
+  if (fields.length === 0) {
+    throw new GassmaInvalidValueError(aggregate, "at least one field");
+  }
+
+  return fields.map((field) => {
+    if (!availableFields.includes(field)) {
+      throw new GassmaUnknownArgumentError(field, availableFields);
+    }
+    return {
+      key: `a:${aggregate}:${field}`,
+      value: value[field],
+      field: field,
+      aggregate: aggregate,
+    };
+  });
+};
+
+const buildFieldSortKey = (
+  field: string,
+  value: unknown,
+  by: string[],
+): GroupSortKey => {
+  if (!by.includes(field)) {
+    throw new GassmaUnknownArgumentError(field, [...by, ...AGGREGATE_KEYS]);
+  }
+  return { key: `f:${field}`, value: value, field: field, aggregate: null };
+};
+
+// Prisma 実測: by に無い列は orderBy に書けないが、集計の中の列は by に無くてよい
+const buildGroupSortKeys = (
+  orderByArr: Record<string, unknown>[],
+  by: string[],
+  getAvailableFields: () => string[],
+): GroupSortKey[] => {
+  return orderByArr.flatMap((entry) => {
+    if (!isDict(entry)) {
+      throw new GassmaInvalidValueError("orderBy", '"asc" | "desc"');
+    }
+
+    return Object.keys(entry).flatMap((key) =>
+      AGGREGATE_KEYS.includes(key)
+        ? buildAggregateSortKeys(key, entry[key], getAvailableFields())
+        : [buildFieldSortKey(key, entry[key], by)],
+    );
+  });
+};
+
+const toOrderByArray = (
+  orderBy: OrderBy | OrderBy[] | null | undefined,
+): Record<string, unknown>[] => {
+  if (orderBy === null || orderBy === undefined) return [];
+  return Array.isArray(orderBy) ? orderBy : [orderBy];
+};
+
+const getAvailableFields = (
+  gassmaControllerUtil: GassmaControllerUtil,
+): string[] => {
+  const ignoredFields =
+    gassmaControllerUtil.whereValidation?.ignoredFields ?? [];
+
+  return getTitle(gassmaControllerUtil).filter(
+    (title) => !ignoredFields.includes(title),
+  );
+};
+
+export { buildGroupSortKeys, toOrderByArray, getAvailableFields };
+export type { GroupSortKey };

--- a/src/util/groupby/groubyUtil/groupPagination.ts
+++ b/src/util/groupby/groubyUtil/groupPagination.ts
@@ -1,0 +1,36 @@
+import { GassmaMissingArgumentError } from "../../../errors/argument/argumentError";
+import { applySkipTake } from "../../find/findUtil/applySkipTake";
+
+const hasEffectiveOrderBy = (orderByArr: Record<string, unknown>[]): boolean =>
+  orderByArr.some(
+    (entry) =>
+      entry !== null &&
+      typeof entry === "object" &&
+      Object.keys(entry).length > 0,
+  );
+
+// Prisma 実測: take があるか skip が 0 以外なら orderBy が必須。空の orderBy は数えない
+const ensurePaginationOrderBy = (
+  orderByArr: Record<string, unknown>[],
+  take: number | null | undefined,
+  skip: number | null | undefined,
+): void => {
+  if (typeof take !== "number" && !skip) return;
+  if (hasEffectiveOrderBy(orderByArr)) return;
+
+  throw new GassmaMissingArgumentError("orderBy");
+};
+
+// Prisma 実測: groupBy の負の take は findMany と違い、反転した並びのまま返す
+const applyGroupSkipTake = (
+  results: Record<string, unknown>[],
+  skip: number | null | undefined,
+  take: number | null | undefined,
+): Record<string, unknown>[] => {
+  const backward = typeof take === "number" && take < 0;
+  const ordered = backward ? [...results].reverse() : results;
+
+  return applySkipTake(ordered, skip, backward ? -take : take);
+};
+
+export { ensurePaginationOrderBy, applyGroupSkipTake };

--- a/src/util/groupby/groupby.ts
+++ b/src/util/groupby/groupby.ts
@@ -14,6 +14,16 @@ import {
 } from "../validate/buildValidatedAggregateSelect";
 import { validateFiniteNumberOption } from "../validate/validateFiniteNumberOption";
 import { byClassification } from "./groubyUtil/by";
+import { orderGroups } from "./groubyUtil/groupOrderBy";
+import {
+  buildGroupSortKeys,
+  getAvailableFields,
+  toOrderByArray,
+} from "./groubyUtil/groupOrderByKeys";
+import {
+  applyGroupSkipTake,
+  ensurePaginationOrderBy,
+} from "./groubyUtil/groupPagination";
 import { havingFilter } from "./groubyUtil/having";
 
 const groupByFunc = (
@@ -21,8 +31,9 @@ const groupByFunc = (
   groupByData: GroupByData,
 ) => {
   const where = groupByData.where || {};
-  const orderBy = groupByData.orderBy || null;
+  const orderByArr = toOrderByArray(groupByData.orderBy);
   const take = "take" in groupByData ? groupByData.take : null;
+  validateFiniteNumberOption("take", take);
   validateFiniteNumberOption("skip", groupByData.skip);
   const skip = groupByData.skip || null;
   const validateFieldSelect = (value: Select | null | undefined) =>
@@ -42,13 +53,14 @@ const groupByFunc = (
   const by = Array.isArray(groupByData.by) ? groupByData.by : [groupByData.by];
   const having = groupByData.having || null;
 
+  const sortKeys = buildGroupSortKeys(orderByArr, by, () =>
+    getAvailableFields(gassmaControllerUtil),
+  );
+  ensurePaginationOrderBy(orderByArr, take, skip);
+
   const findData: FindData = {
     where: where,
   };
-
-  if (orderBy) findData.orderBy = orderBy;
-  if (take !== null && take !== undefined) findData.take = take;
-  if (skip) findData.skip = skip;
 
   const findedRows = findManyFunc(gassmaControllerUtil, findData);
 
@@ -90,7 +102,13 @@ const groupByFunc = (
     }
   });
 
-  return groupByResult;
+  const orderedResult = orderGroups(
+    byClassificationed,
+    groupByResult,
+    sortKeys,
+  );
+
+  return applyGroupSkipTake(orderedResult, skip, take);
 };
 
 export { groupByFunc };


### PR DESCRIPTION
**`groupBy` に `take` を渡すと、集計値そのものが壊れていました。**

```
データ: A×3行, B×1行, C×2行

修正前  groupBy({ by: ["name"], _count: { id: true }, take: 2 })
        → [{ name: "A", _count: { id: 2 } }]
```

グループが1つしか返らないだけでなく、**A の件数が 3 ではなく 2** になっています。エラーは出ません。

原因は `orderBy` / `take` / `skip` を**下層の `findManyFunc` にそのまま渡していた**ことです。**グループ化の前に行が削られる**ので、3行目の A も B も C も存在しないことになって数え直されます。

```
修正前  where → orderBy → take/skip → グループ化 → having
修正後  where → グループ化 → having → orderBy → skip → take
```

## Prisma の実測（発行 SQL 付き・私も独立に確認）

| 入力 | Prisma | SQL |
|---|---|---|
| `take` / `skip` **単独** | **エラー** | — |
| `take: 2` + `orderBy` | 先頭2**グループ** | `GROUP BY … ORDER BY … LIMIT ?` |
| `orderBy: { _count: { label: "desc" } }` | 件数順 | `ORDER BY COUNT(label) DESC` |
| `orderBy` に `by` 外の列 | **エラー**「Missing fields: col」 | — |
| 複合 `[{_count},{label}]` | 複合ソート | `ORDER BY COUNT(label) DESC, label ASC` |
| `having` + `orderBy` + `take` | 併用可 | `GROUP BY … HAVING … ORDER BY … LIMIT` |

境界も詰めました。**`skip: 0` 単独だけは通り、`take: 0` 単独はエラー**。`orderBy: {}` や `[]` は「指定なし」として扱われエラー。`_count: { _all: ... }` でのソートは不可。**集計の中の列は `by` に無くてよく、結果に選択していなくてもソートできます。**

**`take` の負数の扱いが `findMany` と違います。**

```
groupBy  orderBy asc, take:-2   → [C, B]     ← 反転順のまま
findMany orderBy asc, take:-2   → [C, C]     ← 正順に戻す
```

実装で作り分けています。

## 修正前・修正後（私の側で実測）

| 入力 | 修正前 | 修正後 |
|---|---|---|
| `take: 2` 単独 | **A:2**（1グループ・件数破損） | `Argument \`orderBy\` is missing.` |
| `skip: 1` 単独 | **A:2, B:1, C:2**（A が破損） | 同上 |
| `take: 2` + `orderBy name asc` | **1グループのみ** | **A:3, B:1** |
| `orderBy: { _count: { id: "desc" } }` | **throw**（`Unknown argument 'id'`） | A:3, C:2, B:1 |
| `orderBy: { _sum: { age: "desc" } }` | **throw** | C:110, A:60, B:40 |
| `orderBy` に `by` 外の列 | **黙って無視され全件** | `Unknown argument \`age\`. Did you mean \`name\`?` |
| 複合 `[{_count desc},{name asc}]` | **throw** | A, C, B |
| `take: -2` + `orderBy asc` | 件数破損 | **C:2, B:1**（反転のまま） |
| `having` + `orderBy` + `take: 1` | **`[]`（黙って空）** | A:3 |

`_avg` / `_max` / `_min` でのソートも動きます。

## 実装

集計ソートの値は**既存の `getCount` / `getSum` / `getAvg` / `getMax` / `getMin`** をそのグループの行に対して呼んで算出、`skip`/`take` は**既存の `applySkipTake`** を再利用しています（`GassmaSkipNegativeError` や非有限値の検証を落とさないため）。

`orderBy` の**検証はシートを読む前**に走るので、不正な `orderBy` はシートを読まずに落ちます。

**新規エラークラスはゼロ**です（公開シンボル57・エラークラス47で不変）。

| ファイル | 内容 |
|---|---|
| `groupby.ts` | 配線（114行） |
| `groubyUtil/groupOrderByKeys.ts` **新規** | `orderBy` キーの検証と平坦化（95行） |
| `groubyUtil/groupOrderBy.ts` **新規** | グループ単位のソート（74行） |
| `groubyUtil/groupPagination.ts` **新規** | `orderBy` 必須判定と skip/take（36行） |
| `findUtil/orderBy.ts` | 比較関数を `buildOrderByComparator` として切り出し（**挙動不変**） |

## `orderBy` 無しの `take` / `skip` はエラーにしました

Prisma に合わせています。「グループの出現順に適用する」案も検討しましたが、**シート出現順という gassma 固有の暗黙順序に依存し、Prisma から移ってきた利用者が気づかないまま別の結果を得る**ことになります。**今回潰したのと同じ種類の失敗**です。

メッセージは既存の `GassmaMissingArgumentError` で **`Argument \`orderBy\` is missing.`**。Prisma の「Missing fields: id」（利用者は `orderBy` を書いていないのに）よりは分かりやすいですが、**「take/skip を使うときは orderBy が要る」という理由までは伝えません**。専用エラークラスを足せば理想的ですが**公開シンボルが増える仕様追加なので実装せず判断を仰ぎます**。

## `aggregate` は無変更でよいと確認しました

Prisma の `aggregate` は `take`/`skip` を**サブクエリの LIMIT/OFFSET = 行に適用**してから集計します（`SELECT COUNT(...) FROM (SELECT … LIMIT ? OFFSET ?)`）。`orderBy` 無しでもエラーになりません。**gassma の現状と一致**します。

## 検証結果

- `npm test`: **3,099件 全 green**（3,065 → +34）
- **往復契約テスト3スイート32件 green、期待値は無変更**。`take`/`skip` を下層に渡さなくなっても、**読み込みは元々シート全体**なので往復数は変わりません。これを固定するテストを `perCallReadCache` に1件追加（**集計 orderBy と take 付きでも3往復**）
- `tsc --noEmit` / lint（警告48件・ベースラインと同数） / format / `verify:bundle` pass
- 新規の `as` **0**・`for...of` **0**・`instanceof` **0**、全ファイル200行以内

### 変更した既存テスト5件（すべて「行に適用」を前提にしていたもの）

| テスト | 変更 |
|---|---|
| `should work with orderBy` | `orderBy: { 年齢: desc }` が `by` 外なので新仕様では拒否。`{ 住所: "desc" }` に変更し**順序を検証**する `toEqual` に（旧テストは順不同比較で「orderBy は並びに影響しない」という**誤ったコメント付き**だった） |
| `should work with skip` | `orderBy` を追加。「Tokyo が3件に化ける」→「Tokyo4 の1グループ」 |
| `should work with take` | 同上。**件数が壊れないことの回帰テスト**に |
| `should handle take=0` | `orderBy` を追加。結果 `[]` は不変 |
| `should handle skip exceeding total records` | 名前を `…total groups` に（絞る対象が行→グループ） |

バグを説明していた古いコメント3行（`Take should limit input data before grouping` 等）も削除しています。`NaN`/`null` の `take`/`skip` を拒否する既存テストは**無変更で green**です（非有限・null の検証を `orderBy` 必須チェックより先に置いたため）。

## 判断が必要な残件

**1. エラーメッセージ。** 専用エラークラスを足すか、既存流用のままか（上記）。

**2. `orderBy` の1エントリに複数キー**（`{ 住所: "asc", 職業: "desc" }`）。Prisma はエラー、gassma は既存の `parseOrderByEntry` が**先頭キーだけ見る**仕様です。**`findMany` と共通の既存差分**なので今回は触っていません。

**3. cli の型追随が必要です**（調査済み）。現状 `GroupByData` は `Omit<AggregateData, "cursor">` で **`findMany` と同じ `OrderBy` 型を共有**しており、

- `_avg` / `_sum` / `_min` / `_max` キーが**存在しない**（今回動くようになった集計ソートが型で書けない）
- `_count` は**リレーション件数用**で意味が違う
- **`by` 外の列やリレーションでのソートが型的に通ってしまう**（実行時は throw するようになった）

`OrderByWithAggregation` 相当の新規ジェネレータ追加 + `GroupByData` での `orderBy` 再宣言が要ります。`_avg`/`_sum` は数値列限定（既存の `isNumberColumn` 流用可）。`take`/`skip` の型自体は変更不要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)