### PR TITLE
chore: bump the library version to 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gassma",
-  "version": "8",
+  "version": "9",
   "description": "GASsma is Google Apps Script(GAS) of SpreadSheet library that can be used like prisma.",
   "types": "src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
GAS ライブラリのバージョン 9 のデプロイに合わせて `package.json` の `version` を 8 → 9 に上げる。

**この値は飾りではない。** `gassma bootstrap` が新規プロジェクトの `appsscript.json` に書き込むライブラリ版数の取得元で、CLI が **GitHub の main を直接読んでいる**。

```ts
// gassma-cli: packages/cli/src/bootstrap/env/fetchLatestLibraryVersion.ts
"https://raw.githubusercontent.com/akahoshi1421/gassma/main/package.json"
```

放置すると **新規プロジェクトが古い版に固定される**（#225 で 7 → 8 に直したときと同じ実害）。

## このバージョンに入るもの

| PR | 内容 |
|---|---|
| #228 | **ロックを利用者の Lock に変更**（ライブラリの ScriptLock を全廃）。**破壊的変更** |
| #229 | `$getAutoincrement` / `$setAutoincrement` / `$syncAutoincrement` |
| #226 | `groupBy` のパイプライン順序の修正と、集計値での `orderBy` |
| #227 | `orderBy` なしの `take` を `GassmaGroupByOrderByRequiredError` で拒否 |
| #230 | 新規スプレッドシートの空の既定シートを削除 |
| #231 | **空モデルで列が全消しされる不具合の修正** |

## 実機確認済み

GAS 上で `testAutoincrementAll` / `testTransactionAll` / `testMigrateAll` の3グループがすべて通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y71efPB7S4cuMBnK6ebqrZ