### PR TITLE
feat: add $get/$set/$syncAutoincrement counter API

### DIFF
--- a/src/__test__/errors/errorPrototypeChain.test.ts
+++ b/src/__test__/errors/errorPrototypeChain.test.ts
@@ -7,6 +7,10 @@ import {
   GassmaAggregateSumTypeError,
   GassmaAggregateTypeError,
 } from "../../errors/aggregate/aggregateError";
+import {
+  GassmaAutoincrementInTransactionError,
+  GassmaAutoincrementNotConfiguredError,
+} from "../../errors/autoincrement/autoincrementError";
 import { GassmaInValidColumnValueError } from "../../errors/changeSettings/changeSettingsError";
 import {
   GassmaFindFirstTakeError,
@@ -137,6 +141,18 @@ const cases: ErrorCase[] = [
     className: "GassmaAggregateAvgTypeError",
     ctor: GassmaAggregateAvgTypeError,
     create: () => new GassmaAggregateAvgTypeError(),
+  },
+  {
+    className: "GassmaAutoincrementNotConfiguredError",
+    ctor: GassmaAutoincrementNotConfiguredError,
+    create: () =>
+      new GassmaAutoincrementNotConfiguredError("Users", "name", ["id"]),
+  },
+  {
+    className: "GassmaAutoincrementInTransactionError",
+    ctor: GassmaAutoincrementInTransactionError,
+    create: () =>
+      new GassmaAutoincrementInTransactionError("$setAutoincrement"),
   },
 ];
 

--- a/src/__test__/util/core/getColumnValues.test.ts
+++ b/src/__test__/util/core/getColumnValues.test.ts
@@ -1,0 +1,85 @@
+import type { GassmaControllerUtil } from "../../../types/gassmaControllerUtilType";
+import { getColumnValues } from "../../../util/core/getColumnValues";
+
+type RangeCall = [number, number, number, number];
+
+const makeSheet = (data: unknown[][]) => {
+  const calls: RangeCall[] = [];
+  const sheet = {
+    getName: () => "Users",
+    getLastRow: () => data.length,
+    getLastColumn: () => (data[0] ? data[0].length : 0),
+    getRange: (row: number, col: number, numRows: number, numCols: number) => {
+      calls.push([row, col, numRows, numCols]);
+      return {
+        getValues: () =>
+          data
+            .slice(row - 1, row - 1 + numRows)
+            .map((r) => r.slice(col - 1, col - 1 + numCols)),
+      };
+    },
+  };
+  return { sheet, calls };
+};
+
+const utilOf = (
+  sheet: ReturnType<typeof makeSheet>["sheet"],
+  endColumnNumber: number,
+  fieldMapping?: Record<string, string>,
+): GassmaControllerUtil => {
+  const util: GassmaControllerUtil = {
+    sheet: sheet as any,
+    startRowNumber: 1,
+    startColumnNumber: 1,
+    endColumnNumber,
+  };
+  if (fieldMapping) util.fieldMapping = fieldMapping;
+  return util;
+};
+
+const rows: unknown[][] = [
+  ["id", "name", "age"],
+  [1, "Alice", 20],
+  [2, "Bob", 30],
+];
+
+describe("getColumnValues", () => {
+  it("指定フィールドの列の値を返す", () => {
+    const { sheet } = makeSheet(rows);
+    expect(getColumnValues(utilOf(sheet, 3), "id")).toEqual([1, 2]);
+  });
+
+  it("見出し行と対象の1列しか読まない", () => {
+    const { sheet, calls } = makeSheet(rows);
+    getColumnValues(utilOf(sheet, 3), "age");
+    expect(calls).toEqual([
+      [1, 1, 1, 3],
+      [2, 3, 2, 1],
+    ]);
+  });
+
+  it("存在しないフィールドなら null を返し列は読まない", () => {
+    const { sheet, calls } = makeSheet(rows);
+    expect(getColumnValues(utilOf(sheet, 3), "nope")).toBeNull();
+    expect(calls).toEqual([[1, 1, 1, 3]]);
+  });
+
+  it("データ行が無ければ空配列", () => {
+    const { sheet } = makeSheet([["id", "name", "age"]]);
+    expect(getColumnValues(utilOf(sheet, 3), "id")).toEqual([]);
+  });
+
+  it("map のコード名で列を解決する", () => {
+    const { sheet } = makeSheet(rows);
+    expect(
+      getColumnValues(utilOf(sheet, 3, { userAge: "age" }), "userAge"),
+    ).toEqual([20, 30]);
+  });
+
+  it("map 適用後はシート上の生の列名では解決しない", () => {
+    const { sheet } = makeSheet(rows);
+    expect(
+      getColumnValues(utilOf(sheet, 3, { userAge: "age" }), "age"),
+    ).toBeNull();
+  });
+});

--- a/src/__test__/util/defaults/autoincrementApi.test.ts
+++ b/src/__test__/util/defaults/autoincrementApi.test.ts
@@ -1,0 +1,318 @@
+import { GassmaInvalidValueError } from "../../../errors/argument/argumentError";
+import {
+  GassmaAutoincrementInTransactionError,
+  GassmaAutoincrementNotConfiguredError,
+} from "../../../errors/autoincrement/autoincrementError";
+import { GassmaClient } from "../../../gassma";
+import type { GassmaController } from "../../../gassmaController";
+import type { GassmaClientOptions } from "../../../types/relationTypes";
+import {
+  buildTxTestEnv,
+  clearGasGlobals,
+  makeLoggedSheet,
+} from "../transaction/transactionTestClient";
+
+const KEY = "gassma_autoincrement_ai-test_Users_id";
+
+type Env = {
+  users: GassmaController;
+  posts: GassmaController;
+  propsStore: Record<string, string>;
+  waitLock: jest.Mock;
+  releaseLock: jest.Mock;
+};
+
+const buildEnv = (
+  userRows: unknown[][],
+  options?: Partial<GassmaClientOptions>,
+): Env => {
+  const users = makeLoggedSheet("Users", userRows);
+  const posts = makeLoggedSheet("Posts", [
+    ["id", "title"],
+    [1, "Post A"],
+  ]);
+  const sheets = [users.sheet, posts.sheet];
+  const spreadsheet = {
+    getId: () => "ai-test",
+    getSheets: () => sheets,
+    getSheetByName: (name: string) =>
+      sheets.find((sheet: any) => sheet.getName() === name) ?? null,
+  };
+  const propsStore: Record<string, string> = {};
+  Object.assign(globalThis, {
+    SpreadsheetApp: { getActiveSpreadsheet: () => spreadsheet },
+    PropertiesService: {
+      getScriptProperties: () => ({
+        getProperty: (key: string) => propsStore[key] ?? null,
+        setProperty: (key: string, value: string) => {
+          propsStore[key] = value;
+        },
+        deleteProperty: (key: string) => {
+          delete propsStore[key];
+        },
+        getKeys: () => Object.keys(propsStore),
+      }),
+    },
+  });
+  let held = false;
+  const waitLock = jest.fn(() => {
+    held = true;
+  });
+  const releaseLock = jest.fn(() => {
+    held = false;
+  });
+  const client: any = new GassmaClient({
+    lock: { waitLock, releaseLock, hasLock: () => held },
+    autoincrement: { Users: "id" },
+    ...options,
+  });
+  return {
+    users: client.Users,
+    posts: client.Posts,
+    propsStore,
+    waitLock,
+    releaseLock,
+  };
+};
+
+const defaultRows: unknown[][] = [
+  ["id", "name", "age"],
+  [1, "Alice", 20],
+  [2, "Bob", 30],
+];
+
+afterEach(() => {
+  clearGasGlobals();
+});
+
+describe("$getAutoincrement", () => {
+  it("未設定なら次に発行される値は 1", () => {
+    const env = buildEnv(defaultRows);
+    expect(env.users.$getAutoincrement("id")).toBe(1);
+  });
+
+  it("create の後は次に発行される値が進む", () => {
+    const env = buildEnv(defaultRows);
+    env.users.create({ data: { name: "Carol", age: 40 } });
+    expect(env.users.$getAutoincrement("id")).toBe(2);
+  });
+
+  it("ロックを取らない", () => {
+    const env = buildEnv(defaultRows);
+    env.users.$getAutoincrement("id");
+    expect(env.waitLock).not.toHaveBeenCalled();
+  });
+
+  it("autoincrement 設定の無いフィールドは拒否する", () => {
+    const env = buildEnv(defaultRows);
+    expect(() => env.users.$getAutoincrement("name")).toThrow(
+      GassmaAutoincrementNotConfiguredError,
+    );
+  });
+
+  it("autoincrement 設定の無いシートは拒否する", () => {
+    const env = buildEnv(defaultRows);
+    expect(() => env.posts.$getAutoincrement("id")).toThrow(
+      GassmaAutoincrementNotConfiguredError,
+    );
+  });
+});
+
+describe("$setAutoincrement", () => {
+  it("次に発行される値を設定する", () => {
+    const env = buildEnv(defaultRows);
+    env.users.$setAutoincrement("id", 501);
+    expect(env.propsStore[KEY]).toBe("500");
+    expect(env.users.$getAutoincrement("id")).toBe(501);
+  });
+
+  it("設定した値が実際に次の create で採番される", () => {
+    const env = buildEnv(defaultRows);
+    env.users.$setAutoincrement("id", 501);
+    const created: any = env.users.create({ data: { name: "Carol", age: 40 } });
+    expect(created.id).toBe(501);
+  });
+
+  it("ロックを取得して解放する", () => {
+    const env = buildEnv(defaultRows);
+    env.users.$setAutoincrement("id", 501);
+    expect(env.waitLock).toHaveBeenCalled();
+    expect(env.releaseLock).toHaveBeenCalled();
+  });
+
+  it("不正な値は拒否しカウンターを書き換えない", () => {
+    const env = buildEnv(defaultRows);
+    expect(() => env.users.$setAutoincrement("id", 0)).toThrow(
+      GassmaInvalidValueError,
+    );
+    expect(env.propsStore[KEY]).toBeUndefined();
+  });
+});
+
+describe("$syncAutoincrement", () => {
+  it("既存データの最大値 + 1 を次の値にして返す", () => {
+    const env = buildEnv([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [500, "Bob", 30],
+      [12, "Carol", 40],
+    ]);
+    expect(env.users.$syncAutoincrement("id")).toBe(501);
+    expect(env.propsStore[KEY]).toBe("500");
+  });
+
+  it("同期した後の create が既存行と衝突しない", () => {
+    const env = buildEnv([
+      ["id", "name", "age"],
+      [1, "Alice", 20],
+      [500, "Bob", 30],
+    ]);
+    env.users.$syncAutoincrement("id");
+    const created: any = env.users.create({ data: { name: "Carol", age: 40 } });
+    expect(created.id).toBe(501);
+  });
+
+  it("データが無ければ次の値は 1", () => {
+    const env = buildEnv([["id", "name", "age"]]);
+    expect(env.users.$syncAutoincrement("id")).toBe(1);
+    expect(env.propsStore[KEY]).toBe("0");
+  });
+
+  it("空セルや非数値は無視する", () => {
+    const env = buildEnv([
+      ["id", "name", "age"],
+      ["", "Alice", 20],
+      ["x", "Bob", 30],
+      [3, "Carol", 40],
+    ]);
+    expect(env.users.$syncAutoincrement("id")).toBe(4);
+  });
+
+  it("シート全体ではなく見出し行と対象列だけを読む", () => {
+    const users = makeLoggedSheet("Users", defaultRows);
+    const calls: number[][] = [];
+    const rawSheet: any = users.sheet;
+    const original = rawSheet.getRange;
+    rawSheet.getRange = (
+      row: number,
+      col: number,
+      numRows: number,
+      numCols: number,
+    ) => {
+      calls.push([row, col, numRows, numCols]);
+      return original(row, col, numRows, numCols);
+    };
+    const sheets = [users.sheet];
+    Object.assign(globalThis, {
+      SpreadsheetApp: {
+        getActiveSpreadsheet: () => ({
+          getId: () => "ai-test",
+          getSheets: () => sheets,
+          getSheetByName: (name: string) =>
+            sheets.find((sheet: any) => sheet.getName() === name) ?? null,
+        }),
+      },
+      PropertiesService: {
+        getScriptProperties: () => ({
+          getProperty: () => null,
+          setProperty: () => undefined,
+          getKeys: () => [],
+        }),
+      },
+    });
+    const client: any = new GassmaClient({
+      autoincrement: { Users: "id" },
+    });
+    calls.splice(0);
+    client.Users.$syncAutoincrement("id");
+    expect(calls).toEqual([
+      [1, 1, 1, 3],
+      [2, 1, 2, 1],
+    ]);
+  });
+
+  it("map のコード名で列を解決する", () => {
+    const env = buildEnv(
+      [
+        ["identifier", "name", "age"],
+        [7, "Alice", 20],
+      ],
+      { map: { Users: { id: "identifier" } } },
+    );
+    expect(env.users.$syncAutoincrement("id")).toBe(8);
+  });
+
+  it("ロックを取得して解放する", () => {
+    const env = buildEnv(defaultRows);
+    env.users.$syncAutoincrement("id");
+    expect(env.waitLock).toHaveBeenCalled();
+    expect(env.releaseLock).toHaveBeenCalled();
+  });
+
+  it("autoincrement 設定の無いフィールドは拒否する", () => {
+    const env = buildEnv(defaultRows);
+    expect(() => env.users.$syncAutoincrement("age")).toThrow(
+      GassmaAutoincrementNotConfiguredError,
+    );
+  });
+});
+
+describe("$transaction 中の呼び出し", () => {
+  it("tx クライアント経由の $setAutoincrement は拒否する", () => {
+    const env = buildTxTestEnv({ autoincrement: true });
+    expect(() =>
+      env.client.$transaction((tx: any) => tx.Users.$setAutoincrement("id", 5)),
+    ).toThrow(GassmaAutoincrementInTransactionError);
+  });
+
+  it("外側のクライアント経由の $setAutoincrement も拒否する", () => {
+    const env = buildTxTestEnv({ autoincrement: true });
+    const outer: any = env.client;
+    expect(() =>
+      env.client.$transaction(() => outer.Users.$setAutoincrement("id", 5)),
+    ).toThrow(GassmaAutoincrementInTransactionError);
+  });
+
+  it("tx クライアント経由の $syncAutoincrement は拒否する", () => {
+    const env = buildTxTestEnv({ autoincrement: true });
+    expect(() =>
+      env.client.$transaction((tx: any) => tx.Users.$syncAutoincrement("id")),
+    ).toThrow(GassmaAutoincrementInTransactionError);
+  });
+
+  it("外側のクライアント経由の $syncAutoincrement も拒否する", () => {
+    const env = buildTxTestEnv({ autoincrement: true });
+    const outer: any = env.client;
+    expect(() =>
+      env.client.$transaction(() => outer.Users.$syncAutoincrement("id")),
+    ).toThrow(GassmaAutoincrementInTransactionError);
+  });
+
+  it("$getAutoincrement は tx クライアント経由でも読める", () => {
+    const env = buildTxTestEnv({ autoincrement: true });
+    const result = env.client.$transaction((tx: any) =>
+      tx.Users.$getAutoincrement("id"),
+    );
+    expect(result).toBe(1);
+  });
+
+  it("トランザクション終了後は $setAutoincrement が再び使える", () => {
+    const env = buildTxTestEnv({ autoincrement: true });
+    env.client.$transaction((tx: any) => tx.Users.findMany());
+    const users: any = env.client;
+    users.Users.$setAutoincrement("id", 10);
+    expect(env.propsStore["gassma_autoincrement_tx-test_Users_id"]).toBe("9");
+  });
+
+  it("トランザクションが失敗した後も $setAutoincrement が使える", () => {
+    const env = buildTxTestEnv({ autoincrement: true });
+    expect(() =>
+      env.client.$transaction(() => {
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+    const users: any = env.client;
+    users.Users.$setAutoincrement("id", 10);
+    expect(env.propsStore["gassma_autoincrement_tx-test_Users_id"]).toBe("9");
+  });
+});

--- a/src/__test__/util/defaults/autoincrementCounter.test.ts
+++ b/src/__test__/util/defaults/autoincrementCounter.test.ts
@@ -1,0 +1,256 @@
+import { GassmaInvalidValueError } from "../../../errors/argument/argumentError";
+import {
+  GassmaAutoincrementInTransactionError,
+  GassmaAutoincrementNotConfiguredError,
+} from "../../../errors/autoincrement/autoincrementError";
+import type { Lock } from "../../../types/relationTypes";
+import type { AutoincrementTarget } from "../../../util/defaults/autoincrementCounter";
+import {
+  getAutoincrementCounter,
+  setAutoincrementCounter,
+  syncAutoincrementCounter,
+} from "../../../util/defaults/autoincrementCounter";
+import { setTransactionInProgress } from "../../../util/transaction/transactionState";
+
+const KEY = "gassma_autoincrement_ss1_Users_id";
+
+const mockWaitLock = jest.fn();
+const mockReleaseLock = jest.fn();
+const mockHasLock = jest.fn(() => false);
+const lock: Lock = {
+  waitLock: mockWaitLock,
+  releaseLock: mockReleaseLock,
+  hasLock: mockHasLock,
+};
+
+let store: Record<string, string> = {};
+
+const targetOf = (
+  override?: Partial<AutoincrementTarget>,
+): AutoincrementTarget => ({
+  modelName: "Users",
+  field: "id",
+  configuredFields: ["id"],
+  keyBase: "ss1_Users",
+  lock,
+  ...override,
+});
+
+beforeEach(() => {
+  store = {};
+  mockWaitLock.mockReset();
+  mockReleaseLock.mockReset();
+  mockHasLock.mockReset();
+  mockHasLock.mockReturnValue(false);
+  (globalThis as Record<string, unknown>).PropertiesService = {
+    getScriptProperties: () => ({
+      getProperty: (key: string) => store[key] ?? null,
+      setProperty: (key: string, value: string) => {
+        store[key] = value;
+      },
+    }),
+  };
+});
+
+afterEach(() => {
+  setTransactionInProgress(false);
+  delete (globalThis as Record<string, unknown>).PropertiesService;
+});
+
+describe("getAutoincrementCounter", () => {
+  it("未設定なら次に発行される値は 1", () => {
+    expect(getAutoincrementCounter(targetOf())).toBe(1);
+  });
+
+  it("最後に発行した値 + 1 を返す", () => {
+    store[KEY] = "12";
+    expect(getAutoincrementCounter(targetOf())).toBe(13);
+  });
+
+  it("読み取りだけなのでロックを取らない", () => {
+    store[KEY] = "12";
+    getAutoincrementCounter(targetOf());
+    expect(mockWaitLock).not.toHaveBeenCalled();
+    expect(mockReleaseLock).not.toHaveBeenCalled();
+  });
+
+  it("トランザクション中でも読める", () => {
+    store[KEY] = "4";
+    setTransactionInProgress(true);
+    expect(getAutoincrementCounter(targetOf())).toBe(5);
+  });
+
+  it("autoincrement 未設定のフィールドは拒否する", () => {
+    expect(() => getAutoincrementCounter(targetOf({ field: "name" }))).toThrow(
+      GassmaAutoincrementNotConfiguredError,
+    );
+  });
+});
+
+describe("setAutoincrementCounter", () => {
+  it("次に発行される値として保存する(内部は -1)", () => {
+    setAutoincrementCounter(targetOf(), 501);
+    expect(store[KEY]).toBe("500");
+    expect(getAutoincrementCounter(targetOf())).toBe(501);
+  });
+
+  it("1 を指定できる", () => {
+    setAutoincrementCounter(targetOf(), 1);
+    expect(store[KEY]).toBe("0");
+  });
+
+  it("ロックを取得して解放する", () => {
+    setAutoincrementCounter(targetOf(), 10);
+    expect(mockWaitLock).toHaveBeenCalledWith(10000);
+    expect(mockReleaseLock).toHaveBeenCalled();
+  });
+
+  it("lock が無ければロック無しで実行する", () => {
+    setAutoincrementCounter(targetOf({ lock: null }), 10);
+    expect(store[KEY]).toBe("9");
+    expect(mockWaitLock).not.toHaveBeenCalled();
+  });
+
+  it("autoincrement 未設定のフィールドは拒否する", () => {
+    expect(() =>
+      setAutoincrementCounter(targetOf({ field: "name" }), 10),
+    ).toThrow(GassmaAutoincrementNotConfiguredError);
+    expect(store).toEqual({});
+  });
+
+  it("トランザクション中は拒否する", () => {
+    setTransactionInProgress(true);
+    expect(() => setAutoincrementCounter(targetOf(), 10)).toThrow(
+      GassmaAutoincrementInTransactionError,
+    );
+    expect(store).toEqual({});
+  });
+
+  const invalidValues: [string, unknown][] = [
+    ["0", 0],
+    ["負数", -1],
+    ["小数", 1.5],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["-Infinity", Number.NEGATIVE_INFINITY],
+    ["文字列", "5"],
+    ["null", null],
+    ["undefined", undefined],
+    ["boolean", true],
+  ];
+
+  invalidValues.forEach(([label, value]) => {
+    it(`不正な値(${label})は拒否する`, () => {
+      expect(() => setAutoincrementCounter(targetOf(), value as any)).toThrow(
+        GassmaInvalidValueError,
+      );
+      expect(store).toEqual({});
+    });
+  });
+});
+
+describe("syncAutoincrementCounter", () => {
+  it("既存の最大値 + 1 を次の値にして返す", () => {
+    expect(syncAutoincrementCounter(targetOf(), () => [1, 500, 12])).toBe(501);
+    expect(store[KEY]).toBe("500");
+  });
+
+  it("空セルや非数値は無視する", () => {
+    const values = [1, "", null, "999", new Date(), true, 7];
+    expect(syncAutoincrementCounter(targetOf(), () => values)).toBe(8);
+    expect(store[KEY]).toBe("7");
+  });
+
+  it("数値が1つも無ければ次の値は 1", () => {
+    expect(syncAutoincrementCounter(targetOf(), () => ["a", "", null])).toBe(1);
+    expect(store[KEY]).toBe("0");
+  });
+
+  it("行が無ければ次の値は 1", () => {
+    expect(syncAutoincrementCounter(targetOf(), () => [])).toBe(1);
+    expect(store[KEY]).toBe("0");
+  });
+
+  it("負数しか無ければ次の値は 1", () => {
+    expect(syncAutoincrementCounter(targetOf(), () => [-5, -1])).toBe(1);
+    expect(store[KEY]).toBe("0");
+  });
+
+  it("小数は切り捨てた値を最大値として扱う", () => {
+    expect(syncAutoincrementCounter(targetOf(), () => [3.7])).toBe(4);
+    expect(store[KEY]).toBe("3");
+  });
+
+  it("既存のカウンターより小さくても既存データに合わせる", () => {
+    store[KEY] = "1000";
+    expect(syncAutoincrementCounter(targetOf(), () => [3])).toBe(4);
+    expect(store[KEY]).toBe("3");
+  });
+
+  it("ロックを取得して解放する", () => {
+    syncAutoincrementCounter(targetOf(), () => [3]);
+    expect(mockWaitLock).toHaveBeenCalledWith(10000);
+    expect(mockReleaseLock).toHaveBeenCalled();
+  });
+
+  it("列の読み込みはロックの内側で行う", () => {
+    const order: string[] = [];
+    mockWaitLock.mockImplementation(() => order.push("waitLock"));
+    mockReleaseLock.mockImplementation(() => order.push("releaseLock"));
+    syncAutoincrementCounter(targetOf(), () => {
+      order.push("read");
+      return [3];
+    });
+    expect(order).toEqual(["waitLock", "read", "releaseLock"]);
+  });
+
+  it("autoincrement 未設定のフィールドは拒否する", () => {
+    expect(() =>
+      syncAutoincrementCounter(targetOf({ field: "name" }), () => [3]),
+    ).toThrow(GassmaAutoincrementNotConfiguredError);
+    expect(store).toEqual({});
+  });
+
+  it("トランザクション中は拒否する", () => {
+    setTransactionInProgress(true);
+    expect(() => syncAutoincrementCounter(targetOf(), () => [3])).toThrow(
+      GassmaAutoincrementInTransactionError,
+    );
+    expect(store).toEqual({});
+  });
+
+  it("列が見つからなければ拒否する", () => {
+    expect(() => syncAutoincrementCounter(targetOf(), () => null)).toThrow(
+      GassmaInvalidValueError,
+    );
+    expect(store).toEqual({});
+  });
+});
+
+describe("GassmaAutoincrementNotConfiguredError", () => {
+  it("シート名・フィールド名・設定済みフィールドを含む", () => {
+    const error = new GassmaAutoincrementNotConfiguredError("Users", "name", [
+      "id",
+      "seq",
+    ]);
+    expect(error.message).toContain("Users");
+    expect(error.message).toContain("name");
+    expect(error.message).toContain("id, seq");
+  });
+
+  it("設定が1つも無い場合もシート名とフィールド名が分かる", () => {
+    const error = new GassmaAutoincrementNotConfiguredError("Posts", "id", []);
+    expect(error.message).toContain("Posts");
+    expect(error.message).toContain("id");
+  });
+});
+
+describe("GassmaAutoincrementInTransactionError", () => {
+  it("呼ばれたメソッド名を含む", () => {
+    const error = new GassmaAutoincrementInTransactionError(
+      "$setAutoincrement",
+    );
+    expect(error.message).toContain("$setAutoincrement");
+    expect(error.message).toContain("$transaction");
+  });
+});

--- a/src/__test__/util/defaults/autoincrementKey.test.ts
+++ b/src/__test__/util/defaults/autoincrementKey.test.ts
@@ -1,0 +1,15 @@
+import { buildAutoincrementKey } from "../../../util/defaults/autoincrementKey";
+
+describe("buildAutoincrementKey", () => {
+  it("ScriptProperties のキーを組み立てる", () => {
+    expect(buildAutoincrementKey("sheet1_Users", "id")).toBe(
+      "gassma_autoincrement_sheet1_Users_id",
+    );
+  });
+
+  it("フィールドごとに別のキーになる", () => {
+    expect(buildAutoincrementKey("sheet1_Users", "seq")).toBe(
+      "gassma_autoincrement_sheet1_Users_seq",
+    );
+  });
+});

--- a/src/errors/autoincrement/autoincrementError.ts
+++ b/src/errors/autoincrement/autoincrementError.ts
@@ -1,0 +1,27 @@
+class GassmaAutoincrementNotConfiguredError extends Error {
+  constructor(sheetName: string, field: string, configuredFields: string[]) {
+    const configured = Array.isArray(configuredFields) ? configuredFields : [];
+    const tail =
+      configured.length === 0
+        ? `\n\nSheet \`${sheetName}\` has no autoincrement fields.`
+        : `\n\nAutoincrement fields on \`${sheetName}\`: ${configured.join(", ")}`;
+    super(
+      `Field \`${field}\` on \`${sheetName}\` is not configured with autoincrement.${tail}`,
+    );
+    this.name = "GassmaAutoincrementNotConfiguredError";
+  }
+}
+
+class GassmaAutoincrementInTransactionError extends Error {
+  constructor(methodName: string) {
+    super(
+      `\`${methodName}\` cannot be called inside $transaction. The autoincrement counter lives in ScriptProperties, so it is not rolled back when the transaction fails. Call it outside $transaction.`,
+    );
+    this.name = "GassmaAutoincrementInTransactionError";
+  }
+}
+
+export {
+  GassmaAutoincrementInTransactionError,
+  GassmaAutoincrementNotConfiguredError,
+};

--- a/src/gassmaController.ts
+++ b/src/gassmaController.ts
@@ -38,12 +38,19 @@ import type { Lock, RelationContext } from "./types/relationTypes";
 import type { SheetIo } from "./types/transactionTypes";
 import { aggregateFunc } from "./util/aggregate/aggregate";
 import { changeSettingsFunc } from "./util/changeSettings/changeSettings";
+import { getColumnValues } from "./util/core/getColumnValues";
 import { getTitle } from "./util/core/getTitle";
 import { countFunc } from "./util/count/count";
 import { createFunc } from "./util/create/create";
 import { createManyFunc } from "./util/create/createManyFunc";
 import { resolveNestedCreate } from "./util/create/nestedWrite/resolveNestedCreate";
 import { applyAutoincrement } from "./util/defaults/applyAutoincrement";
+import type { AutoincrementTarget } from "./util/defaults/autoincrementCounter";
+import {
+  getAutoincrementCounter,
+  setAutoincrementCounter,
+  syncAutoincrementCounter,
+} from "./util/defaults/autoincrementCounter";
 import type { DefaultsForSheet } from "./util/defaults/applyDefaults";
 import { applyDefaults } from "./util/defaults/applyDefaults";
 import { applyUpdatedAt } from "./util/defaults/applyUpdatedAt";
@@ -275,14 +282,41 @@ class GassmaController {
     );
   }
 
+  private autoincrementKeyBase(): string {
+    return `${this.spreadsheetId}_${this.sheet.getName()}`;
+  }
+
+  private autoincrementTarget(field: string): AutoincrementTarget {
+    return {
+      modelName: this.codeName ?? this.sheet.getName(),
+      field,
+      configuredFields: this.autoincrementFields,
+      keyBase: this.autoincrementKeyBase(),
+      lock: this.lock,
+    };
+  }
+
+  public $getAutoincrement(field: string): number {
+    return getAutoincrementCounter(this.autoincrementTarget(field));
+  }
+
+  public $setAutoincrement(field: string, next: number): void {
+    setAutoincrementCounter(this.autoincrementTarget(field), next);
+  }
+
+  public $syncAutoincrement(field: string): number {
+    return syncAutoincrementCounter(this.autoincrementTarget(field), () =>
+      getColumnValues(this.getGassmaControllerUtil(), field),
+    );
+  }
+
   private applyAutoincrementToData(
     data: Record<string, unknown>,
   ): Record<string, unknown> {
     if (!this.autoincrementFields) return data;
-    const keyBase = `${this.spreadsheetId}_${this.sheet.getName()}`;
     const values = generateAutoincrementValues(
       this.autoincrementFields,
-      keyBase,
+      this.autoincrementKeyBase(),
       this.lock,
     );
     return applyAutoincrement(
@@ -386,7 +420,7 @@ class GassmaController {
     const aiValues = aiFields
       ? generateAutoincrementValues(
           aiFields,
-          `${this.spreadsheetId}_${this.sheet.getName()}`,
+          this.autoincrementKeyBase(),
           this.lock,
           createdData.data.length,
         )

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -124,6 +124,9 @@ declare namespace Gassma {
         : { [K in keyof S]: number }
       : number;
     groupBy(groupByData: GroupByData): Record<string, any>[];
+    $getAutoincrement(field: string): number;
+    $setAutoincrement(field: string, next: number): void;
+    $syncAutoincrement(field: string): number;
     _setRelationContext(context: RelationContext): void;
     _setGlobalOmit(omit: Omit): void;
     _setDefaults(defaults: {
@@ -734,6 +737,12 @@ declare namespace Gassma {
   }
   class GassmaInvalidLockError extends Error {
     constructor();
+  }
+  class GassmaAutoincrementNotConfiguredError extends Error {
+    constructor(sheetName: string, field: string, configuredFields: string[]);
+  }
+  class GassmaAutoincrementInTransactionError extends Error {
+    constructor(methodName: string);
   }
 }
 

--- a/src/publicApi.ts
+++ b/src/publicApi.ts
@@ -1,5 +1,6 @@
 import * as aggregateErrors from "./errors/aggregate/aggregateError";
 import * as argumentErrors from "./errors/argument/argumentError";
+import * as autoincrementErrors from "./errors/autoincrement/autoincrementError";
 import * as changeSettingsErrors from "./errors/changeSettings/changeSettingsError";
 import * as findErrors from "./errors/find/findError";
 import * as groupByErrors from "./errors/groupBy/groupByError";
@@ -136,3 +137,8 @@ export const GassmaTransactionLockRequiredError =
   transactionErrors.GassmaTransactionLockRequiredError;
 
 export const GassmaInvalidLockError = lockErrors.GassmaInvalidLockError;
+
+export const GassmaAutoincrementNotConfiguredError =
+  autoincrementErrors.GassmaAutoincrementNotConfiguredError;
+export const GassmaAutoincrementInTransactionError =
+  autoincrementErrors.GassmaAutoincrementInTransactionError;

--- a/src/util/core/getColumnValues.ts
+++ b/src/util/core/getColumnValues.ts
@@ -1,0 +1,29 @@
+import type { GassmaControllerUtil } from "../../types/gassmaControllerUtilType";
+import { resolveReader } from "../read/sheetReader";
+import { getTitle } from "./getTitle";
+
+const getColumnValues = (
+  gassmaControllerUtil: GassmaControllerUtil,
+  field: string,
+): unknown[] | null => {
+  const { sheet, startRowNumber, startColumnNumber } = gassmaControllerUtil;
+
+  const columnIndex = getTitle(gassmaControllerUtil).indexOf(field);
+  if (columnIndex === -1) return null;
+
+  const reader = resolveReader(gassmaControllerUtil.reader);
+  const rowLength = reader.getLastRow(sheet) - startRowNumber;
+  if (rowLength <= 0) return [];
+
+  return reader
+    .getRangeValues(
+      sheet,
+      startRowNumber + 1,
+      startColumnNumber + columnIndex,
+      rowLength,
+      1,
+    )
+    .map((row) => row[0]);
+};
+
+export { getColumnValues };

--- a/src/util/defaults/autoincrementCounter.ts
+++ b/src/util/defaults/autoincrementCounter.ts
@@ -1,0 +1,114 @@
+import { GassmaInvalidValueError } from "../../errors/argument/argumentError";
+import {
+  GassmaAutoincrementInTransactionError,
+  GassmaAutoincrementNotConfiguredError,
+} from "../../errors/autoincrement/autoincrementError";
+import type { Lock } from "../../types/relationTypes";
+import { runWithLock } from "../lock/runWithLock";
+import { isTransactionInProgress } from "../transaction/transactionState";
+import { buildAutoincrementKey } from "./autoincrementKey";
+
+const LOCK_TIMEOUT_MS = 10000;
+
+type AutoincrementTarget = {
+  modelName: string;
+  field: string;
+  configuredFields: string[] | null;
+  keyBase: string;
+  lock: Lock | null;
+};
+
+const assertNotInTransaction = (methodName: string): void => {
+  if (isTransactionInProgress()) {
+    throw new GassmaAutoincrementInTransactionError(methodName);
+  }
+};
+
+const assertConfigured = (target: AutoincrementTarget): void => {
+  const configured = target.configuredFields ?? [];
+  if (configured.indexOf(target.field) !== -1) return;
+  throw new GassmaAutoincrementNotConfiguredError(
+    target.modelName,
+    String(target.field),
+    configured,
+  );
+};
+
+const assertNextValue = (next: unknown): number => {
+  if (
+    typeof next !== "number" ||
+    !Number.isFinite(next) ||
+    Math.floor(next) !== next ||
+    next < 1
+  ) {
+    throw new GassmaInvalidValueError(
+      "next",
+      "an integer greater than or equal to 1",
+    );
+  }
+  return next;
+};
+
+const keyOf = (target: AutoincrementTarget): string =>
+  buildAutoincrementKey(target.keyBase, target.field);
+
+const readIssued = (key: string): number =>
+  Number(PropertiesService.getScriptProperties().getProperty(key) || 0);
+
+const writeIssued = (key: string, issued: number): void => {
+  PropertiesService.getScriptProperties().setProperty(key, String(issued));
+};
+
+const maxIssuedIn = (values: unknown[]): number => {
+  let max = 0;
+  values.forEach((value) => {
+    if (typeof value !== "number" || !Number.isFinite(value)) return;
+    const floored = Math.floor(value);
+    if (floored > max) max = floored;
+  });
+  return max;
+};
+
+const getAutoincrementCounter = (target: AutoincrementTarget): number => {
+  assertConfigured(target);
+  return readIssued(keyOf(target)) + 1;
+};
+
+const setAutoincrementCounter = (
+  target: AutoincrementTarget,
+  next: unknown,
+): void => {
+  assertNotInTransaction("$setAutoincrement");
+  assertConfigured(target);
+  const validated = assertNextValue(next);
+  runWithLock(target.lock, LOCK_TIMEOUT_MS, () => {
+    writeIssued(keyOf(target), validated - 1);
+  });
+};
+
+const syncAutoincrementCounter = (
+  target: AutoincrementTarget,
+  readColumnValues: () => unknown[] | null,
+): number => {
+  assertNotInTransaction("$syncAutoincrement");
+  assertConfigured(target);
+  return runWithLock(target.lock, LOCK_TIMEOUT_MS, () => {
+    const values = readColumnValues();
+    if (values === null) {
+      throw new GassmaInvalidValueError(
+        "field",
+        `a column that exists on \`${target.modelName}\``,
+      );
+    }
+    const issued = maxIssuedIn(values);
+    writeIssued(keyOf(target), issued);
+    return issued + 1;
+  });
+};
+
+export {
+  getAutoincrementCounter,
+  setAutoincrementCounter,
+  syncAutoincrementCounter,
+};
+export type { AutoincrementTarget };

--- a/src/util/defaults/autoincrementKey.ts
+++ b/src/util/defaults/autoincrementKey.ts
@@ -1,0 +1,6 @@
+const KEY_PREFIX = "gassma_autoincrement_";
+
+const buildAutoincrementKey = (keyBase: string, field: string): string =>
+  `${KEY_PREFIX}${keyBase}_${field}`;
+
+export { buildAutoincrementKey };

--- a/src/util/defaults/generateAutoincrementValues.ts
+++ b/src/util/defaults/generateAutoincrementValues.ts
@@ -1,8 +1,8 @@
 import type { Lock } from "../../types/relationTypes";
 import { runWithLock } from "../lock/runWithLock";
+import { buildAutoincrementKey } from "./autoincrementKey";
 
 const LOCK_TIMEOUT_MS = 10000;
-const KEY_PREFIX = "gassma_autoincrement_";
 
 const generateAutoincrementValues = (
   fields: string[],
@@ -15,7 +15,7 @@ const generateAutoincrementValues = (
     const result: Record<string, number | number[]> = {};
 
     fields.forEach((field) => {
-      const key = `${KEY_PREFIX}${keyBase}_${field}`;
+      const key = buildAutoincrementKey(keyBase, field);
       const current = Number(props.getProperty(key) || 0);
 
       if (count && count > 1) {

--- a/src/util/transaction/runTransaction.ts
+++ b/src/util/transaction/runTransaction.ts
@@ -16,11 +16,13 @@ import {
 } from "./transactionBackup";
 import { createTransactionBuffer } from "./transactionBuffer";
 import { createTransactionDeadline } from "./transactionDeadline";
+import {
+  isTransactionInProgress,
+  setTransactionInProgress,
+} from "./transactionState";
 
 const DEFAULT_MAX_WAIT_MS = 20000;
 const DEFAULT_TIMEOUT_MS = 60000;
-
-let transactionInProgress = false;
 
 const acquireLock = (lock: Lock, maxWaitMs: number): boolean => {
   if (lock.hasLock()) return false;
@@ -38,7 +40,7 @@ const runTransaction = <T>(
   buildBufferedClient: (sheetIo: SheetIo) => object,
   lock: Lock | undefined,
 ): T => {
-  if (transactionInProgress) {
+  if (isTransactionInProgress()) {
     throw new GassmaNestedTransactionError();
   }
   if (!lock) {
@@ -48,7 +50,7 @@ const runTransaction = <T>(
   const timeoutMs = options?.timeout ?? DEFAULT_TIMEOUT_MS;
   const rollback = options?.rollback ?? true;
   const acquired = acquireLock(lock, maxWaitMs);
-  transactionInProgress = true;
+  setTransactionInProgress(true);
   try {
     warnStaleTransactionBackups();
     const checkDeadline = createTransactionDeadline(timeoutMs);
@@ -67,7 +69,7 @@ const runTransaction = <T>(
     }
     return result;
   } finally {
-    transactionInProgress = false;
+    setTransactionInProgress(false);
     if (acquired) lock.releaseLock();
   }
 };

--- a/src/util/transaction/transactionState.ts
+++ b/src/util/transaction/transactionState.ts
@@ -1,0 +1,9 @@
+let transactionInProgress = false;
+
+const isTransactionInProgress = (): boolean => transactionInProgress;
+
+const setTransactionInProgress = (value: boolean): void => {
+  transactionInProgress = value;
+};
+
+export { isTransactionInProgress, setTransactionInProgress };


### PR DESCRIPTION
## 背景

**途中から GASsma を導入した人が壊れる。** カウンタは ScriptProperties の `gassma_autoincrement_${spreadsheetId}_${sheetName}_${field}` にあり、初期値は 0（`Number(props.getProperty(key) || 0)`）。**既存データを一切見ない。** id が 1〜500 まで入っているシートに導入すると、最初の `create` が **id: 1** を採番して既存行と衝突する。

### なぜ Prisma に無い機能を足すのか

**Prisma のスキーマにこの機能は無い。** 実測で確認した。

```
error: Error parsing attribute "@default":
  The `autoincrement` function does not take any argument.
```

無いのは意図的で、**カウンタが Prisma のものではなく DB のもの**だから。初期値の設定は `ALTER SEQUENCE "User_id_seq" RESTART WITH 1000`（PostgreSQL）のような DB 固有の操作になり、Prisma の公式手順は「`migrate dev --create-only` で SQL を生成させて手で編集する」。**スキーマで表現できないものは生の SQL でやる**という設計方針。

**gassma にはその逃げ道が無い。** ScriptProperties は**ライブラリ側のインスタンス**で、利用者のスクリプトからは別ストアとして見える（実機確認済み）。CLI からも届かない（CLI は利用者のマシンで動く）。**したがって実行時 API が必要**というのがこの PR の根拠。

**スキーマ属性（`autoincrement(100)` のような形）は採らなかった。** Prisma が明確に拒否している構文なので、合わせる方針から外れる。

## API

```ts
gassma.User.$getAutoincrement("id");        // 次に発行される値を返す（未設定なら 1）
gassma.User.$setAutoincrement("id", 501);   // 次に発行される値を 501 にする
gassma.User.$syncAutoincrement("id");       // 既存の最大値+1 を設定し、その値を返す
```

**受け渡しするのは「次に発行される値」で統一した**（`ALTER SEQUENCE ... RESTART WITH 1000` と同じ意味）。内部は「最後に発行した値」を持っているので、`$set(501)` はプロパティに `500` を書く。

`$syncAutoincrement` は「既存データに合わせる」という実際にやりたい操作を1回で済ませるためのもの。**採番のたびに走査する自動シードは採用しなかった** — 初回だけ走査する方式は、後から手で行を追加されると即座にずれるうえ「もう大丈夫」という誤った安心感を与えるため。明示的に呼ぶ形なら、手編集のあとに呼び直せば回復できる。

## エラー

| 条件 | エラー |
|---|---|
| 対象フィールドが autoincrement 設定されていない | `GassmaAutoincrementNotConfiguredError`（新規） |
| `$transaction` の中から `$set` / `$sync` を呼ぶ | `GassmaAutoincrementInTransactionError`（新規） |
| `$set` の値が整数でない・1 未満 | `GassmaInvalidValueError`（**既存を流用**） |

`$getAutoincrement` は読み取りなのでトランザクション内でも許可。

### トランザクション内を禁止した理由

**カウンタは ScriptProperties にあってシートのバッファに乗らないため、ロールバックされない。** トランザクションが失敗してもカウンタだけ書き換わったまま残る、という状態を原理的に作らない。

**`buildTransactionClient` は Proxy で全メソッドを素通しする**ので、何もしなければ tx 経由でも呼べてしまう。**tx クライアント経由・外側のクライアント経由の両方で弾けることをテストで固定した。**

判定に使う `transactionInProgress` は `runTransaction.ts` から 9 行の `transactionState.ts` に切り出した。直接エクスポートすると `gassmaController → runTransaction → buildTransactionClient → gassmaController` の循環になるため。`runTransaction` の挙動は不変。

## ロックとキーの共通化

- **3操作とも `runWithLock` でクライアントの lock を取る**（`$sync` は read-modify-write なので必須）。`$get` は単発の `getProperty` なのでロック無し
- **キーの組み立てを `autoincrementKey.ts` に切り出し、`generateAutoincrementValues` と共有した。** 別々に書けば必ずずれる

## `$syncAutoincrement` の読み取り

**シート全体は読まない。** 見出し行1行（`map` を通した列名解決込み）と該当1列だけ。

契約テストで固定した:
- 単体: `getRange` が `[[1,1,1,3], [2,3,2,1]]` の2回きり
- 統合: 実クライアント経由で `[[1,1,1,3], [2,1,2,1]]` のみ

負数・小数は `Math.max(0, Math.floor(max))` 相当で扱う（次の値が必ず 1 以上になり `$set` の検証と矛盾しない／`3.7` があるとき次が `4` になり衝突しない）。

## 検証

- **3205件 pass**（228 suite）／`tsc --noEmit` クリーン／`verify:bundle` OK（公開シンボル 60→**62**、エラークラス 50→**52**）
- **変異テスト24件すべて検知。** ±1 のオフセット3種／設定済みチェック3種／トランザクション判定3種／値検証3種／ロック3種／走査の扱い4種／キーのプレフィックス／全列読み／`map` 解決
  - **キーのプレフィックスを変えると既存の採番テストまで24件落ちる** = 共通化が実際に効いている証拠
- 上記の変異のうち2件（`$get` の `+1` 除去・トランザクション判定の無効化）は独立に再実行して確認済み（8件・6件が失敗）

## 関連

gassma-cli 側で `field` の型を**そのモデルの autoincrement フィールドだけに絞る**対応を別途進めている。文字列のままだと typo が黙って通るため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ