### PR TITLE
feat: groupBy が orderBy を要求する理由を伝える

### DIFF
--- a/src/__test__/errors/errorPrototypeChain.test.ts
+++ b/src/__test__/errors/errorPrototypeChain.test.ts
@@ -13,7 +13,10 @@ import {
   GassmaFindSelectOmitConflictError,
   NotFoundError,
 } from "../../errors/find/findError";
-import { GassmaGroupByHavingDontWriteByError } from "../../errors/groupBy/groupByError";
+import {
+  GassmaGroupByHavingDontWriteByError,
+  GassmaGroupByOrderByRequiredError,
+} from "../../errors/groupBy/groupByError";
 import { NestedWriteTargetNotFoundError } from "../../errors/relation/nestedWriteError";
 import {
   GassmaIncludeSelectConflictError,
@@ -68,6 +71,11 @@ const cases: ErrorCase[] = [
     className: "GassmaGroupByHavingDontWriteByError",
     ctor: GassmaGroupByHavingDontWriteByError,
     create: () => new GassmaGroupByHavingDontWriteByError(),
+  },
+  {
+    className: "GassmaGroupByOrderByRequiredError",
+    ctor: GassmaGroupByOrderByRequiredError,
+    create: () => new GassmaGroupByOrderByRequiredError("take"),
   },
   {
     className: "GassmaFindSelectOmitConflictError",

--- a/src/__test__/errors/groupByOrderByRequiredError.test.ts
+++ b/src/__test__/errors/groupByOrderByRequiredError.test.ts
@@ -1,0 +1,40 @@
+import { GassmaGroupByOrderByRequiredError } from "../../errors/groupBy/groupByError";
+
+describe("GassmaGroupByOrderByRequiredError", () => {
+  test("take だけを指定したときのメッセージ", () => {
+    const error = new GassmaGroupByOrderByRequiredError("take");
+
+    expect(error.message).toBe(
+      "groupBy requires `orderBy` when using `take`. Specify `orderBy` with at least one field, or remove `take`.",
+    );
+    expect(error.name).toBe("GassmaGroupByOrderByRequiredError");
+  });
+
+  test("skip だけを指定したときのメッセージ", () => {
+    const error = new GassmaGroupByOrderByRequiredError("skip");
+
+    expect(error.message).toBe(
+      "groupBy requires `orderBy` when using `skip`. Specify `orderBy` with at least one field, or remove `skip`.",
+    );
+  });
+
+  test("take と skip の両方を指定したときのメッセージ", () => {
+    const error = new GassmaGroupByOrderByRequiredError("take", "skip");
+
+    expect(error.message).toBe(
+      "groupBy requires `orderBy` when using `take` and `skip`. Specify `orderBy` with at least one field, or remove `take` and `skip`.",
+    );
+  });
+
+  test("Error を継承している", () => {
+    const error = new GassmaGroupByOrderByRequiredError("take");
+
+    expect(Object.prototype.toString.call(error)).toBe("[object Error]");
+  });
+
+  test("toThrow(コンストラクタ) でキャッチできる", () => {
+    expect(() => {
+      throw new GassmaGroupByOrderByRequiredError("skip");
+    }).toThrow(GassmaGroupByOrderByRequiredError);
+  });
+});

--- a/src/__test__/util/groupby/groupbyPipeline.test.ts
+++ b/src/__test__/util/groupby/groupbyPipeline.test.ts
@@ -1,8 +1,8 @@
 import {
-  GassmaMissingArgumentError,
   GassmaInvalidValueError,
   GassmaUnknownArgumentError,
 } from "../../../errors/argument/argumentError";
+import { GassmaGroupByOrderByRequiredError } from "../../../errors/groupBy/groupByError";
 import { groupByFunc } from "../../../util/groupby/groupby";
 import {
   getExtendedMockControllerUtil,
@@ -255,7 +255,7 @@ describe("groupBy の take / skip は orderBy を要求する", () => {
         _count: { 名前: true },
         take: 2,
       }),
-    ).toThrow(GassmaMissingArgumentError);
+    ).toThrow(GassmaGroupByOrderByRequiredError);
   });
 
   test("take: 0 単体もエラー", () => {
@@ -265,7 +265,7 @@ describe("groupBy の take / skip は orderBy を要求する", () => {
         _count: { 名前: true },
         take: 0,
       }),
-    ).toThrow(GassmaMissingArgumentError);
+    ).toThrow(GassmaGroupByOrderByRequiredError);
   });
 
   test("skip 単体はエラー", () => {
@@ -275,7 +275,7 @@ describe("groupBy の take / skip は orderBy を要求する", () => {
         _count: { 名前: true },
         skip: 3,
       }),
-    ).toThrow(GassmaMissingArgumentError);
+    ).toThrow(GassmaGroupByOrderByRequiredError);
   });
 
   test("skip: 0 と take の組み合わせもエラー", () => {
@@ -286,7 +286,7 @@ describe("groupBy の take / skip は orderBy を要求する", () => {
         skip: 0,
         take: 2,
       }),
-    ).toThrow(GassmaMissingArgumentError);
+    ).toThrow(GassmaGroupByOrderByRequiredError);
   });
 
   test("空の orderBy は orderBy として数えない", () => {
@@ -297,7 +297,7 @@ describe("groupBy の take / skip は orderBy を要求する", () => {
         orderBy: {},
         take: 2,
       }),
-    ).toThrow(GassmaMissingArgumentError);
+    ).toThrow(GassmaGroupByOrderByRequiredError);
   });
 
   test("空配列の orderBy も orderBy として数えない", () => {
@@ -308,7 +308,7 @@ describe("groupBy の take / skip は orderBy を要求する", () => {
         orderBy: [],
         take: 2,
       }),
-    ).toThrow(GassmaMissingArgumentError);
+    ).toThrow(GassmaGroupByOrderByRequiredError);
   });
 
   test("空エントリだけの orderBy 配列も orderBy として数えない", () => {
@@ -319,7 +319,57 @@ describe("groupBy の take / skip は orderBy を要求する", () => {
         orderBy: [{}],
         take: 2,
       }),
-    ).toThrow(GassmaMissingArgumentError);
+    ).toThrow(GassmaGroupByOrderByRequiredError);
+  });
+
+  test("take 単体のときは take だけが文言に出る", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        take: 2,
+      }),
+    ).toThrow(
+      "groupBy requires `orderBy` when using `take`. Specify `orderBy` with at least one field, or remove `take`.",
+    );
+  });
+
+  test("skip 単体のときは skip だけが文言に出る", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        skip: 3,
+      }),
+    ).toThrow(
+      "groupBy requires `orderBy` when using `skip`. Specify `orderBy` with at least one field, or remove `skip`.",
+    );
+  });
+
+  test("take と skip の両方のときは両方が文言に出る", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        take: 2,
+        skip: 1,
+      }),
+    ).toThrow(
+      "groupBy requires `orderBy` when using `take` and `skip`. Specify `orderBy` with at least one field, or remove `take` and `skip`.",
+    );
+  });
+
+  test("skip: 0 と take の組み合わせでは引き金の take だけが文言に出る", () => {
+    expect(() =>
+      groupByFunc(extended(), {
+        by: "住所",
+        _count: { 名前: true },
+        skip: 0,
+        take: 2,
+      }),
+    ).toThrow(
+      "groupBy requires `orderBy` when using `take`. Specify `orderBy` with at least one field, or remove `take`.",
+    );
   });
 
   test("skip: 0 単体はエラーにならず全グループが返る", () => {

--- a/src/errors/groupBy/groupByError.ts
+++ b/src/errors/groupBy/groupByError.ts
@@ -7,4 +7,17 @@ class GassmaGroupByHavingDontWriteByError extends Error {
   }
 }
 
-export { GassmaGroupByHavingDontWriteByError };
+class GassmaGroupByOrderByRequiredError extends Error {
+  constructor(...paginationArguments: string[]) {
+    const list = paginationArguments.map((name) => `\`${name}\``).join(" and ");
+    super(
+      `groupBy requires \`orderBy\` when using ${list}. Specify \`orderBy\` with at least one field, or remove ${list}.`,
+    );
+    this.name = "GassmaGroupByOrderByRequiredError";
+  }
+}
+
+export {
+  GassmaGroupByHavingDontWriteByError,
+  GassmaGroupByOrderByRequiredError,
+};

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -666,6 +666,9 @@ declare namespace Gassma {
   class GassmaGroupByHavingDontWriteByError extends Error {
     constructor();
   }
+  class GassmaGroupByOrderByRequiredError extends Error {
+    constructor(...paginationArguments: string[]);
+  }
   class GassmaAggregateMaxError extends Error {
     constructor();
   }

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -98,6 +98,8 @@ export const GassmaInValidColumnValueError =
 
 export const GassmaGroupByHavingDontWriteByError =
   groupByErrors.GassmaGroupByHavingDontWriteByError;
+export const GassmaGroupByOrderByRequiredError =
+  groupByErrors.GassmaGroupByOrderByRequiredError;
 
 export const GassmaAggregateMaxError = aggregateErrors.GassmaAggregateMaxError;
 export const GassmaAggregateMinError = aggregateErrors.GassmaAggregateMinError;

--- a/src/util/groupby/groubyUtil/groupPagination.ts
+++ b/src/util/groupby/groubyUtil/groupPagination.ts
@@ -1,4 +1,4 @@
-import { GassmaMissingArgumentError } from "../../../errors/argument/argumentError";
+import { GassmaGroupByOrderByRequiredError } from "../../../errors/groupBy/groupByError";
 import { applySkipTake } from "../../find/findUtil/applySkipTake";
 
 const hasEffectiveOrderBy = (orderByArr: Record<string, unknown>[]): boolean =>
@@ -9,16 +9,25 @@ const hasEffectiveOrderBy = (orderByArr: Record<string, unknown>[]): boolean =>
       Object.keys(entry).length > 0,
   );
 
+const usedPaginationArguments = (
+  take: number | null | undefined,
+  skip: number | null | undefined,
+): string[] => [
+  ...(typeof take === "number" ? ["take"] : []),
+  ...(skip ? ["skip"] : []),
+];
+
 // Prisma 実測: take があるか skip が 0 以外なら orderBy が必須。空の orderBy は数えない
 const ensurePaginationOrderBy = (
   orderByArr: Record<string, unknown>[],
   take: number | null | undefined,
   skip: number | null | undefined,
 ): void => {
-  if (typeof take !== "number" && !skip) return;
+  const used = usedPaginationArguments(take, skip);
+  if (used.length === 0) return;
   if (hasEffectiveOrderBy(orderByArr)) return;
 
-  throw new GassmaMissingArgumentError("orderBy");
+  throw new GassmaGroupByOrderByRequiredError(...used);
 };
 
 // Prisma 実測: groupBy の負の take は findMany と違い、反転した並びのまま返す


### PR DESCRIPTION
#226 で `groupBy` の `take` / `skip` に `orderBy` を必須にしましたが、**そのエラーが「書き忘れ」と区別できませんでした。**

```
Argument `by` is missing.       ← by は常に必須
Argument `where` is missing.    ← where は常に必須
Argument `orderBy` is missing.  ← orderBy は必須ではない。take/skip を書いたから要るようになった
```

**3つ目だけが「条件付きの必須」**です。`orderBy` を使うつもりが無い利用者は、**`take` を消せば直ることに気づけません。**

## 変更後

```
groupBy requires `orderBy` when using `take`.
Specify `orderBy` with at least one field, or remove `take`.
```

**引き金になった引数だけを名指しします**（私の側でも実測）。

```
take のみ        → when using `take`
skip のみ        → when using `skip`
両方            → when using `take` and `skip`
skip: 0 + take  → when using `take`      ← skip: 0 は引き金ではないので出ない
```

前半で**無条件必須ではない**ことを示し、後半で**直し方2通り**（`orderBy` を足す / `take` を消す）を出しています。

**Prisma の文言は真似していません。**

```
Every field used for orderBy must be included in the by-arguments of the query.
Missing fields: id
```

利用者が書いていない `orderBy` と `id` に言及していて、内部事情が漏れています。

## クラス名

**`GassmaGroupByOrderByRequiredError`**

`GassmaAggregateSelectionRequiredError`（`aggregate` の「条件付きで何かが要る」エラー）と同じ **「Gassma + 領域 + 何が + RequiredError」** に揃えました。領域接頭辞は既存の `GassmaGroupByHavingDontWriteByError` と同じです。「Specify … with at least one field.」も `GassmaAggregateSelectionRequiredError` の言い回しを踏襲しています。

## シグネチャを可変長引数にした理由

```ts
constructor(...paginationArguments: string[])
```

当初 `string[]` を1つ受ける形にしたところ、**`verify:bundle` が落ちました**。あの検証は全エラークラスを `new Ctor("arg1", "arg2", …)` で生成するため、配列前提だと `map is not a function` になります。

既存の `GassmaUnknownArgumentError` は `Array.isArray` の防御分岐でこれを回避していますが、**可変長にすれば防御コードもデッドブランチも無しで検証を素通しできる**ので、こちらを採りました。

## 公開面への登録

**3箇所すべてに登録済み**です（1つでも漏れると `instanceof` で捕まえられません。#156 で実際に起きた不具合です）。

```
bundle 検証 OK: 公開シンボル 58 件 (トップレベル宣言 58 件、エラークラス 48 件)
```

- `src/errors/groupBy/groupByError.ts`（クラス本体・23行）
- `src/publicApi.ts`
- `src/index.d.ts`

## 検証結果

- `npm test`: **3,111件 全 green**（3,099 → +12）
- **往復契約テスト期待値無変更で green**
- `tsc --noEmit` / lint（警告48件・ベースラインと同数） / format pass

**変更した既存テストは7件**で、いずれも `toThrow(GassmaMissingArgumentError)` → `toThrow(GassmaGroupByOrderByRequiredError)` の**クラス名だけ**です。入力も「throw すること」自体も変えていません（#226 で追加したテスト群）。

新規12件は、エラークラス単体の文言5件（**TDD で最初に赤を確認**）、prototype チェーン3件、`groupBy` 経由の文言検証4件です。

## cli 側のミラーに必要なもの

`errorClassDefinitions.ts` の `GassmaGroupByHavingDontWriteByError` の直後に、本体の `index.d.ts` と同じ並びで追加が必要です。

```ts
{
  name: "GassmaGroupByOrderByRequiredError",
  extends: "Error",
  params: "...paginationArguments: string[]",
},
```

**`params` が可変長である点が既存エントリと異なる**ので、生成テンプレートがそのまま `constructor(...)` に埋めるだけかは確認が要ります。

## 判断が必要で実装しなかった点

**`GassmaUnknownArgumentError` の `Array.isArray` 防御分岐**は、可変長化すれば不要になる同種の回避策ですが、**依頼範囲外なので触っていません。**

リファレンス（`エラー一覧.md`）への追記も範囲外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)