### PR TITLE
fix: leave the columns untouched for a model without columns

### DIFF
--- a/src/__test__/util/migrate/migrateSheets.test.ts
+++ b/src/__test__/util/migrate/migrateSheets.test.ts
@@ -903,6 +903,132 @@ describe("migrateSheets 既定の空シート削除", () => {
   });
 });
 
+describe("migrateSheets columns が空のモデル", () => {
+  const NO_COLUMNS_LOG =
+    'Gassma.migrateSheets: model "Memo" declares no columns. The columns of sheet "Memo" are left untouched.';
+
+  test("acceptDataLoss: true でも既存の列とデータを1つも失わない", () => {
+    const memo = makeSheet("Memo", [
+      ["title", "body"],
+      ["a", "b"],
+      ["c", "d"],
+      ["e", "f"],
+    ]);
+    const env = makeSpreadsheet("active", [memo]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "Memo", columns: [] }],
+      acceptDataLoss: true,
+    });
+
+    expect(memo.snapshot()).toEqual([
+      ["title", "body"],
+      ["a", "b"],
+      ["c", "d"],
+      ["e", "f"],
+    ]);
+    expect(memo.deletedColumns).toEqual([]);
+    expect(memo.writes).toEqual([]);
+    expect(env.sheetNames()).toEqual(["Memo"]);
+    expect(env.deletedNames).toEqual([]);
+  });
+
+  test("acceptDataLoss: false では schema に無い列として警告しない", () => {
+    const memo = makeSheet("Memo", [
+      ["title", "body"],
+      ["a", "b"],
+    ]);
+    const env = makeSpreadsheet("active", [memo]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [{ name: "Memo", columns: [] }],
+      acceptDataLoss: false,
+    });
+
+    expect(memo.snapshot()).toEqual([
+      ["title", "body"],
+      ["a", "b"],
+    ]);
+    expect(messagesOf(warnSpy)).toEqual([]);
+  });
+
+  test("is up to date と報告せず列を管理していないログを出す", () => {
+    const memo = makeSheet("Memo", [["title"], ["a"]]);
+    const env = makeSpreadsheet("active", [memo]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({ models: [{ name: "Memo", columns: [] }] });
+
+    const logs = messagesOf(logSpy);
+    expect(logs.some((log) => log.includes("up to date"))).toBe(false);
+    expect(logs).toContain(NO_COLUMNS_LOG);
+  });
+
+  test("シートが存在しない場合は今までどおり作成しヘッダーを書かない", () => {
+    const env = makeSpreadsheet("active", []);
+    installSpreadsheetApp(env);
+
+    migrateSheets({ models: [{ name: "Memo", columns: [] }] });
+
+    expect(env.insertedNames).toEqual(["Memo"]);
+    expect(env.handleOf("Memo").snapshot()).toEqual([]);
+    expect(env.handleOf("Memo").writes).toEqual([]);
+    expect(messagesOf(logSpy).some((log) => log.includes("created"))).toBe(
+      true,
+    );
+  });
+
+  test("2回実行しても列とデータが変わらない", () => {
+    const memo = makeSheet("Memo", [
+      ["title", "body"],
+      ["a", "b"],
+    ]);
+    const env = makeSpreadsheet("active", [memo]);
+    installSpreadsheetApp(env);
+    const options = {
+      models: [{ name: "Memo", columns: [] }],
+      acceptDataLoss: true,
+    };
+
+    migrateSheets(options);
+    const snapshotAfterFirst = memo.snapshot();
+
+    migrateSheets(options);
+
+    expect(memo.snapshot()).toEqual(snapshotAfterFirst);
+    expect(memo.deletedColumns).toEqual([]);
+    expect(memo.writes).toEqual([]);
+  });
+
+  test("同じ実行に含まれる columns があるモデルの挙動は変わらない", () => {
+    const memo = makeSheet("Memo", [["title"], ["a"]]);
+    const users = makeSheet("User", [
+      ["id", "legacy"],
+      [1, "x"],
+    ]);
+    const env = makeSpreadsheet("active", [memo, users]);
+    installSpreadsheetApp(env);
+
+    migrateSheets({
+      models: [
+        { name: "Memo", columns: [] },
+        { name: "User", columns: ["id", "name"] },
+      ],
+      acceptDataLoss: true,
+    });
+
+    expect(memo.snapshot()).toEqual([["title"], ["a"]]);
+    expect(memo.deletedColumns).toEqual([]);
+    expect(users.snapshot()).toEqual([["id", "name"], [1]]);
+    expect(users.deletedColumns).toEqual([2]);
+    expect(messagesOf(warnSpy)).toContain(
+      'Gassma.migrateSheets: You are about to drop the column "legacy" on the sheet "User", which still contains 1 non-empty values.',
+    );
+  });
+});
+
 describe("migrateSheets 引数の検証", () => {
   test("models が無い場合は GassmaMissingArgumentError を投げる", () => {
     installSpreadsheetApp(makeSpreadsheet("active", []));

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -365,7 +365,11 @@ declare namespace Gassma {
    * with `acceptDataLoss: true` they are dropped after a warning that reports
    * how much data they still contain (silently when they are empty; the last
    * remaining sheet is kept, since a spreadsheet must contain at least one
-   * sheet). Never reorders existing columns, never writes to data rows.
+   * sheet). The empty sheet Google puts in every new spreadsheet is dropped
+   * regardless of `acceptDataLoss`, as it holds no data. A model without
+   * columns manages no column at all: an existing sheet keeps every column it
+   * has, even with `acceptDataLoss: true`. Never reorders existing columns,
+   * never writes to data rows.
    */
   function migrateSheets(options: MigrateSheetsOptions): void;
 

--- a/src/util/migrate/migrateSheets.ts
+++ b/src/util/migrate/migrateSheets.ts
@@ -104,6 +104,12 @@ const syncExistingSheet = (
   model: MigrateModel,
   acceptDataLoss: boolean,
 ) => {
+  if (model.columns.length === 0) {
+    console.log(
+      `${LOG_PREFIX} model "${model.name}" declares no columns. The columns of sheet "${model.name}" are left untouched.`,
+    );
+    return;
+  }
   const headers = readHeaders(sheet);
   appendMissingColumns(sheet, model, headers);
   if (acceptDataLoss) {
@@ -157,8 +163,10 @@ const dropExtraSheets = (spreadsheet: Spreadsheet, models: MigrateModel[]) => {
  * how much data they still contain (silently when they are empty; the last
  * remaining sheet is kept, since a spreadsheet must contain at least one
  * sheet). The empty sheet Google puts in every new spreadsheet is dropped
- * regardless of `acceptDataLoss`, as it holds no data. Never reorders existing
- * columns, never writes to data rows.
+ * regardless of `acceptDataLoss`, as it holds no data. A model without columns
+ * manages no column at all: an existing sheet keeps every column it has, even
+ * with `acceptDataLoss: true`. Never reorders existing columns, never writes to
+ * data rows.
  */
 const migrateSheets = (options: MigrateSheetsOptions): void => {
   if (!options || !options.models) {


### PR DESCRIPTION
## 不具合

**フィールドが1つも無いモデルを宣言すると、そのシートの列とデータが全部消える。**

`migrateSheets` に `{ name: "Memo", columns: [] }` が渡ると、`dropExtraColumns` が「モデルの `columns` に無い列」を全部消すため、既存の列とその中身がすべて失われる。

実測（修正前）:

```
Gassma.migrateSheets: sheet "Memo" is up to date     ← このログを出した直後に
Memo の中身: [[],[],[]]                              ← title / body と全行のデータが消える
```

**「is up to date」と報告した直後に全消ししていた。**

到達経路は実在する。フィールドを書かないモデルは Prisma として valid で、gassma の `validate` も `generate` も通る（実測）。

```prisma
model Memo {
  @@ignore
}
```

**「宣言が無い」を「全部消せ」と読み替えていた。** `deleteMany({ where: {} })` を全件削除と解釈していたのと同じ形で、#208〜#223 で潰してきた種類の挙動。

### 見つかった経緯

リファレンスに**「メモ用シートを削除から守るには、空のモデルを `@@ignore` で定義してください」**と書こうとして、実測で気づいた。**その助言は守るつもりのシートを破壊する。** 公開前に止まった。

## 修正

`model.columns` が空なら、そのシートの列に一切触らない。

```ts
if (model.columns.length === 0) {
  console.log(`${LOG_PREFIX} model "${model.name}" declares no columns. The columns of sheet "${model.name}" are left untouched.`);
  return;
}
```

- 列を追加しない／**削除しない**（`acceptDataLoss` が true でも）／「スキーマに無い列」の警告も出さない（全列について出てしまい無意味）
- **「is up to date」と報告しない**（実態と食い違うため）

**ガードは `syncExistingSheet` の中、`readHeaders` より手前に置いた。** 列に触る3経路（`appendMissingColumns` / `dropExtraColumns` / `warnExtraColumns`）が**すべてこの関数の中にしかない**ため。呼び出し側に置くと、将来この関数に列操作が増えたときすり抜ける。**「検査位置が実質」という #192〜#223 の教訓に従った。** ヘッダー読み取りもスキップされるので往復も増えない。

### 変えていないこと

- **シートが存在しない場合の作成は従来どおり**（`columns: []` でもシートは作られる）
- **`dropExtraSheets` の対象にならない点も従来どおり**（`models` に載っている以上「スキーマに無いシート」ではない）
- **`columns` が1つ以上あるモデルの挙動は一切変えていない**（既存テストの期待値を1つも変更していない）

## 検証

- **3211件 pass**（228 suite、新規6件）／`tsc --noEmit` クリーン／`verify:bundle` OK（公開シンボル62・エラークラス52で**不変**）／`migrateSheets.ts` は **191行**（200行以内）
- **変異テスト6件すべて検知**（ガード削除／条件を絶対不成立に／条件の反転／ログを出さない／ガードを `appendMissingColumns` の後ろへ／ガードを `acceptDataLoss` 分岐内だけに）
- **修正前の再現ケースで、データが完全に保たれることを独立に確認した**

```
修正前:  Memo の中身: [[],[],[]]
修正後:  Memo の中身: [["title","body"],["買い物","牛乳"]]
```

## ⚠️ #230 と競合する

**`feat/drop-pristine-default-sheet`（#230）と同じファイルを触っており、試行マージで競合を確認した。**

```
CONFLICT (content): Merge conflict in src/util/migrate/migrateSheets.ts
CONFLICT (content): Merge conflict in src/__test__/util/migrate/migrateSheets.test.ts
```

どちらも追加箇所が近いだけで論理的な矛盾はない。**後からマージするほうを rebase する必要がある。** マージ順が決まったら、残ったほうをこちらで rebase して再検証する。

`src/index.d.ts` の JSDoc も同じ文面がミラーされていたので同期した（挙動変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ